### PR TITLE
test(backend): add health endpoint test coverage

### DIFF
--- a/backend/src/__tests__/health.test.ts
+++ b/backend/src/__tests__/health.test.ts
@@ -1,0 +1,19 @@
+import request from "supertest";
+import app from "../index";
+
+describe("Health Endpoint", () => {
+  it("returns status payload with ISO timestamp", async () => {
+    const response = await request(app).get("/health").expect(200);
+
+    expect(response.body).toHaveProperty("status", "ok");
+    expect(response.body).toHaveProperty("timestamp");
+    expect(Number.isNaN(Date.parse(response.body.timestamp))).toBe(false);
+  });
+
+  it("is exempt from global rate limiting", async () => {
+    for (let i = 0; i < 120; i++) {
+      const response = await request(app).get("/health");
+      expect(response.status).toBe(200);
+    }
+  });
+});


### PR DESCRIPTION
Closes #184

## Changes
- added backend test coverage for GET /health
- verifies response contract (status: ok + ISO timestamp)
- verifies the health endpoint remains exempt from global rate limiting

## Testing
- attempted: pnpm test -- health.test.ts
- blocked in this environment because backend dependencies are not installed (jest not found), and pnpm install timed out before completion