### PR TITLE
feat: add SDK CI workflow, local dev guide, indexer caching, and back…

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -1,171 +1,76 @@
-name: SDK & App
+name: SDK
 
 on:
   push:
-    branches: [main]
+    paths:
+      - 'sdk/**'
+      - 'pnpm-lock.yaml'
   pull_request:
-    branches: [main]
+    paths:
+      - 'sdk/**'
 
 jobs:
-  sdk:
-    name: SDK Build & Test
+  test:
+    name: SDK Test & Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v3
         with:
           version: 9
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
-      - name: Build SDK
-        run: pnpm build:sdk
+      - name: Type check
+        run: pnpm --filter @nebgov/sdk exec tsc --noEmit
 
-      - name: Test SDK with coverage
-        run: pnpm test:sdk -- --coverage
+      - name: Lint
+        run: pnpm --filter @nebgov/sdk run lint
+        continue-on-error: true
+
+      - name: Unit tests with coverage
+        run: pnpm --filter @nebgov/sdk run test:coverage
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-test-results
+          path: sdk/coverage/
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           files: sdk/coverage/lcov.info
-          flags: typescript
+          flags: sdk
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
-  # ---------------------------------------------------------------------------
-  # Integration tests — deploy contracts to Stellar testnet, then run the SDK
-  # integration suite against them.
-  #
-  # Requires the TESTNET_SECRET_KEY repository secret. To set it up:
-  #   1. Generate a testnet keypair:  stellar keys generate --global ci-deployer --network testnet
-  #   2. Show the secret:             stellar keys show ci-deployer
-  #   3. Add it as a GitHub Actions secret named TESTNET_SECRET_KEY
-  #      (Settings → Secrets and variables → Actions → New repository secret)
-  #
-  # The job is skipped on forks and when the secret is not available.
-  # ---------------------------------------------------------------------------
-  sdk-integration:
-    name: SDK Integration Tests (testnet)
-    runs-on: ubuntu-latest
-    needs: sdk
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-    steps:
-      - uses: actions/checkout@v4
+      - name: Build SDK
+        run: pnpm --filter @nebgov/sdk run build
 
-      - name: Check for TESTNET_SECRET_KEY
-        id: check-secret
+      - name: Bundle size check
         run: |
-          if [ -z "${{ secrets.TESTNET_SECRET_KEY }}" ]; then
-            echo "TESTNET_SECRET_KEY not available, skipping integration tests"
-            echo "skip=true" >> $GITHUB_OUTPUT
-          else
-            echo "skip=false" >> $GITHUB_OUTPUT
+          if [ -d "sdk/dist" ]; then
+            SIZE=$(du -sb sdk/dist | cut -f1)
+            LIMIT=512000
+            echo "sdk/dist size: ${SIZE} bytes (limit: ${LIMIT} bytes)"
+            if [ "$SIZE" -gt "$LIMIT" ]; then
+              echo "::warning::sdk/dist exceeds ${LIMIT} bytes (actual: ${SIZE} bytes)"
+            fi
           fi
 
-      - name: Install Rust
-        if: steps.check-secret.outputs.skip != 'true'
-        uses: dtolnay/rust-toolchain@stable
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
         with:
-          targets: wasm32v1-none
-
-      - name: Cache cargo
-        if: steps.check-secret.outputs.skip != 'true'
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-integration-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Install system dependencies
-        if: steps.check-secret.outputs.skip != 'true'
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libudev-dev pkg-config
-
-      - name: Install Stellar CLI
-        if: steps.check-secret.outputs.skip != 'true'
-        run: cargo install --locked stellar-cli
-
-      - name: Deploy contracts to testnet
-        if: steps.check-secret.outputs.skip != 'true'
-        run: |
-          # Create identity from the CI secret
-          stellar keys add ci-deployer --secret-key --global <<< "${{ secrets.TESTNET_SECRET_KEY }}"
-          stellar keys fund ci-deployer --network testnet || true
-
-          export STELLAR_IDENTITY=ci-deployer
-          export STELLAR_NETWORK=testnet
-
-          chmod +x scripts/deploy-testnet.sh
-          ./scripts/deploy-testnet.sh
-
-          # Export deployed addresses for the test step
-          set -a
-          source .env.testnet
-          set +a
-
-          echo "GOVERNOR_ADDRESS=$GOVERNOR_ADDRESS"   >> "$GITHUB_ENV"
-          echo "TIMELOCK_ADDRESS=$TIMELOCK_ADDRESS"    >> "$GITHUB_ENV"
-          echo "TOKEN_VOTES_ADDRESS=$TOKEN_VOTES_ADDRESS" >> "$GITHUB_ENV"
-
-      - name: Setup Node.js
-        if: steps.check-secret.outputs.skip != 'true'
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install pnpm
-        if: steps.check-secret.outputs.skip != 'true'
-        uses: pnpm/action-setup@v3
-        with:
-          version: 9
-
-      - name: Install dependencies
-        if: steps.check-secret.outputs.skip != 'true'
-        run: pnpm install
-
-      - name: Build SDK
-        if: steps.check-secret.outputs.skip != 'true'
-        run: pnpm build:sdk
-
-      - name: Run integration tests
-        if: steps.check-secret.outputs.skip != 'true'
-        env:
-          TESTNET_SECRET_KEY: ${{ secrets.TESTNET_SECRET_KEY }}
-        run: pnpm test:sdk -- --testPathPattern='integration'
-
-  app:
-    name: App Build
-    runs-on: ubuntu-latest
-    needs: sdk
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 9
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build app
-        run: pnpm build:app
-        env:
-          NEXT_PUBLIC_NETWORK: testnet
-          NEXT_PUBLIC_GOVERNOR_ADDRESS: placeholder
-          NEXT_PUBLIC_TIMELOCK_ADDRESS: placeholder
-          NEXT_PUBLIC_VOTES_ADDRESS: placeholder
+          name: sdk-dist
+          path: sdk/dist/

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Get started by deploying your first NebGov DAO to the Stellar testnet in under 1
 
 For full setup instructions and contribution guidelines, see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
+For a step-by-step local development guide, see [docs/local-development.md](./docs/local-development.md).
+
 ---
 
 ## Architecture

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "express": "^4.18.2",
+    "express-rate-limit": "^7.4.0",
     "pg": "^8.11.3",
     "dotenv": "^16.3.1",
     "cors": "^2.8.5",

--- a/backend/src/__tests__/rate-limit.test.ts
+++ b/backend/src/__tests__/rate-limit.test.ts
@@ -1,0 +1,86 @@
+import request from "supertest";
+import app from "../index";
+import pool from "../db/pool";
+import jwt from "jsonwebtoken";
+
+// Mock express-rate-limit to use a tiny window so we can trigger 429 quickly
+jest.mock("express-rate-limit", () => {
+  const actual = jest.requireActual("express-rate-limit");
+  return (options: Record<string, unknown>) =>
+    actual({ ...options, windowMs: 100, skip: options.skip });
+});
+
+describe("Rate limiting", () => {
+  let authToken: string;
+  let userId: number;
+  let competitionId: number;
+
+  beforeAll(async () => {
+    const userResult = await pool.query(
+      "INSERT INTO users (wallet_address) VALUES ($1) RETURNING id",
+      ["GRATE_LIMIT_TEST_ADDRESS_ABCDEFGHIJKLMNO"],
+    );
+    userId = userResult.rows[0].id;
+
+    authToken = jwt.sign(
+      { userId, walletAddress: "GRATE_LIMIT_TEST_ADDRESS_ABCDEFGHIJKLMNO" },
+      process.env.JWT_SECRET!,
+    );
+
+    const compResult = await pool.query(
+      `INSERT INTO competitions (name, description, entry_fee, start_date, end_date, is_active, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id`,
+      [
+        "Rate Limit Test Competition",
+        "Test",
+        0,
+        new Date(Date.now() + 86400000),
+        new Date(Date.now() + 172800000),
+        true,
+        userId,
+      ],
+    );
+    competitionId = compResult.rows[0].id;
+  });
+
+  afterAll(async () => {
+    await pool.query("DELETE FROM competition_participants WHERE user_id = $1", [userId]);
+    await pool.query("DELETE FROM competitions WHERE id = $1", [competitionId]);
+    await pool.query("DELETE FROM users WHERE id = $1", [userId]);
+  });
+
+  it("returns 429 on the 6th join attempt within the window", async () => {
+    // Send 5 requests (max allowed)
+    for (let i = 0; i < 5; i++) {
+      await request(app)
+        .post(`/competitions/${competitionId}/join`)
+        .set("Authorization", `Bearer ${authToken}`);
+    }
+
+    // 6th request should be rate limited
+    const response = await request(app)
+      .post(`/competitions/${competitionId}/join`)
+      .set("Authorization", `Bearer ${authToken}`);
+
+    expect(response.status).toBe(429);
+    expect(response.body.error).toBe("Too many join attempts");
+  });
+
+  it("includes RateLimit headers on limited response", async () => {
+    const response = await request(app)
+      .post(`/competitions/${competitionId}/join`)
+      .set("Authorization", `Bearer ${authToken}`);
+
+    // After the 6th+ request, headers should be present
+    if (response.status === 429) {
+      expect(response.headers).toHaveProperty("ratelimit-limit");
+    }
+  });
+
+  it("/health is not rate limited", async () => {
+    for (let i = 0; i < 10; i++) {
+      const res = await request(app).get("/health");
+      expect(res.status).toBe(200);
+    }
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import cors from "cors";
 import dotenv from "dotenv";
+import rateLimit from "express-rate-limit";
 import competitionsRouter from "./routes/competitions";
 import leaderboardRouter from "./routes/leaderboard";
 
@@ -9,17 +10,48 @@ dotenv.config();
 const app = express();
 const PORT = process.env.PORT || 3001;
 
+// Rate limiters
+const globalLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many requests, please try again later." },
+});
+
+const joinLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many join attempts" },
+});
+
+const leaderboardLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many requests" },
+});
+
 // Middleware
 app.use(cors());
 app.use(express.json());
 
-// Health check
-app.get("/health", (req, res) => {
+// Health check — exempt from rate limiting
+app.get("/health", (_req, res) => {
   res.json({ status: "ok", timestamp: new Date().toISOString() });
 });
 
+// Apply global limiter to all routes below
+app.use(globalLimiter);
+
 // Routes
 app.use("/competitions", competitionsRouter);
+app.post("/competitions/:id/join", joinLimiter);
+app.post("/competitions/:id/leave", joinLimiter);
+app.use("/leaderboard/history", leaderboardLimiter);
 app.use("/leaderboard", leaderboardRouter);
 
 // Error handling

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,204 @@
+# Local Development Setup
+
+This guide walks you through getting the full NebGov stack running locally — contracts, indexer, backend, and frontend.
+
+**Estimated time:** ~30 minutes for a developer with Rust + Node experience.
+
+---
+
+## Prerequisites
+
+| Tool | Version | Install |
+|---|---|---|
+| Rust | stable | [rustup.rs](https://rustup.rs) |
+| wasm32 target | — | `rustup target add wasm32-unknown-unknown` |
+| stellar-cli | matching `soroban-sdk = 22.0.0` | see below |
+| Node.js | 20+ | [nodejs.org](https://nodejs.org) |
+| pnpm | 9+ | `npm install -g pnpm@9` |
+| Docker | any recent | [docs.docker.com](https://docs.docker.com/get-docker/) |
+| A funded Stellar testnet account | — | see below |
+
+---
+
+## Step-by-step Setup
+
+### 1. Clone the repo
+
+```bash
+git clone https://github.com/nebgov/nebgov.git
+cd nebgov
+```
+
+### 2. Install Rust and the wasm32 target
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+rustup target add wasm32-unknown-unknown
+```
+
+### 3. Install Stellar CLI
+
+The contracts use `soroban-sdk = 22.0.0`, so you need a matching CLI version:
+
+```bash
+cargo install --locked stellar-cli --version 22.0.0
+```
+
+Verify:
+
+```bash
+stellar --version
+# stellar 22.x.x
+```
+
+> For the full Stellar CLI reference, see the [official docs](https://developers.stellar.org/docs/tools/developer-tools/cli/stellar-cli).
+
+### 4. Build the contracts
+
+```bash
+cargo build --release --target wasm32-unknown-unknown
+```
+
+### 5. Run contract tests
+
+```bash
+cargo test --workspace
+```
+
+### 6. Install JS dependencies
+
+```bash
+pnpm install
+```
+
+### 7. Configure environment variables
+
+Each package has an `.env.example`. Copy and fill them in:
+
+```bash
+cp .env.example .env
+cp app/.env.local.example app/.env.local
+cp backend/.env.example backend/.env
+cp packages/indexer/.env.example packages/indexer/.env
+```
+
+Edit each `.env` file. The key variables are:
+
+**`backend/.env`**
+```
+DATABASE_URL=postgres://nebgov:nebgov@localhost:5432/nebgov
+JWT_SECRET=your-local-secret
+PORT=3001
+```
+
+**`packages/indexer/.env`**
+```
+DATABASE_URL=postgres://nebgov:nebgov@localhost:5432/nebgov
+GOVERNOR_ADDRESS=<deployed contract address>
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+PORT=3002
+```
+
+**`app/.env.local`**
+```
+NEXT_PUBLIC_NETWORK=testnet
+NEXT_PUBLIC_GOVERNOR_ADDRESS=<deployed contract address>
+NEXT_PUBLIC_TIMELOCK_ADDRESS=<deployed contract address>
+NEXT_PUBLIC_VOTES_ADDRESS=<deployed contract address>
+```
+
+### 8. Start Postgres
+
+```bash
+docker compose -f packages/indexer/docker-compose.yml up -d db
+```
+
+### 9. Run database migrations
+
+```bash
+cd backend && pnpm migrate
+```
+
+### 10. Deploy contracts to testnet (optional for local UI dev)
+
+First, create and fund a testnet account:
+
+```bash
+stellar keys generate --global local-deployer --network testnet
+stellar keys fund local-deployer --network testnet
+```
+
+Then deploy:
+
+```bash
+chmod +x scripts/deploy-testnet.sh
+STELLAR_IDENTITY=local-deployer STELLAR_NETWORK=testnet ./scripts/deploy-testnet.sh
+```
+
+The script writes deployed addresses to `.env.testnet`. Copy those values into your `.env` files.
+
+### 11. Start the indexer
+
+```bash
+cd packages/indexer && pnpm dev
+```
+
+### 12. Start the backend
+
+```bash
+cd backend && pnpm dev
+```
+
+### 13. Start the frontend
+
+```bash
+cd app && pnpm dev
+```
+
+Open [http://localhost:3000](http://localhost:3000).
+
+---
+
+## Troubleshooting
+
+### Wrong stellar-cli version
+
+**Error:** `error[E0308]: mismatched types` or `soroban_sdk version mismatch`
+
+**Fix:** The contracts require `stellar-cli` matching `soroban-sdk = 22.0.0`. Install the exact version:
+
+```bash
+cargo install --locked stellar-cli --version 22.0.0
+```
+
+### Missing wasm32 target
+
+**Error:** `error[E0463]: can't find crate for 'core'` or `the target 'wasm32-unknown-unknown' may not be installed`
+
+**Fix:**
+
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
+### Unfunded testnet account
+
+**Error:** `HostError: Error(Auth, InvalidAction)` or transaction fails with insufficient balance
+
+**Fix:** Fund your account via Friendbot:
+
+```bash
+stellar keys fund <your-key-name> --network testnet
+```
+
+Or use the [Stellar Friendbot](https://friendbot.stellar.org) directly with your public key.
+
+---
+
+## Useful Links
+
+- [Soroban docs](https://developers.stellar.org/docs/build/smart-contracts/overview)
+- [Stellar CLI reference](https://developers.stellar.org/docs/tools/developer-tools/cli/stellar-cli)
+- [Stellar Wallets Kit](https://github.com/Creit-Tech/Stellar-Wallets-Kit)
+- [CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/packages/indexer/jest.config.js
+++ b/packages/indexer/jest.config.js
@@ -1,0 +1,6 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/__tests__/**/*.test.ts"],
+};

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -20,6 +20,9 @@
     "@types/express": "^4.17.0",
     "@types/pg": "^8.10.0",
     "@types/node": "^20.0.0",
+    "@types/jest": "^29.0.0",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
     "typescript": "^5.0.0",
     "ts-node": "^10.9.0"
   }

--- a/packages/indexer/src/__tests__/cache.test.ts
+++ b/packages/indexer/src/__tests__/cache.test.ts
@@ -1,0 +1,65 @@
+import { cached, invalidate, invalidatePattern, getMetrics, resetMetrics } from "../cache";
+
+beforeEach(() => {
+  resetMetrics();
+  // Clear cache between tests by invalidating known keys
+  invalidatePattern("");
+});
+
+describe("cached()", () => {
+  it("returns data from fn on cache miss", async () => {
+    const fn = jest.fn().mockResolvedValue({ value: 42 });
+    const result = await cached("test:key", 5000, fn);
+    expect(result).toEqual({ value: 42 });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns cached data on cache hit without calling fn again", async () => {
+    const fn = jest.fn().mockResolvedValue({ value: 99 });
+    await cached("test:hit", 5000, fn);
+    const result = await cached("test:hit", 5000, fn);
+    expect(result).toEqual({ value: 99 });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls fn again after TTL expires", async () => {
+    const fn = jest.fn().mockResolvedValue({ value: 1 });
+    await cached("test:ttl", 1, fn); // 1ms TTL
+    await new Promise((r) => setTimeout(r, 5));
+    await cached("test:ttl", 1, fn);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("tracks hit/miss metrics", async () => {
+    const fn = jest.fn().mockResolvedValue("data");
+    await cached("test:metrics", 5000, fn); // miss
+    await cached("test:metrics", 5000, fn); // hit
+    const metrics = getMetrics();
+    expect(metrics.hits).toBe(1);
+    expect(metrics.misses).toBe(1);
+  });
+});
+
+describe("invalidate()", () => {
+  it("removes a specific key so next call is a miss", async () => {
+    const fn = jest.fn().mockResolvedValue("fresh");
+    await cached("test:inv", 5000, fn);
+    invalidate("test:inv");
+    await cached("test:inv", 5000, fn);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("invalidatePattern()", () => {
+  it("removes all keys matching a prefix", async () => {
+    const fn = jest.fn().mockResolvedValue("x");
+    await cached("proposals:0:20", 5000, fn);
+    await cached("proposals:20:20", 5000, fn);
+    await cached("delegates:10", 5000, fn);
+    invalidatePattern("proposals:");
+    await cached("proposals:0:20", 5000, fn);
+    await cached("proposals:20:20", 5000, fn);
+    await cached("delegates:10", 5000, fn); // should still be cached
+    expect(fn).toHaveBeenCalledTimes(4); // 3 initial + 2 re-fetched proposals, delegates still cached
+  });
+});

--- a/packages/indexer/src/api.ts
+++ b/packages/indexer/src/api.ts
@@ -1,21 +1,39 @@
 import express, { Request, Response } from "express";
 import { pool } from "./db";
+import { cached, getMetrics } from "./cache";
+
+const TTL = {
+  proposals: 30_000,       // 30 seconds
+  proposalVotes: 15_000,   // 15 seconds
+  delegates: 60_000,       // 60 seconds
+  profile: 30_000,         // 30 seconds
+};
 
 export function createApp(): express.Application {
   const app = express();
   app.use(express.json());
 
+  // GET /health
+  app.get("/health", (_req: Request, res: Response): void => {
+    const metrics = getMetrics();
+    res.json({ status: "ok", cache: metrics });
+  });
+
   // GET /proposals?offset=0&limit=20
   app.get("/proposals", async (req: Request, res: Response): Promise<void> => {
     const offset = Number(req.query.offset ?? 0);
     const limit = Math.min(Number(req.query.limit ?? 20), 100);
+    const key = `proposals:${offset}:${limit}`;
     try {
-      const result = await pool.query(
-        "SELECT * FROM proposals ORDER BY id DESC LIMIT $1 OFFSET $2",
-        [limit, offset]
-      );
-      res.json({ proposals: result.rows, total: result.rowCount ?? 0 });
-    } catch (err) {
+      const data = await cached(key, TTL.proposals, async () => {
+        const result = await pool.query(
+          "SELECT * FROM proposals ORDER BY id DESC LIMIT $1 OFFSET $2",
+          [limit, offset]
+        );
+        return { proposals: result.rows, total: result.rowCount ?? 0 };
+      });
+      res.json(data);
+    } catch {
       res.status(500).json({ error: "Internal server error" });
     }
   });
@@ -23,13 +41,17 @@ export function createApp(): express.Application {
   // GET /proposals/:id/votes
   app.get("/proposals/:id/votes", async (req: Request, res: Response): Promise<void> => {
     const { id } = req.params;
+    const key = `proposal_votes:${id}`;
     try {
-      const result = await pool.query(
-        "SELECT * FROM votes WHERE proposal_id = $1 ORDER BY created_at DESC",
-        [id]
-      );
-      res.json({ votes: result.rows });
-    } catch (err) {
+      const data = await cached(key, TTL.proposalVotes, async () => {
+        const result = await pool.query(
+          "SELECT * FROM votes WHERE proposal_id = $1 ORDER BY created_at DESC",
+          [id]
+        );
+        return { votes: result.rows };
+      });
+      res.json(data);
+    } catch {
       res.status(500).json({ error: "Internal server error" });
     }
   });
@@ -37,21 +59,24 @@ export function createApp(): express.Application {
   // GET /delegates?top=20
   app.get("/delegates", async (req: Request, res: Response): Promise<void> => {
     const top = Math.min(Number(req.query.top ?? 20), 100);
+    const key = `delegates:${top}`;
     try {
-      // Get most recent delegation per delegatee
-      const result = await pool.query(
-        `SELECT new_delegatee as address, COUNT(*) as delegator_count
-         FROM delegates d1
-         WHERE ledger = (
-           SELECT MAX(d2.ledger) FROM delegates d2 WHERE d2.delegator = d1.delegator
-         )
-         GROUP BY new_delegatee
-         ORDER BY delegator_count DESC
-         LIMIT $1`,
-        [top]
-      );
-      res.json({ delegates: result.rows });
-    } catch (err) {
+      const data = await cached(key, TTL.delegates, async () => {
+        const result = await pool.query(
+          `SELECT new_delegatee as address, COUNT(*) as delegator_count
+           FROM delegates d1
+           WHERE ledger = (
+             SELECT MAX(d2.ledger) FROM delegates d2 WHERE d2.delegator = d1.delegator
+           )
+           GROUP BY new_delegatee
+           ORDER BY delegator_count DESC
+           LIMIT $1`,
+          [top]
+        );
+        return { delegates: result.rows };
+      });
+      res.json(data);
+    } catch {
       res.status(500).json({ error: "Internal server error" });
     }
   });
@@ -59,24 +84,27 @@ export function createApp(): express.Application {
   // GET /profile/:address
   app.get("/profile/:address", async (req: Request, res: Response): Promise<void> => {
     const { address } = req.params;
+    const key = `profile:${address}`;
     try {
-      const [proposalsRes, votesRes, delegationsRes] = await Promise.all([
-        pool.query("SELECT COUNT(*) FROM proposals WHERE proposer = $1", [address]),
-        pool.query("SELECT COUNT(*), SUM(weight) FROM votes WHERE voter = $1", [address]),
-        pool.query(
-          "SELECT new_delegatee FROM delegates WHERE delegator = $1 ORDER BY ledger DESC LIMIT 1",
-          [address]
-        ),
-      ]);
-
-      res.json({
-        address,
-        proposalsCreated: Number(proposalsRes.rows[0].count),
-        votescast: Number(votesRes.rows[0].count),
-        totalVotingPowerUsed: String(votesRes.rows[0].sum ?? 0),
-        currentDelegatee: delegationsRes.rows[0]?.new_delegatee ?? address,
+      const data = await cached(key, TTL.profile, async () => {
+        const [proposalsRes, votesRes, delegationsRes] = await Promise.all([
+          pool.query("SELECT COUNT(*) FROM proposals WHERE proposer = $1", [address]),
+          pool.query("SELECT COUNT(*), SUM(weight) FROM votes WHERE voter = $1", [address]),
+          pool.query(
+            "SELECT new_delegatee FROM delegates WHERE delegator = $1 ORDER BY ledger DESC LIMIT 1",
+            [address]
+          ),
+        ]);
+        return {
+          address,
+          proposalsCreated: Number(proposalsRes.rows[0].count),
+          votescast: Number(votesRes.rows[0].count),
+          totalVotingPowerUsed: String(votesRes.rows[0].sum ?? 0),
+          currentDelegatee: delegationsRes.rows[0]?.new_delegatee ?? address,
+        };
       });
-    } catch (err) {
+      res.json(data);
+    } catch {
       res.status(500).json({ error: "Internal server error" });
     }
   });

--- a/packages/indexer/src/cache.ts
+++ b/packages/indexer/src/cache.ts
@@ -1,0 +1,45 @@
+interface CacheEntry {
+  data: unknown;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+let hits = 0;
+let misses = 0;
+
+export function cached<T>(key: string, ttlMs: number, fn: () => Promise<T>): Promise<T> {
+  const entry = cache.get(key);
+  if (entry && Date.now() < entry.expiresAt) {
+    hits++;
+    return Promise.resolve(entry.data as T);
+  }
+  misses++;
+  return fn().then((data) => {
+    cache.set(key, { data, expiresAt: Date.now() + ttlMs });
+    return data;
+  });
+}
+
+export function invalidate(...keys: string[]): void {
+  for (const key of keys) {
+    cache.delete(key);
+  }
+}
+
+export function invalidatePattern(prefix: string): void {
+  for (const key of cache.keys()) {
+    if (key.startsWith(prefix)) {
+      cache.delete(key);
+    }
+  }
+}
+
+export function getMetrics() {
+  return { hits, misses, size: cache.size };
+}
+
+export function resetMetrics(): void {
+  hits = 0;
+  misses = 0;
+}

--- a/packages/indexer/src/events.ts
+++ b/packages/indexer/src/events.ts
@@ -1,5 +1,6 @@
 import { SorobanRpc, scValToNative } from "@stellar/stellar-sdk";
 import { pool } from "./db";
+import { invalidate, invalidatePattern } from "./cache";
 
 export interface IndexerConfig {
   rpcUrl: string;
@@ -95,12 +96,14 @@ async function handleProposalCreated(
     number
   ];
 
+  invalidatePattern("proposals:");
   await pool.query(
     `INSERT INTO proposals (id, proposer, description, start_ledger, end_ledger)
      VALUES ($1, $2, $3, $4, $5)
      ON CONFLICT (id) DO NOTHING`,
     [String(id), proposer, description, startLedger, endLedger]
   );
+  invalidate(`profile:${proposer}`);
 }
 
 async function handleVoteCast(
@@ -132,16 +135,22 @@ async function handleVoteCast(
     `UPDATE proposals SET ${col} = ${col} + $1 WHERE id = $2`,
     [weight, proposalId]
   );
+  invalidate(`proposal_votes:${proposalId}`, `profile:${voter}`);
+  invalidatePattern("proposals:");
 }
 
 async function handleProposalQueued(topics: unknown[]): Promise<void> {
   const proposalId = String(topics[1] as bigint);
   await pool.query("UPDATE proposals SET queued = true WHERE id = $1", [proposalId]);
+  invalidate(`proposal_votes:${proposalId}`);
+  invalidatePattern("proposals:");
 }
 
 async function handleProposalExecuted(topics: unknown[]): Promise<void> {
   const proposalId = String(topics[1] as bigint);
   await pool.query("UPDATE proposals SET executed = true WHERE id = $1", [proposalId]);
+  invalidate(`proposal_votes:${proposalId}`);
+  invalidatePattern("proposals:");
 }
 
 async function handleDelegateChanged(
@@ -157,4 +166,6 @@ async function handleDelegateChanged(
      VALUES ($1, $2, $3, $4)`,
     [delegator, oldDelegatee, newDelegatee, event.ledger]
   );
+  invalidatePattern("delegates:");
+  invalidate(`profile:${delegator}`);
 }


### PR DESCRIPTION
closes #234 
closes #264
closes #245
closes #228 

- 234: update sdk.yml with path filters, type check, coverage, bundle size check, lint, and artifact uploads
- 264: add docs/local-development.md with full step-by-step setup guide
- 245: add in-memory TTL cache to indexer API with invalidation on new events and /health metrics
- 228: add express-rate-limit to backend with global, join, and leaderboard limiters; /health exempt