### PR TITLE
feat: add Postgres indexes to indexer schema and governor pause/unpause events (#230 #247)

### DIFF
--- a/contracts/governor/src/events.rs
+++ b/contracts/governor/src/events.rs
@@ -3,6 +3,8 @@ use soroban_sdk::{Address, Bytes, BytesN, Env, String, Symbol, Vec};
 use crate::{GovernorSettings, Proposal, VoteSupport};
 
 pub const PROPOSAL_CREATED_TOPIC: &str = "ProposalCreated";
+pub const PAUSED_TOPIC: &str = "Paused";
+pub const UNPAUSED_TOPIC: &str = "Unpaused";
 pub const VOTE_CAST_TOPIC: &str = "VoteCast";
 pub const VOTE_CAST_WITH_REASON_TOPIC: &str = "VoteCastWithReason";
 pub const PROPOSAL_QUEUED_TOPIC: &str = "ProposalQueued";
@@ -85,6 +87,19 @@ pub struct GovernorUpgradedEvent {
 pub struct ConfigUpdatedEvent {
     pub old_settings: GovernorSettings,
     pub new_settings: GovernorSettings,
+}
+
+#[derive(Clone)]
+#[soroban_sdk::contracttype]
+pub struct PauseEvent {
+    pub pauser: Address,
+    pub ledger: u32,
+}
+
+#[derive(Clone)]
+#[soroban_sdk::contracttype]
+pub struct UnpauseEvent {
+    pub ledger: u32,
 }
 
 fn vote_support_to_u32(support: &VoteSupport) -> u32 {
@@ -213,6 +228,25 @@ pub fn emit_config_updated(
         ConfigUpdatedEvent {
             old_settings: old_settings.clone(),
             new_settings: new_settings.clone(),
+        },
+    );
+}
+
+pub fn emit_paused(env: &Env, pauser: &Address) {
+    env.events().publish(
+        (Symbol::new(env, PAUSED_TOPIC), pauser.clone()),
+        PauseEvent {
+            pauser: pauser.clone(),
+            ledger: env.ledger().sequence(),
+        },
+    );
+}
+
+pub fn emit_unpaused(env: &Env) {
+    env.events().publish(
+        (Symbol::new(env, UNPAUSED_TOPIC),),
+        UnpauseEvent {
+            ledger: env.ledger().sequence(),
         },
     );
 }

--- a/contracts/governor/src/lib.rs
+++ b/contracts/governor/src/lib.rs
@@ -1626,10 +1626,7 @@ impl GovernorContract {
 
         env.storage().instance().set(&DataKey::IsPaused, &true);
 
-        env.events().publish(
-            (Symbol::new(&env, "ContractPaused"),),
-            (caller, env.ledger().sequence()),
-        );
+        events::emit_paused(&env, &caller);
     }
 
     /// Unpause the contract to resume normal operations.
@@ -1639,8 +1636,7 @@ impl GovernorContract {
 
         env.storage().instance().set(&DataKey::IsPaused, &false);
 
-        env.events()
-            .publish((symbol_short!("unpaused"),), env.ledger().sequence());
+        events::emit_unpaused(&env);
     }
 
     /// Check if the contract is currently paused.

--- a/docs/events.md
+++ b/docs/events.md
@@ -74,6 +74,27 @@ Emitted when the governor contract upgrades its WASM.
 | `old_hash` | `BytesN<32>` | Previously stored WASM hash. The initial value is all zeros until the first tracked upgrade. |
 | `new_hash` | `BytesN<32>` | New WASM hash applied to the contract. |
 
+## Paused
+
+Emitted when the contract is paused by the authorized pauser role.
+
+| Field | Type | Description |
+|---|---|---|
+| `pauser` | `Address` | Address that triggered the pause (also appears as the second topic segment). |
+| `ledger` | `u32` | Ledger sequence number at which the pause was applied. |
+
+> **Topics:** `["Paused", <pauser address>]`
+
+## Unpaused
+
+Emitted when the contract is unpaused via a governance proposal (contract self-auth).
+
+| Field | Type | Description |
+|---|---|---|
+| `ledger` | `u32` | Ledger sequence number at which the contract was unpaused. |
+
+> **Topics:** `["Unpaused"]`
+
 ## ConfigUpdated
 
 Emitted when governance updates the governor settings.

--- a/packages/indexer/src/db.ts
+++ b/packages/indexer/src/db.ts
@@ -68,5 +68,18 @@ export async function initDb(): Promise<void> {
 
     INSERT INTO indexer_state (id, last_ledger) VALUES (1, 0)
     ON CONFLICT (id) DO NOTHING;
+
+    CREATE INDEX IF NOT EXISTS idx_proposals_created_at ON proposals(created_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_proposals_proposer ON proposals(proposer);
+
+    CREATE INDEX IF NOT EXISTS idx_votes_proposal_id ON votes(proposal_id);
+    CREATE INDEX IF NOT EXISTS idx_votes_voter ON votes(voter);
+
+    CREATE INDEX IF NOT EXISTS idx_delegates_delegator ON delegates(delegator);
+    CREATE INDEX IF NOT EXISTS idx_delegates_ledger ON delegates(ledger DESC);
+    CREATE INDEX IF NOT EXISTS idx_delegates_new_delegatee ON delegates(new_delegatee);
+
+    CREATE INDEX IF NOT EXISTS idx_wrapper_deposits_account ON wrapper_deposits(account);
+    CREATE INDEX IF NOT EXISTS idx_wrapper_withdrawals_account ON wrapper_withdrawals(account);
   `);
 }

--- a/sdk/src/__tests__/events.test.ts
+++ b/sdk/src/__tests__/events.test.ts
@@ -1,11 +1,13 @@
 import {
   parseConfigUpdatedEvent,
   parseGovernorUpgradedEvent,
+  parsePauseEvent,
   parseProposalCancelledEvent,
   parseProposalCreatedEvent,
   parseProposalExecutedEvent,
   parseProposalExpiredEvent,
   parseProposalQueuedEvent,
+  parseUnpauseEvent,
   parseVoteCastEvent,
   SorobanEvent,
 } from "../events";
@@ -183,5 +185,55 @@ describe("event parsers", () => {
         proposalThreshold: 200n,
       },
     });
+  });
+
+  it("parses Paused", () => {
+    const event: SorobanEvent = {
+      ledger: 9,
+      contractId: "C123",
+      topic: ["Paused", "GPAUSER"],
+      value: {
+        pauser: "GPAUSER",
+        ledger: 9,
+      },
+    };
+
+    expect(parsePauseEvent(event)).toEqual({
+      pauser: "GPAUSER",
+      ledger: 9,
+    });
+  });
+
+  it("parsePauseEvent returns null for wrong topic", () => {
+    const event: SorobanEvent = {
+      ledger: 9,
+      contractId: "C123",
+      topic: ["SomethingElse"],
+      value: { pauser: "GPAUSER", ledger: 9 },
+    };
+    expect(parsePauseEvent(event)).toBeNull();
+  });
+
+  it("parses Unpaused", () => {
+    const event: SorobanEvent = {
+      ledger: 10,
+      contractId: "C123",
+      topic: ["Unpaused"],
+      value: {
+        ledger: 10,
+      },
+    };
+
+    expect(parseUnpauseEvent(event)).toEqual({ ledger: 10 });
+  });
+
+  it("parseUnpauseEvent returns null for wrong topic", () => {
+    const event: SorobanEvent = {
+      ledger: 10,
+      contractId: "C123",
+      topic: ["Paused"],
+      value: { ledger: 10 },
+    };
+    expect(parseUnpauseEvent(event)).toBeNull();
   });
 });

--- a/sdk/src/events.ts
+++ b/sdk/src/events.ts
@@ -18,6 +18,8 @@ const TOPICS = {
   proposalExpired: "ProposalExpired",
   governorUpgraded: "GovernorUpgraded",
   configUpdated: "ConfigUpdated",
+  paused: "Paused",
+  unpaused: "Unpaused",
   legacyProposalCreated: "prop_crtd",
   legacyVoteCast: "vote",
   legacyProposalExecuted: "execute",
@@ -77,6 +79,15 @@ export interface GovernorUpgradedEventData {
 export interface ConfigUpdatedEventData {
   oldSettings: GovernorSettings;
   newSettings: GovernorSettings;
+}
+
+export interface PauseEventData {
+  pauser: string;
+  ledger: number;
+}
+
+export interface UnpauseEventData {
+  ledger: number;
 }
 
 export interface SubscriptionOptions {
@@ -551,4 +562,44 @@ export function subscribeToConfigUpdated(
   opts: SubscriptionOptions
 ): () => void {
   return createTopicSubscription(governorAddress, TOPICS.configUpdated, callback, opts);
+}
+
+export function parsePauseEvent(event: SorobanEvent): PauseEventData | null {
+  if (event.topic[0] !== TOPICS.paused) return null;
+  if (!isRecord(event.value)) return null;
+
+  const ledger = toNumber(event.value.ledger);
+  if (ledger === null) return null;
+
+  // The pauser address is the second topic segment when present; fall back to
+  // the value field for completeness.
+  const pauser = event.topic[1] ?? String(event.value.pauser ?? "");
+
+  return { pauser: String(pauser), ledger };
+}
+
+export function parseUnpauseEvent(event: SorobanEvent): UnpauseEventData | null {
+  if (event.topic[0] !== TOPICS.unpaused) return null;
+  if (!isRecord(event.value)) return null;
+
+  const ledger = toNumber(event.value.ledger);
+  if (ledger === null) return null;
+
+  return { ledger };
+}
+
+export function subscribeToPauseEvents(
+  governorAddress: string,
+  callback: (event: SorobanEvent) => void,
+  opts: SubscriptionOptions
+): () => void {
+  return createTopicSubscription(governorAddress, TOPICS.paused, callback, opts);
+}
+
+export function subscribeToUnpauseEvents(
+  governorAddress: string,
+  callback: (event: SorobanEvent) => void,
+  opts: SubscriptionOptions
+): () => void {
+  return createTopicSubscription(governorAddress, TOPICS.unpaused, callback, opts);
 }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -45,6 +45,8 @@ export {
   subscribeToProposalExpired,
   subscribeToGovernorUpgraded,
   subscribeToConfigUpdated,
+  subscribeToPauseEvents,
+  subscribeToUnpauseEvents,
 } from "./events";
 export type {
   SorobanEvent,
@@ -58,6 +60,8 @@ export type {
   ProposalExpiredEventData,
   GovernorUpgradedEventData,
   ConfigUpdatedEventData,
+  PauseEventData,
+  UnpauseEventData,
 } from "./events";
 export {
   parseProposalCreatedEvent,
@@ -69,5 +73,7 @@ export {
   parseProposalExpiredEvent,
   parseGovernorUpgradedEvent,
   parseConfigUpdatedEvent,
+  parsePauseEvent,
+  parseUnpauseEvent,
 } from "./events";
 export * from "./types";


### PR DESCRIPTION
Fixes #230
Fixes #247

## What changed

### #230 — Postgres indexes for indexer query performance

Added `CREATE INDEX IF NOT EXISTS` statements to `initDb()` in `packages/indexer/src/db.ts`. All indexes are idempotent and safe to apply on existing databases.

| Index | Query it accelerates |
|---|---|
| `idx_proposals_created_at` on `proposals(created_at DESC)` | `GET /proposals` — ordered by `created_at DESC` |
| `idx_proposals_proposer` on `proposals(proposer)` | `GET /profile/:address` — proposals by proposer |
| `idx_votes_proposal_id` on `votes(proposal_id)` | `GET /proposals/:id/votes` — votes per proposal |
| `idx_votes_voter` on `votes(voter)` | `GET /profile/:address` — votes by voter |
| `idx_delegates_delegator` on `delegates(delegator)` | `GET /delegates` — latest delegation per delegator |
| `idx_delegates_ledger` on `delegates(ledger DESC)` | Latest-delegation queries ordered by ledger |
| `idx_delegates_new_delegatee` on `delegates(new_delegatee)` | `GET /delegates?top=10` — group-by delegatee |
| `idx_wrapper_deposits_account` on `wrapper_deposits(account)` | Deposit history per account |
| `idx_wrapper_withdrawals_account` on `wrapper_withdrawals(account)` | Withdrawal history per account |

### #247 — Governor contract pause/unpause events

**`contracts/governor/src/events.rs`**
- Added `PauseEvent { pauser: Address, ledger: u32 }` struct
- Added `UnpauseEvent { ledger: u32 }` struct
- Added `emit_paused(env, pauser)` — publishes with topic `["Paused", <pauser>]` for indexed filtering
- Added `emit_unpaused(env)` — publishes with topic `["Unpaused"]`

**`contracts/governor/src/lib.rs`**
- Replaced raw `env.events().publish((Symbol::new(&env, "ContractPaused"),), (caller, ...))` in `pause()` with `events::emit_paused(&env, &caller)`
- Replaced raw `env.events().publish((symbol_short!("unpaused"),), ...)` in `unpause()` with `events::emit_unpaused(&env)`

**`docs/events.md`**
- Added `Paused` and `Unpaused` event reference entries with field tables and topic format notes

**`sdk/src/events.ts`**
- Added `TOPICS.paused = "Paused"` and `TOPICS.unpaused = "Unpaused"`
- Added `PauseEventData` and `UnpauseEventData` interfaces
- Added `parsePauseEvent` and `parseUnpauseEvent` functions
- Added `subscribeToPauseEvents` and `subscribeToUnpauseEvents` subscription helpers

**`sdk/src/index.ts`**
- Re-exported all new functions and types

**`sdk/src/__tests__/events.test.ts`**
- Added test cases for `parsePauseEvent` (valid event and wrong-topic guard) and `parseUnpauseEvent` (valid event and wrong-topic guard)

## How to test

- **#230**: Start indexer against a fresh Postgres instance — `initDb()` creates all indexes; re-running is safe
- **#247**: `cd contracts/governor && cargo test` — existing snapshot tests should pass; new events appear in event stream when pause/unpause are called
- **SDK**: `cd sdk && pnpm test` — new parse tests should pass