### PR TITLE
Implemented: server-side notification persistence (with localStorage fallback)

### DIFF
--- a/app/.env.local.example
+++ b/app/.env.local.example
@@ -13,5 +13,8 @@ NEXT_PUBLIC_VOTES_ADDRESS=CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2
 # Stellar network: mainnet, testnet, or futurenet
 NEXT_PUBLIC_NETWORK=testnet
 
+# Optional: Backend API base URL for persisted notifications
+NEXT_PUBLIC_BACKEND_URL=http://localhost:3001
+
 # Optional: Custom RPC URL (defaults to public endpoint if not set)
 # NEXT_PUBLIC_RPC_URL=https://soroban-testnet.stellar.org

--- a/app/src/app/notifications/page.tsx
+++ b/app/src/app/notifications/page.tsx
@@ -6,11 +6,14 @@ import {
   DEFAULT_NOTIFICATION_TOGGLES,
   loadNotificationHistory,
   loadNotificationToggles,
+  markAllNotificationsRead,
   saveNotificationToggles,
+  syncNotificationsFromBackend,
   type NotificationHistoryEntry,
   type NotificationToggleKey,
   type NotificationToggles,
 } from "../../lib/governance-notifications";
+import { useWallet } from "../../lib/wallet-context";
 
 const TOGGLE_ROWS: {
   key: NotificationToggleKey;
@@ -58,6 +61,7 @@ function permissionLabel(): string {
 }
 
 export default function NotificationsPage() {
+  const { isConnected } = useWallet();
   const [toggles, setToggles] = useState<NotificationToggles>({
     ...DEFAULT_NOTIFICATION_TOGGLES,
   });
@@ -66,7 +70,11 @@ export default function NotificationsPage() {
   useEffect(() => {
     setToggles(loadNotificationToggles());
     setHistory(loadNotificationHistory());
-  }, []);
+    if (isConnected) {
+      void syncNotificationsFromBackend().catch(() => undefined);
+    }
+    markAllNotificationsRead();
+  }, [isConnected]);
 
   useEffect(() => {
     const onHistory = () => setHistory(loadNotificationHistory());

--- a/app/src/components/NavBar.tsx
+++ b/app/src/components/NavBar.tsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react";
 import { useTheme } from "../hooks/useTheme";
 import toast from "react-hot-toast";
+import { loadNotificationHistory } from "../lib/governance-notifications";
 
 const NAV_LINKS = [
   { name: "Proposals", href: "/", icon: LayoutDashboard },
@@ -40,6 +41,7 @@ export function NavBar() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isWalletMenuOpen, setIsWalletMenuOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
+  const [unread, setUnread] = useState(0);
   const drawerRef = useRef<HTMLDivElement>(null);
   const { theme, setTheme } = useTheme();
 
@@ -62,6 +64,16 @@ export function NavBar() {
       document.body.style.overflow = "";
     };
   }, [isMenuOpen]);
+
+  useEffect(() => {
+    const compute = () => {
+      const rows = loadNotificationHistory();
+      setUnread(rows.filter((r) => !r.read).length);
+    };
+    compute();
+    window.addEventListener("nebgov-notify-history", compute);
+    return () => window.removeEventListener("nebgov-notify-history", compute);
+  }, []);
 
   useEffect(() => {
     if (!isWalletMenuOpen) return;
@@ -132,7 +144,14 @@ export function NavBar() {
                       : "text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white hover:bg-gray-50 dark:hover:bg-gray-800"
                   }`}
                 >
-                  {link.name}
+                  <span className="inline-flex items-center gap-2">
+                    {link.name}
+                    {link.href === "/notifications" && unread > 0 && (
+                      <span className="min-w-5 h-5 px-1.5 rounded-full bg-indigo-600 text-white text-[11px] leading-5 text-center">
+                        {unread > 99 ? "99+" : unread}
+                      </span>
+                    )}
+                  </span>
                 </Link>
               );
             })}
@@ -304,7 +323,12 @@ export function NavBar() {
                       className={`w-5 h-5 flex-shrink-0 ${isActive ? "text-indigo-600" : "text-gray-400"}`}
                       aria-hidden
                     />
-                    {link.name}
+                    <span className="flex-1">{link.name}</span>
+                    {link.href === "/notifications" && unread > 0 && (
+                      <span className="min-w-6 h-6 px-2 rounded-full bg-indigo-600 text-white text-xs leading-6 text-center">
+                        {unread > 99 ? "99+" : unread}
+                      </span>
+                    )}
                   </Link>
                 );
               })}

--- a/app/src/lib/backend.ts
+++ b/app/src/lib/backend.ts
@@ -1,0 +1,49 @@
+export function backendBaseUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_BACKEND_URL?.replace(/\/+$/, "") ||
+    "http://localhost:3001"
+  );
+}
+
+export const LS_AUTH_TOKEN = "nebgov-auth-token";
+
+export function getAuthToken(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return localStorage.getItem(LS_AUTH_TOKEN);
+  } catch {
+    return null;
+  }
+}
+
+export function setAuthToken(token: string | null): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (!token) localStorage.removeItem(LS_AUTH_TOKEN);
+    else localStorage.setItem(LS_AUTH_TOKEN, token);
+  } catch {
+    /* ignore */
+  }
+}
+
+export async function backendFetch<T>(
+  path: string,
+  opts: RequestInit & { auth?: boolean } = {}
+): Promise<T> {
+  const url = `${backendBaseUrl()}${path.startsWith("/") ? path : `/${path}`}`;
+  const headers = new Headers(opts.headers);
+  headers.set("Content-Type", "application/json");
+
+  if (opts.auth) {
+    const token = getAuthToken();
+    if (token) headers.set("Authorization", `Bearer ${token}`);
+  }
+
+  const res = await fetch(url, { ...opts, headers });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Backend ${res.status}: ${text || res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+

--- a/app/src/lib/governance-notifications.ts
+++ b/app/src/lib/governance-notifications.ts
@@ -2,6 +2,8 @@
  * Browser notification preferences and on-device event history (localStorage).
  */
 
+import { backendFetch, getAuthToken } from "./backend";
+
 export const LS_NOTIFY_TOGGLES = "nebgov-notify-toggles";
 export const LS_NOTIFY_HISTORY = "nebgov-notify-history";
 export const LS_PROPOSAL_META = "nebgov-proposal-meta";
@@ -39,6 +41,7 @@ export type NotificationHistoryEntry = {
   body: string;
   at: number;
   ledger?: number;
+  read?: boolean;
 };
 
 const MAX_HISTORY = 200;
@@ -58,6 +61,16 @@ export function loadNotificationToggles(): NotificationToggles {
 export function saveNotificationToggles(t: NotificationToggles): void {
   localStorage.setItem(LS_NOTIFY_TOGGLES, JSON.stringify(t));
   window.dispatchEvent(new Event("nebgov-notify-toggles"));
+
+  const token = getAuthToken();
+  if (!token) return;
+  void backendFetch<NotificationToggles>("/notifications/preferences", {
+    method: "POST",
+    auth: true,
+    body: JSON.stringify(t),
+  }).catch(() => {
+    /* best-effort */
+  });
 }
 
 export function loadNotificationHistory(): NotificationHistoryEntry[] {
@@ -65,7 +78,8 @@ export function loadNotificationHistory(): NotificationHistoryEntry[] {
   try {
     const raw = localStorage.getItem(LS_NOTIFY_HISTORY);
     if (!raw) return [];
-    return JSON.parse(raw) as NotificationHistoryEntry[];
+    const parsed = JSON.parse(raw) as NotificationHistoryEntry[];
+    return parsed.map((e) => ({ ...e, read: e.read ?? false }));
   } catch {
     return [];
   }
@@ -85,11 +99,92 @@ export function appendNotificationHistory(
     title: entry.title,
     body: entry.body,
     ledger: entry.ledger,
+    read: false,
   };
   const prev = loadNotificationHistory();
   const next = [row, ...prev].slice(0, MAX_HISTORY);
   localStorage.setItem(LS_NOTIFY_HISTORY, JSON.stringify(next));
   window.dispatchEvent(new Event("nebgov-notify-history"));
+
+  const token = getAuthToken();
+  if (!token) return;
+  void backendFetch("/notifications", {
+    method: "POST",
+    auth: true,
+    body: JSON.stringify({
+      type: row.kind,
+      proposal_id: Number.isFinite(Number(row.proposalId))
+        ? Number(row.proposalId)
+        : undefined,
+      message: `${row.title}\n\n${row.body}`,
+    }),
+  }).catch(() => {
+    /* best-effort */
+  });
+}
+
+export function unreadCount(): number {
+  return loadNotificationHistory().filter((e) => !e.read).length;
+}
+
+export async function syncNotificationsFromBackend(): Promise<void> {
+  const token = getAuthToken();
+  if (!token) return;
+
+  const [prefs, history] = await Promise.all([
+    backendFetch<NotificationToggles>("/notifications/preferences", {
+      method: "GET",
+      auth: true,
+    }),
+    backendFetch<{
+      data: {
+        id: number;
+        type: string;
+        proposal_id: number | null;
+        message: string | null;
+        read: boolean;
+        created_at: string;
+      }[];
+    }>("/notifications?limit=200&offset=0", { method: "GET", auth: true }),
+  ]);
+
+  localStorage.setItem(LS_NOTIFY_TOGGLES, JSON.stringify(prefs));
+  window.dispatchEvent(new Event("nebgov-notify-toggles"));
+
+  const mapped: NotificationHistoryEntry[] = history.data.map((r) => {
+    const msg = r.message ?? "";
+    const [title, ...rest] = msg.split("\n\n");
+    return {
+      id: String(r.id),
+      kind: (r.type as NotificationEventKind) ?? "active",
+      proposalId: r.proposal_id != null ? String(r.proposal_id) : "0",
+      title: title || r.type,
+      body: rest.join("\n\n") || "",
+      at: new Date(r.created_at).getTime(),
+      read: r.read,
+    };
+  });
+
+  localStorage.setItem(LS_NOTIFY_HISTORY, JSON.stringify(mapped));
+  window.dispatchEvent(new Event("nebgov-notify-history"));
+}
+
+export function markAllNotificationsRead(): void {
+  const prev = loadNotificationHistory();
+  if (prev.length === 0) return;
+  const next = prev.map((e) => ({ ...e, read: true }));
+  localStorage.setItem(LS_NOTIFY_HISTORY, JSON.stringify(next));
+  window.dispatchEvent(new Event("nebgov-notify-history"));
+
+  const token = getAuthToken();
+  if (!token) return;
+  void backendFetch("/notifications/mark-read", {
+    method: "POST",
+    auth: true,
+    body: JSON.stringify({ all: true }),
+  }).catch(() => {
+    /* best-effort */
+  });
 }
 
 export type ProposalMeta = {

--- a/app/src/lib/wallet-context.tsx
+++ b/app/src/lib/wallet-context.tsx
@@ -23,6 +23,8 @@ import {
   AlbedoModule,
   type ISupportedWallet,
 } from "@creit.tech/stellar-wallets-kit";
+import { backendFetch, setAuthToken } from "./backend";
+import { syncNotificationsFromBackend } from "./governance-notifications";
 
 function appNetworkPassphrase(): string {
   const n = process.env.NEXT_PUBLIC_NETWORK || "testnet";
@@ -96,6 +98,17 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
             if (typeof window !== "undefined" && "Notification" in window) {
               void Notification.requestPermission();
             }
+
+            try {
+              const login = await backendFetch<{ token: string }>("/auth/login", {
+                method: "POST",
+                body: JSON.stringify({ wallet_address: rawAddress }),
+              });
+              setAuthToken(login.token);
+              await syncNotificationsFromBackend();
+            } catch {
+              // Backend is optional; localStorage notifications still work.
+            }
           } catch (err) {
             const msg =
               err instanceof Error ? err.message : "Failed to get address";
@@ -117,6 +130,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     setAddress(null);
     setPublicKey(null);
     setError(null);
+    setAuthToken(null);
   }, []);
 
   const signTransaction = useCallback(

--- a/backend/src/__tests__/notifications.test.ts
+++ b/backend/src/__tests__/notifications.test.ts
@@ -1,0 +1,106 @@
+import request from "supertest";
+import app from "../index";
+import pool from "../db/pool";
+import jwt from "jsonwebtoken";
+
+describe("Notification Endpoints", () => {
+  let authToken: string;
+  let userId: number;
+
+  beforeAll(async () => {
+    const userResult = await pool.query(
+      "INSERT INTO users (wallet_address) VALUES ($1) RETURNING id",
+      ["GTESTNOTIFY123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"],
+    );
+    userId = userResult.rows[0].id;
+    authToken = jwt.sign(
+      { userId, walletAddress: "GTESTNOTIFY123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ" },
+      process.env.JWT_SECRET!,
+    );
+  });
+
+  afterAll(async () => {
+    await pool.query("DELETE FROM notification_history WHERE user_id = $1", [
+      userId,
+    ]);
+    await pool.query("DELETE FROM notification_preferences WHERE user_id = $1", [
+      userId,
+    ]);
+    await pool.query("DELETE FROM users WHERE id = $1", [userId]);
+  });
+
+  it("GET /notifications/preferences returns defaults when missing", async () => {
+    const res = await request(app)
+      .get("/notifications/preferences")
+      .set("Authorization", `Bearer ${authToken}`)
+      .expect(200);
+
+    expect(res.body).toHaveProperty("created_self", true);
+    expect(res.body).toHaveProperty("active", true);
+  });
+
+  it("POST /notifications/preferences upserts preferences", async () => {
+    const res = await request(app)
+      .post("/notifications/preferences")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({ active: false, executed: true })
+      .expect(200);
+
+    expect(res.body.active).toBe(false);
+
+    const res2 = await request(app)
+      .get("/notifications/preferences")
+      .set("Authorization", `Bearer ${authToken}`)
+      .expect(200);
+
+    expect(res2.body.active).toBe(false);
+    expect(res2.body.executed).toBe(true);
+  });
+
+  it("POST /notifications creates a history entry, GET returns it", async () => {
+    const created = await request(app)
+      .post("/notifications")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({
+        type: "active",
+        proposal_id: 123,
+        message: "Proposal is active",
+      })
+      .expect(201);
+
+    expect(created.body).toHaveProperty("id");
+    expect(created.body.read).toBe(false);
+
+    const res = await request(app)
+      .get("/notifications?limit=50&offset=0")
+      .set("Authorization", `Bearer ${authToken}`)
+      .expect(200);
+
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.meta).toHaveProperty("unread");
+    expect(res.body.meta.unread).toBeGreaterThanOrEqual(1);
+  });
+
+  it("POST /notifications/mark-read marks all as read", async () => {
+    await request(app)
+      .post("/notifications")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({ type: "queued", proposal_id: 124, message: "Queued" })
+      .expect(201);
+
+    const marked = await request(app)
+      .post("/notifications/mark-read")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({ all: true })
+      .expect(200);
+
+    expect(marked.body.unread).toBe(0);
+  });
+
+  it("requires authentication", async () => {
+    await request(app).get("/notifications").expect(401);
+    await request(app).get("/notifications/preferences").expect(401);
+    await request(app).post("/notifications/preferences").send({}).expect(401);
+  });
+});
+

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -59,3 +59,30 @@ CREATE INDEX IF NOT EXISTS idx_leaderboard_history_date ON leaderboard_history(s
 CREATE INDEX IF NOT EXISTS idx_leaderboard_history_user_date ON leaderboard_history(user_id, snapshot_date);
 CREATE INDEX IF NOT EXISTS idx_competitions_active ON competitions(is_active);
 CREATE INDEX IF NOT EXISTS idx_competitions_dates ON competitions(start_date, end_date);
+
+-- Notification preferences (per user)
+CREATE TABLE IF NOT EXISTS notification_preferences (
+  user_id INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  created_self BOOLEAN DEFAULT true,
+  active BOOLEAN DEFAULT true,
+  voting_ends_soon BOOLEAN DEFAULT true,
+  outcome BOOLEAN DEFAULT true,
+  queued BOOLEAN DEFAULT true,
+  executed BOOLEAN DEFAULT true
+);
+
+-- Notification history (per user)
+CREATE TABLE IF NOT EXISTS notification_history (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  type TEXT NOT NULL,
+  proposal_id BIGINT,
+  message TEXT,
+  read BOOLEAN DEFAULT false,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_history_user_created_at
+  ON notification_history(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_notification_history_user_read
+  ON notification_history(user_id, read);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,8 @@ import cors from "cors";
 import dotenv from "dotenv";
 import competitionsRouter from "./routes/competitions";
 import leaderboardRouter from "./routes/leaderboard";
+import authRouter from "./routes/auth";
+import notificationsRouter from "./routes/notifications";
 
 dotenv.config();
 
@@ -19,8 +21,10 @@ app.get("/health", (req, res) => {
 });
 
 // Routes
+app.use("/auth", authRouter);
 app.use("/competitions", competitionsRouter);
 app.use("/leaderboard", leaderboardRouter);
+app.use("/notifications", notificationsRouter);
 
 // Error handling
 app.use(

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,0 +1,50 @@
+import { Router } from "express";
+import { body, validationResult } from "express-validator";
+import jwt from "jsonwebtoken";
+import pool from "../db/pool";
+
+const router = Router();
+
+// POST /auth/login - Create/find user and return JWT (dev/simple auth)
+router.post(
+  "/login",
+  body("wallet_address").isString().trim().isLength({ min: 10, max: 56 }),
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
+    const walletAddress = (req.body.wallet_address as string).trim();
+
+    try {
+      const existing = await pool.query<{ id: number; wallet_address: string }>(
+        "SELECT id, wallet_address FROM users WHERE wallet_address = $1",
+        [walletAddress],
+      );
+
+      const userId =
+        existing.rows[0]?.id ??
+        (
+          await pool.query<{ id: number }>(
+            "INSERT INTO users (wallet_address) VALUES ($1) RETURNING id",
+            [walletAddress],
+          )
+        ).rows[0].id;
+
+      const token = jwt.sign(
+        { userId, walletAddress },
+        process.env.JWT_SECRET!,
+        { expiresIn: "30d" },
+      );
+
+      res.json({ token, user_id: userId, wallet_address: walletAddress });
+    } catch (error) {
+      console.error("Error in /auth/login:", error);
+      res.status(500).json({ error: "Failed to login" });
+    }
+  },
+);
+
+export default router;
+

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -1,0 +1,210 @@
+import { Response, Router } from "express";
+import { body, query, validationResult } from "express-validator";
+import pool from "../db/pool";
+import { authenticate, AuthRequest } from "../middleware/auth";
+
+const router = Router();
+
+const PREF_KEYS = [
+  "created_self",
+  "active",
+  "voting_ends_soon",
+  "outcome",
+  "queued",
+  "executed",
+] as const;
+
+type PrefKey = (typeof PREF_KEYS)[number];
+
+function defaultPreferences() {
+  return {
+    created_self: true,
+    active: true,
+    voting_ends_soon: true,
+    outcome: true,
+    queued: true,
+    executed: true,
+  };
+}
+
+// GET /notifications/preferences - get current preferences (auth required)
+router.get("/preferences", authenticate, async (req: AuthRequest, res) => {
+  try {
+    const userId = req.userId!;
+    const result = await pool.query(
+      `SELECT ${PREF_KEYS.join(", ")} FROM notification_preferences WHERE user_id = $1`,
+      [userId],
+    );
+    res.json(result.rows[0] ?? defaultPreferences());
+  } catch (error) {
+    console.error("Error fetching notification preferences:", error);
+    res.status(500).json({ error: "Failed to fetch preferences" });
+  }
+});
+
+// POST /notifications/preferences - save preferences (auth required)
+router.post(
+  "/preferences",
+  authenticate,
+  ...PREF_KEYS.map((k) => body(k).optional().isBoolean()),
+  async (req: AuthRequest, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
+    const userId = req.userId!;
+    const next: Record<PrefKey, boolean> = defaultPreferences();
+    for (const k of PREF_KEYS) {
+      if (typeof req.body[k] === "boolean") next[k] = req.body[k];
+    }
+
+    try {
+      await pool.query(
+        `INSERT INTO notification_preferences (user_id, ${PREF_KEYS.join(", ")})
+         VALUES ($1, ${PREF_KEYS.map((_, i) => `$${i + 2}`).join(", ")})
+         ON CONFLICT (user_id) DO UPDATE SET
+           ${PREF_KEYS.map((k, i) => `${k} = $${i + 2}`).join(", ")}`,
+        [userId, ...PREF_KEYS.map((k) => next[k])],
+      );
+
+      res.json(next);
+    } catch (error) {
+      console.error("Error saving notification preferences:", error);
+      res.status(500).json({ error: "Failed to save preferences" });
+    }
+  },
+);
+
+// GET /notifications - fetch user's notification history (auth required)
+router.get(
+  "/",
+  authenticate,
+  [
+    query("limit").optional().isInt({ min: 1, max: 200 }).toInt(),
+    query("offset").optional().isInt({ min: 0 }).toInt(),
+    query("unread_only").optional().isBoolean().toBoolean(),
+  ],
+  async (req: AuthRequest, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
+    const userId = req.userId!;
+    const limit = (req.query.limit as number | undefined) ?? 100;
+    const offset = (req.query.offset as number | undefined) ?? 0;
+    const unreadOnly = (req.query.unread_only as boolean | undefined) ?? false;
+
+    try {
+      const whereUnread = unreadOnly ? "AND read = false" : "";
+      const rows = await pool.query(
+        `SELECT id, type, proposal_id, message, read, created_at
+         FROM notification_history
+         WHERE user_id = $1 ${whereUnread}
+         ORDER BY created_at DESC
+         LIMIT $2 OFFSET $3`,
+        [userId, limit, offset],
+      );
+
+      const count = await pool.query(
+        `SELECT COUNT(*)::int AS total,
+                SUM(CASE WHEN read = false THEN 1 ELSE 0 END)::int AS unread
+         FROM notification_history
+         WHERE user_id = $1`,
+        [userId],
+      );
+
+      res.json({
+        data: rows.rows,
+        meta: {
+          total: count.rows[0]?.total ?? 0,
+          unread: count.rows[0]?.unread ?? 0,
+          limit,
+          offset,
+        },
+      });
+    } catch (error) {
+      console.error("Error fetching notification history:", error);
+      res.status(500).json({ error: "Failed to fetch notifications" });
+    }
+  },
+);
+
+// POST /notifications - add a history entry (auth required)
+router.post(
+  "/",
+  authenticate,
+  body("type").isString().trim().isLength({ min: 1, max: 64 }),
+  body("proposal_id").optional().isInt({ min: 0 }).toInt(),
+  body("message").optional().isString(),
+  async (req: AuthRequest, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
+    const userId = req.userId!;
+    const type = (req.body.type as string).trim();
+    const proposalId = req.body.proposal_id as number | undefined;
+    const message = (req.body.message as string | undefined) ?? null;
+
+    try {
+      const inserted = await pool.query(
+        `INSERT INTO notification_history (user_id, type, proposal_id, message)
+         VALUES ($1, $2, $3, $4)
+         RETURNING id, type, proposal_id, message, read, created_at`,
+        [userId, type, proposalId ?? null, message],
+      );
+      res.status(201).json(inserted.rows[0]);
+    } catch (error) {
+      console.error("Error inserting notification:", error);
+      res.status(500).json({ error: "Failed to create notification" });
+    }
+  },
+);
+
+// POST /notifications/mark-read - mark notifications as read (auth required)
+router.post(
+  "/mark-read",
+  authenticate,
+  body("ids").optional().isArray({ min: 1 }),
+  body("ids.*").optional().isInt().toInt(),
+  body("all").optional().isBoolean(),
+  async (req: AuthRequest, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
+    const userId = req.userId!;
+    const markAll = req.body.all === true;
+    const ids = (req.body.ids as number[] | undefined) ?? [];
+
+    try {
+      if (markAll) {
+        await pool.query(
+          "UPDATE notification_history SET read = true WHERE user_id = $1 AND read = false",
+          [userId],
+        );
+      } else if (ids.length > 0) {
+        await pool.query(
+          "UPDATE notification_history SET read = true WHERE user_id = $1 AND id = ANY($2::int[])",
+          [userId, ids],
+        );
+      }
+
+      const unread = await pool.query(
+        "SELECT COUNT(*)::int AS unread FROM notification_history WHERE user_id = $1 AND read = false",
+        [userId],
+      );
+      res.json({ unread: unread.rows[0]?.unread ?? 0 });
+    } catch (error) {
+      console.error("Error marking notifications read:", error);
+      res.status(500).json({ error: "Failed to mark read" });
+    }
+  },
+);
+
+export default router;
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,9 +79,67 @@ importers:
         version: 8.5.8
       tailwindcss:
         specifier: ^3.3.0
-        version: 3.4.19
+        version: 3.4.19(tsx@4.21.0)
       typescript:
         specifier: ^5
+        version: 5.9.3
+
+  backend:
+    dependencies:
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.6
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.6.1
+      express:
+        specifier: ^4.18.2
+        version: 4.22.1
+      express-validator:
+        specifier: ^7.0.1
+        version: 7.3.2
+      jsonwebtoken:
+        specifier: ^9.0.2
+        version: 9.0.3
+      pg:
+        specifier: ^8.11.3
+        version: 8.20.0
+    devDependencies:
+      '@types/cors':
+        specifier: ^2.8.17
+        version: 2.8.19
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.25
+      '@types/jest':
+        specifier: ^29.5.11
+        version: 29.5.14
+      '@types/jsonwebtoken':
+        specifier: ^9.0.5
+        version: 9.0.10
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.37
+      '@types/pg':
+        specifier: ^8.10.9
+        version: 8.20.0
+      '@types/supertest':
+        specifier: ^6.0.2
+        version: 6.0.3
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
+      supertest:
+        specifier: ^6.3.3
+        version: 6.3.4
+      ts-jest:
+        specifier: ^29.1.1
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)))(typescript@5.9.3)
+      tsx:
+        specifier: ^4.7.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.3.3
         version: 5.9.3
 
   packages/indexer:
@@ -346,6 +404,162 @@ packages:
 
   '@emurgo/cardano-serialization-lib-nodejs@13.2.0':
     resolution: {integrity: sha512-Bz1zLGEqBQ0BVkqt1OgMxdBOE3BdUWUd7Ly9Ecr/aUwkA8AV1w1XzBMe4xblmJHnB1XXNlPH4SraXCvO+q0Mig==}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -727,6 +941,9 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@paralleldrive/cuid2@2.3.1':
+    resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1294,6 +1511,12 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/cookiejar@2.1.5':
+    resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
+
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -1363,8 +1586,14 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/jsonwebtoken@9.0.10':
+    resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/methods@1.1.4':
+    resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
@@ -1409,6 +1638,12 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/superagent@8.1.9':
+    resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
+
+  '@types/supertest@6.0.3':
+    resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -1775,6 +2010,9 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -2122,6 +2360,9 @@ packages:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
 
+  component-emitter@1.3.1:
+    resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -2146,8 +2387,15 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookiejar@2.1.4:
+    resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   create-hash@1.2.0:
     resolution: {integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==}
@@ -2348,6 +2596,9 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  dezalgo@1.0.4:
+    resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
+
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
@@ -2466,6 +2717,11 @@ packages:
 
   es6-promisify@5.0.0:
     resolution: {integrity: sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -2634,6 +2890,10 @@ packages:
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
+  express-validator@7.3.2:
+    resolution: {integrity: sha512-ctLw1Vl6dXVH62dIQMDdTAQkrh480mkFuG6/SGXOaVlwPNukhRAe7EgJIMJ2TSAni8iwHBRp530zAZE5ZPF2IA==}
+    engines: {node: '>= 8.0.0'}
+
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
@@ -2665,6 +2925,9 @@ packages:
   fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
     engines: {node: '>=6'}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
@@ -2744,6 +3007,9 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  formidable@2.1.5:
+    resolution: {integrity: sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -3397,6 +3663,10 @@ packages:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
 
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
@@ -3465,9 +3735,27 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
     deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
 
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
@@ -3475,8 +3763,14 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
+
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   long@5.2.5:
     resolution: {integrity: sha512-e0r9YBBgNCq1D1o5Dp8FMH0N5hsFtXDBiVa0qoJPHpakvZkmDKPRoGffZJII/XsHvj9An9blm+cRJ01yQqU+Dw==}
@@ -3643,6 +3937,11 @@ packages:
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
+    hasBin: true
+
+  mime@2.6.0:
+    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
+    engines: {node: '>=4.0.0'}
     hasBin: true
 
   mimic-fn@2.1.0:
@@ -4615,9 +4914,19 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
+  superagent@8.1.2:
+    resolution: {integrity: sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==}
+    engines: {node: '>=6.4.0 <13 || >=14'}
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
+
   superstruct@2.0.2:
     resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
     engines: {node: '>=14.0.0'}
+
+  supertest@6.3.4:
+    resolution: {integrity: sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==}
+    engines: {node: '>=6.4.0'}
+    deprecated: Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -4762,6 +5071,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tweetnacl-util@0.15.1:
     resolution: {integrity: sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==}
@@ -4991,6 +5305,10 @@ packages:
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
+
+  validator@13.15.35:
+    resolution: {integrity: sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==}
+    engines: {node: '>= 0.10'}
 
   valtio@1.11.2:
     resolution: {integrity: sha512-1XfIxnUXzyswPAPXo1P3Pdx2mq/pIqZICkWN60Hby0d9Iqb+MEIpqgYVlbflvHdrp2YR/q3jyKWRPJJ100yxaw==}
@@ -5440,6 +5758,84 @@ snapshots:
   '@emurgo/cardano-serialization-lib-browser@13.2.1': {}
 
   '@emurgo/cardano-serialization-lib-nodejs@13.2.0': {}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
     dependencies:
@@ -6008,6 +6404,10 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@paralleldrive/cuid2@2.3.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -6912,6 +7312,12 @@ snapshots:
     dependencies:
       '@types/node': 20.19.37
 
+  '@types/cookiejar@2.1.5': {}
+
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 20.19.37
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-color@3.1.3': {}
@@ -6989,9 +7395,16 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/jsonwebtoken@9.0.10':
+    dependencies:
+      '@types/ms': 2.1.0
+      '@types/node': 20.19.37
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/methods@1.1.4': {}
 
   '@types/mime@1.3.5': {}
 
@@ -7040,6 +7453,18 @@ snapshots:
       '@types/send': 0.17.6
 
   '@types/stack-utils@2.0.3': {}
+
+  '@types/superagent@8.1.9':
+    dependencies:
+      '@types/cookiejar': 2.1.5
+      '@types/methods': 1.1.4
+      '@types/node': 20.19.37
+      form-data: 4.0.5
+
+  '@types/supertest@6.0.3':
+    dependencies:
+      '@types/methods': 1.1.4
+      '@types/superagent': 8.1.9
 
   '@types/trusted-types@2.0.7': {}
 
@@ -7600,6 +8025,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  asap@2.0.6: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -7968,6 +8395,8 @@ snapshots:
 
   commander@4.1.1: {}
 
+  component-emitter@1.3.1: {}
+
   concat-map@0.0.1: {}
 
   content-disposition@0.5.4:
@@ -7984,7 +8413,14 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cookiejar@2.1.4: {}
+
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   create-hash@1.2.0:
     dependencies:
@@ -8165,6 +8601,11 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  dezalgo@1.0.4:
+    dependencies:
+      asap: 2.0.6
+      wrappy: 1.0.2
 
   didyoumean@1.2.2: {}
 
@@ -8353,6 +8794,35 @@ snapshots:
   es6-promisify@5.0.0:
     dependencies:
       es6-promise: 4.2.8
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   escalade@3.2.0: {}
 
@@ -8597,6 +9067,11 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
+  express-validator@7.3.2:
+    dependencies:
+      lodash: 4.18.1
+      validator: 13.15.35
+
   express@4.22.1:
     dependencies:
       accepts: 1.3.8
@@ -8654,6 +9129,8 @@ snapshots:
   fast-levenshtein@2.0.6: {}
 
   fast-redact@3.5.0: {}
+
+  fast-safe-stringify@2.1.1: {}
 
   fast-stable-stringify@1.0.0: {}
 
@@ -8735,6 +9212,13 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+
+  formidable@2.1.5:
+    dependencies:
+      '@paralleldrive/cuid2': 2.3.1
+      dezalgo: 1.0.4
+      once: 1.4.0
+      qs: 6.14.2
 
   forwarded@0.2.0: {}
 
@@ -9616,6 +10100,19 @@ snapshots:
 
   jsonpointer@5.0.1: {}
 
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.4
+
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.9
@@ -9699,13 +10196,29 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
   lodash.isequal@4.5.0: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
 
   lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
 
+  lodash.once@4.1.1: {}
+
   lodash@4.17.23: {}
+
+  lodash@4.18.1: {}
 
   long@5.2.5: {}
 
@@ -9991,6 +10504,8 @@ snapshots:
       mime-db: 1.52.0
 
   mime@1.6.0: {}
+
+  mime@2.6.0: {}
 
   mimic-fn@2.1.0: {}
 
@@ -10369,12 +10884,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.8
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.8):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.8)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.8
+      tsx: 4.21.0
 
   postcss-nested@6.2.0(postcss@8.5.8):
     dependencies:
@@ -11091,7 +11607,29 @@ snapshots:
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
 
+  superagent@8.1.2:
+    dependencies:
+      component-emitter: 1.3.1
+      cookiejar: 2.1.4
+      debug: 4.4.3
+      fast-safe-stringify: 2.1.1
+      form-data: 4.0.5
+      formidable: 2.1.5
+      methods: 1.1.2
+      mime: 2.6.0
+      qs: 6.14.2
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
+
   superstruct@2.0.2: {}
+
+  supertest@6.3.4:
+    dependencies:
+      methods: 1.1.2
+      superagent: 8.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   supports-color@7.2.0:
     dependencies:
@@ -11105,7 +11643,7 @@ snapshots:
 
   tailwind-merge@3.5.0: {}
 
-  tailwindcss@3.4.19:
+  tailwindcss@3.4.19(tsx@4.21.0):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -11124,7 +11662,7 @@ snapshots:
       postcss: 8.5.8
       postcss-import: 15.1.0(postcss@8.5.8)
       postcss-js: 4.1.0(postcss@8.5.8)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.8)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.8)(tsx@4.21.0)
       postcss-nested: 6.2.0(postcss@8.5.8)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
@@ -11250,6 +11788,13 @@ snapshots:
   tslib@1.14.1: {}
 
   tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.13.7
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tweetnacl-util@0.15.1: {}
 
@@ -11459,6 +12004,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
+
+  validator@13.15.35: {}
 
   valtio@1.11.2(@types/react@18.3.28)(react@18.3.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - 'sdk'
   - 'app'
   - 'packages/indexer'
+  - 'backend'


### PR DESCRIPTION
Closes #238

---

 Implemented: server-side notification persistence (with localStorage fallback)
Backend (backend/)
DB schema: added notification_preferences + notification_history tables (and indexes) in backend/src/db/schema.sql.
Auth: added POST /auth/login to mint a JWT for a wallet address (used by the frontend when a wallet connects).
Notification routes (auth required):
GET /notifications (history + { meta: { total, unread } })
POST /notifications (insert history entry)
GET /notifications/preferences
POST /notifications/preferences (upsert)
POST /notifications/mark-read (mark all or specific ids)
Unit tests: added backend/src/__tests__/notifications.test.ts.
Wiring: registered new routers in backend/src/index.ts.
Frontend (app/)
Backend integration when wallet connected:
On wallet connect, the app calls POST /auth/login, stores the JWT, then syncs preferences + history into localStorage.
When backend is unreachable / user not connected, it keeps using localStorage only.
Unread badge in NavBar:
NavBar computes unread count from stored history and updates via the existing nebgov-notify-history event.
Mark-as-read on view:
Opening /notifications marks all notifications read locally and (if authenticated) calls the backend mark-read endpoint.
Config:
Added NEXT_PUBLIC_BACKEND_URL to app/.env.local.example.
Workspace fix:
Added backend to pnpm-workspace.yaml so backend deps can be installed via the monorepo.
Notes to run
Run backend migrations (this repo uses schema.sql via pnpm migrate in backend/).
Ensure backend has DATABASE_URL + JWT_SECRET set.
Set NEXT_PUBLIC_BACKEND_URL for the app (defaults to http://localhost:3001).
