### PR TITLE
feat: draft autosave, address labels, vote pagination, and proposal state docs

### DIFF
--- a/app/src/app/api/proposals/[id]/votes/route.ts
+++ b/app/src/app/api/proposals/[id]/votes/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:3001";
+
+interface Vote {
+  id: number;
+  proposal_id: number;
+  voter: string;
+  support: number;
+  weight: string;
+  created_at: string;
+}
+
+interface VotesResponse {
+  votes: Vote[];
+  total: number;
+  page: number;
+  pageSize: number;
+  hasMore: boolean;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const searchParams = request.nextUrl.searchParams;
+  const page = Number(searchParams.get("page") ?? 0);
+  const pageSize = Math.min(Number(searchParams.get("pageSize") ?? 20), 100);
+  const sort = searchParams.get("sort") ?? "newest";
+
+  try {
+    const offset = page * pageSize;
+    const orderBy = sort === "weight"
+      ? "weight DESC"
+      : sort === "address"
+        ? "voter ASC"
+        : "created_at DESC";
+
+    const [countRes, votesRes] = await Promise.all([
+      fetch(`${BACKEND_URL}/proposals/${id}/votes/count`),
+      fetch(
+        `${BACKEND_URL}/proposals/${id}/votes?offset=${offset}&limit=${pageSize}&order=${orderBy}`
+      ),
+    ]);
+
+    if (!countRes.ok || !votesRes.ok) {
+      return NextResponse.json(
+        { error: "Failed to fetch votes" },
+        { status: 500 }
+      );
+    }
+
+    const countData = await countRes.json();
+    const votesData = await votesRes.json();
+    const total = countData.count ?? 0;
+    const votes = votesData.votes ?? [];
+
+    return NextResponse.json({
+      votes,
+      total,
+      page,
+      pageSize,
+      hasMore: offset + pageSize < total,
+    } as VotesResponse);
+  } catch (error) {
+    console.error("Failed to fetch votes:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/src/app/proposal/[id]/page.tsx
+++ b/app/src/app/proposal/[id]/page.tsx
@@ -2,11 +2,12 @@
 
 import { useEffect, useMemo, useState, useCallback } from "react";
 import { VoteSupport, ProposalState, VotesClient, GovernorClient, VoteType, type GovernorSettings, type Network } from "@nebgov/sdk";
-import { AlertTriangle, Info, ExternalLink, Loader2 } from "lucide-react";
+import { AlertTriangle, Info, ExternalLink, Loader2, ChevronUp, ChevronDown } from "lucide-react";
 import { useWallet } from "../../../lib/wallet-context";
 import { DelegateModal } from "../../../components/DelegateModal";
 import { VotingModal } from "../../../components/VotingModal";
 import { fetchProposalMetadata, verifyMetadataHash } from "../../../lib/metadata";
+import { fetchProposalVotes, type ProposalVote } from "../../../lib/backend";
 import {
   BarChart,
   Bar,
@@ -59,6 +60,44 @@ export default function ProposalDetailPage({ params }: Props) {
   const [voteError, setVoteError] = useState<string | null>(null);
   const [votedSupport, setVotedSupport] = useState<VoteSupport | null>(null);
   const [voteType, setVoteType] = useState<VoteType>(VoteType.Simple);
+
+  // Votes pagination
+  const [votes, setVotes] = useState<ProposalVote[]>([]);
+  const [votesPage, setVotesPage] = useState(0);
+  const [votesLoading, setVotesLoading] = useState(false);
+  const [votesTotal, setVotesTotal] = useState(0);
+  const [votesHasMore, setVotesHasMore] = useState(false);
+  const [votesSort, setVotesSort] = useState<"newest" | "weight" | "address">("newest");
+
+  const loadVotes = useCallback(async (pageNum: number, append = false) => {
+    setVotesLoading(true);
+    try {
+      const result = await fetchProposalVotes(
+        params.id,
+        pageNum,
+        20,
+        votesSort
+      );
+      if (append) {
+        setVotes((prev) => [...prev, ...result.votes]);
+      } else {
+        setVotes(result.votes);
+      }
+      setVotesTotal(result.total);
+      setVotesHasMore(result.hasMore);
+    } catch (err) {
+      console.error("Failed to load votes:", err);
+    } finally {
+      setVotesLoading(false);
+    }
+  }, [params.id, votesSort]);
+
+  const loadMoreVotes = () => {
+    if (!votesLoading && votesHasMore) {
+      loadVotes(votesPage + 1, true);
+      setVotesPage((p) => p + 1);
+    }
+  };
 
   const { publicKey, isConnected, signTransaction } = useWallet();
   const { theme } = useTheme();
@@ -150,6 +189,10 @@ export default function ProposalDetailPage({ params }: Props) {
       refreshDelegation();
     }
   }, [isConnected, votesClient, publicKey]);
+
+  useEffect(() => {
+    loadVotes(0, false);
+  }, [loadVotes]);
 
   // Transform data for Recharts
   const chartData = useMemo(() => [
@@ -493,6 +536,81 @@ export default function ProposalDetailPage({ params }: Props) {
           </p>
         </div>
       )}
+
+      {/* Votes List with Pagination */}
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-6 mt-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-sm font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">
+            Votes
+          </h2>
+          <span className="text-xs text-gray-400">
+            Showing {votes.length} of {votesTotal} votes
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2 mb-4">
+          <span className="text-xs text-gray-500">Sort by:</span>
+          <button
+            onClick={() => { setVotesSort("newest"); setVotesPage(0); }}
+            className={`px-2 py-1 text-xs rounded ${votesSort === "newest" ? "bg-indigo-600 text-white" : "bg-gray-100 dark:bg-gray-700"}`}
+          >
+            Newest
+          </button>
+          <button
+            onClick={() => { setVotesSort("weight"); setVotesPage(0); }}
+            className={`px-2 py-1 text-xs rounded ${votesSort === "weight" ? "bg-indigo-600 text-white" : "bg-gray-100 dark:bg-gray-700"}`}
+          >
+            Weight
+          </button>
+          <button
+            onClick={() => { setVotesSort("address"); setVotesPage(0); }}
+            className={`px-2 py-1 text-xs rounded ${votesSort === "address" ? "bg-indigo-600 text-white" : "bg-gray-100 dark:bg-gray-700"}`}
+          >
+            Address
+          </button>
+        </div>
+
+        {votesLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="w-6 h-6 animate-spin text-gray-400" />
+          </div>
+        ) : votes.length === 0 ? (
+          <p className="text-gray-400 text-sm py-8 text-center">No votes yet</p>
+        ) : (
+          <ul className="space-y-2">
+            {votes.map((vote) => (
+              <li
+                key={vote.id}
+                className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-900 rounded-lg"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="font-mono text-sm">{vote.voter.slice(0, 6)}...{vote.voter.slice(-4)}</span>
+                  <span className={`text-xs px-2 py-0.5 rounded ${
+                    vote.support === 1 ? "bg-green-100 text-green-700" :
+                    vote.support === 2 ? "bg-red-100 text-red-700" :
+                    "bg-gray-200 text-gray-600"
+                  }`}>
+                    {vote.support === 1 ? "For" : vote.support === 2 ? "Against" : "Abstain"}
+                  </span>
+                </div>
+                <span className="text-sm font-mono text-gray-600 dark:text-gray-400">
+                  {(Number(vote.weight) / 10 ** 7).toLocaleString()} NEB
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {votesHasMore && (
+          <button
+            onClick={loadMoreVotes}
+            disabled={votesLoading}
+            className="w-full mt-4 py-2 text-sm text-indigo-600 hover:bg-indigo-50 dark:hover:bg-indigo-900/20 rounded-lg transition-colors disabled:opacity-50"
+          >
+            {votesLoading ? "Loading..." : "Load more"}
+          </button>
+        )}
+      </div>
 
       <DelegateModal
         isOpen={delegateModalOpen}

--- a/app/src/app/propose/page.tsx
+++ b/app/src/app/propose/page.tsx
@@ -31,6 +31,7 @@ const TITLE_MIN = 10;
 const TITLE_MAX = 100;
 const DESC_MIN = 20;
 const STORAGE_KEY = "nebgov_proposal_draft";
+const DRAFT_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
 
 const STEPS = [
   { id: 1, label: "Content" },
@@ -54,6 +55,8 @@ interface DraftState {
   descriptionHash: string;
   ipfsRef: string;
   actions: WizardAction[];
+  savedAt: number;
+  currentStep: number;
 }
 
 function newAction(): WizardAction {
@@ -131,7 +134,12 @@ function ProposeWizardInner() {
     descriptionHash: "",
     ipfsRef: "",
     actions: [],
+    savedAt: 0,
+    currentStep: 1,
   });
+  const [savedDraftExists, setSavedDraftExists] = useState(false);
+  const [savedDraftData, setSavedDraftData] = useState<DraftState | null>(null);
+  const [showRestoreBanner, setShowRestoreBanner] = useState(false);
 
   const [isHashing, setIsHashing] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
@@ -151,10 +159,18 @@ function ProposeWizardInner() {
 
   // Hydration / Persistence
   useEffect(() => {
-    const saved = sessionStorage.getItem(STORAGE_KEY);
+    const saved = localStorage.getItem(STORAGE_KEY);
     if (saved) {
       try {
-        setDraft(JSON.parse(saved));
+        const parsed = JSON.parse(saved) as DraftState;
+        const now = Date.now();
+        if (now - parsed.savedAt < DRAFT_EXPIRY_MS) {
+          setSavedDraftData(parsed);
+          setSavedDraftExists(true);
+          setShowRestoreBanner(true);
+        } else {
+          localStorage.removeItem(STORAGE_KEY);
+        }
       } catch (e) {
         console.error("Failed to load draft:", e);
       }
@@ -162,10 +178,42 @@ function ProposeWizardInner() {
     setHydrated(true);
   }, []);
 
+  const restoreDraft = useCallback(() => {
+    if (savedDraftData) {
+      setDraft(savedDraftData);
+      const q = new URLSearchParams(searchParams.toString());
+      q.set("step", String(savedDraftData.currentStep || 1));
+      if (savedDraftData.currentStep !== 4) q.delete("id");
+      router.push(`/propose?${q.toString()}`);
+      setShowRestoreBanner(false);
+    }
+  }, [savedDraftData, router, searchParams]);
+
+  const discardDraft = useCallback(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    setSavedDraftData(null);
+    setSavedDraftExists(false);
+    setShowRestoreBanner(false);
+    setDraft({
+      title: "",
+      description: "",
+      descriptionHash: "",
+      ipfsRef: "",
+      actions: [],
+      savedAt: 0,
+      currentStep: 1,
+    });
+  }, []);
+
   useEffect(() => {
     if (!hydrated) return;
-    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(draft));
-  }, [draft, hydrated]);
+    const draftWithTimestamp: DraftState = {
+      ...draft,
+      savedAt: Date.now(),
+      currentStep: step,
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(draftWithTimestamp));
+  }, [draft, hydrated, step]);
 
   // Auto-hash description when it changes
   useEffect(() => {
@@ -373,7 +421,8 @@ function ProposeWizardInner() {
         signTransaction,
       );
       sessionStorage.removeItem(STORAGE_KEY);
-      setDraft({ title: "", description: "", descriptionHash: "", ipfsRef: "", actions: [] });
+      localStorage.removeItem(STORAGE_KEY);
+      setDraft({ title: "", description: "", descriptionHash: "", ipfsRef: "", actions: [], savedAt: 0, currentStep: 1 });
       router.push(`/propose?step=4&id=${id.toString()}`);
     } catch (e: unknown) {
       setSubmitError(e instanceof Error ? e.message : "Submit failed");
@@ -442,6 +491,32 @@ function ProposeWizardInner() {
       <p className="text-gray-500 dark:text-gray-400 mb-8">
         Step-by-step flow with validation, previews, and on-chain simulation.
       </p>
+
+      {/* Restore Draft Banner */}
+      {showRestoreBanner && savedDraftData && (
+        <div className="mb-6 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl p-4 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <span className="text-amber-800 dark:text-amber-200 text-sm">
+              You have an unsaved draft from{" "}
+              {new Date(savedDraftData.savedAt).toLocaleDateString()}. Restore it?
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={restoreDraft}
+              className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors"
+            >
+              Restore
+            </button>
+            <button
+              onClick={discardDraft}
+              className="px-4 py-2 text-gray-600 dark:text-gray-300 text-sm font-medium hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
+            >
+              Discard
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Progress */}
       <ol className="flex items-center gap-2 mb-10 text-sm">

--- a/app/src/components/AddressDisplay.tsx
+++ b/app/src/components/AddressDisplay.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useMemo, useState, useRef, useEffect } from "react";
+import {
+  getAddressLabel,
+  setCustomLabel,
+  removeCustomLabel,
+  exportCustomLabels,
+  importCustomLabels,
+} from "../lib/address-labels";
+
+interface AddressDisplayProps {
+  address: string;
+  truncate?: boolean;
+  showFullOnHover?: boolean;
+  className?: string;
+}
+
+function truncateAddress(addr: string, chars = 6): string {
+  if (addr.length <= chars * 2) return addr;
+  return `${addr.slice(0, chars)}...${addr.slice(-chars)}`;
+}
+
+export function AddressDisplay({
+  address,
+  truncate = true,
+  showFullOnHover = true,
+  className = "",
+}: AddressDisplayProps) {
+  const label = getAddressLabel(address);
+  const displayAddress = truncate ? truncateAddress(address) : address;
+  const [showMenu, setShowMenu] = useState(false);
+  const [newLabel, setNewLabel] = useState("");
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setShowMenu(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleSaveLabel = () => {
+    if (newLabel.trim()) {
+      setCustomLabel(address, newLabel.trim());
+      setNewLabel("");
+    }
+    setShowMenu(false);
+  };
+
+  const handleRemoveLabel = () => {
+    removeCustomLabel(address);
+    setShowMenu(false);
+  };
+
+  const handleExport = () => {
+    const data = exportCustomLabels();
+    navigator.clipboard.writeText(data);
+    alert("Labels exported to clipboard");
+  };
+
+  const handleImport = () => {
+    const data = prompt("Paste exported labels JSON:");
+    if (data && importCustomLabels(data)) {
+      window.location.reload();
+    }
+  };
+
+  return (
+    <div className={`relative inline-block ${className}`} ref={menuRef}>
+      <div
+        className="cursor-context-menu"
+        onContextMenu={(e) => {
+          e.preventDefault();
+          setShowMenu(!showMenu);
+        }}
+      >
+        {label ? (
+          <span className="font-medium">
+            {label}{" "}
+            <span className="text-gray-400 dark:text-gray-500 font-mono text-sm">
+              ({displayAddress})
+            </span>
+          </span>
+        ) : (
+          <span className="font-mono text-sm">{displayAddress}</span>
+        )}
+      </div>
+
+      {showFullOnHover && !label && (
+        <div className="absolute z-50 hidden group-hover:block bottom-full left-0 mb-1 px-2 py-1 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded whitespace-nowrap">
+          {address}
+        </div>
+      )}
+
+      {showMenu && (
+        <div className="absolute z-50 right-0 mt-1 w-64 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg py-2">
+          {label ? (
+            <>
+              <button
+                onClick={() => {
+                  setNewLabel(label);
+                  setShowMenu(false);
+                }}
+                className="w-full px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700"
+              >
+                Edit label &quot;{label}&quot;
+              </button>
+              <button
+                onClick={handleRemoveLabel}
+                className="w-full px-4 py-2 text-left text-sm text-red-600 hover:bg-gray-100 dark:hover:bg-gray-700"
+              >
+                Remove label
+              </button>
+            </>
+          ) : (
+            <div className="px-4 py-2">
+              <input
+                type="text"
+                value={newLabel}
+                onChange={(e) => setNewLabel(e.target.value)}
+                placeholder="Enter label..."
+                className="w-full px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-900"
+                onKeyDown={(e) => e.key === "Enter" && handleSaveLabel()}
+              />
+              <button
+                onClick={handleSaveLabel}
+                disabled={!newLabel.trim()}
+                className="mt-2 w-full px-2 py-1 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:opacity-50"
+              >
+                Save Label
+              </button>
+            </div>
+          )}
+          <div className="border-t border-gray-200 dark:border-gray-700 mt-2 pt-2">
+            <button
+              onClick={handleExport}
+              className="w-full px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
+              Export labels
+            </button>
+            <button
+              onClick={handleImport}
+              className="w-full px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
+              Import labels
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/lib/address-labels.ts
+++ b/app/src/lib/address-labels.ts
@@ -1,0 +1,121 @@
+const LS_ADDRESS_LABELS = "nebgov_address_labels";
+
+export interface AddressLabel {
+  address: string;
+  label: string;
+  createdAt: number;
+}
+
+export interface AddressLabels {
+  envLabels: Record<string, string>;
+  customLabels: Record<string, string>;
+}
+
+function parseEnvLabels(): Record<string, string> {
+  const envVar = process.env.NEXT_PUBLIC_ADDRESS_LABELS;
+  if (!envVar) return {};
+
+  const labels: Record<string, string> = {};
+  const pairs = envVar.split(",");
+  for (const pair of pairs) {
+    const idx = pair.indexOf("=");
+    if (idx > 0) {
+      const addr = pair.substring(0, idx).trim();
+      const label = pair.substring(idx + 1).trim();
+      if (addr && label) {
+        labels[addr] = label;
+      }
+    }
+  }
+  return labels;
+}
+
+function getLabelMap(labels: AddressLabel[]): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const item of labels) {
+    map[item.address] = item.label;
+  }
+  return map;
+}
+
+export function getAllLabels(): AddressLabels {
+  return {
+    envLabels: parseEnvLabels(),
+    customLabels: getCustomLabels(),
+  };
+}
+
+export function getAddressLabel(address: string): string | null {
+  const { envLabels, customLabels } = getAllLabels();
+  return customLabels[address] ?? envLabels[address] ?? null;
+}
+
+export function getCustomLabels(): Record<string, string> {
+  if (typeof window === "undefined") return {};
+  try {
+    const stored = localStorage.getItem(LS_ADDRESS_LABELS);
+    if (!stored) return {};
+    const data = JSON.parse(stored) as AddressLabel[];
+    return getLabelMap(data);
+  } catch {
+    return {};
+  }
+}
+
+export function setCustomLabel(address: string, label: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    const stored = localStorage.getItem(LS_ADDRESS_LABELS);
+    const labels: AddressLabel[] = stored ? JSON.parse(stored) : [];
+    const existing = labels.findIndex((l) => l.address === address);
+    const newLabel: AddressLabel = {
+      address,
+      label,
+      createdAt: existing >= 0 ? labels[existing].createdAt : Date.now(),
+    };
+    if (existing >= 0) {
+      labels[existing] = newLabel;
+    } else {
+      labels.push(newLabel);
+    }
+    localStorage.setItem(LS_ADDRESS_LABELS, JSON.stringify(labels));
+  } catch {
+    // ignore
+  }
+}
+
+export function removeCustomLabel(address: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    const stored = localStorage.getItem(LS_ADDRESS_LABELS);
+    if (!stored) return;
+    const labels: AddressLabel[] = JSON.parse(stored);
+    const filtered = labels.filter((l) => l.address !== address);
+    localStorage.setItem(LS_ADDRESS_LABELS, JSON.stringify(filtered));
+  } catch {
+    // ignore
+  }
+}
+
+export function exportCustomLabels(): string {
+  const labels = getCustomLabels();
+  return JSON.stringify(labels, null, 2);
+}
+
+export function importCustomLabels(jsonString: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const imported = JSON.parse(jsonString);
+    const existing = getCustomLabels();
+    const merged = { ...existing, ...imported };
+    const labels: AddressLabel[] = Object.entries(merged).map(([address, label]) => ({
+      address,
+      label,
+      createdAt: Date.now(),
+    }));
+    localStorage.setItem(LS_ADDRESS_LABELS, JSON.stringify(labels));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/app/src/lib/backend.ts
+++ b/app/src/lib/backend.ts
@@ -47,3 +47,31 @@ export async function backendFetch<T>(
   return (await res.json()) as T;
 }
 
+export interface ProposalVote {
+  id: number;
+  proposal_id: number;
+  voter: string;
+  support: number;
+  weight: string;
+  created_at: string;
+}
+
+export interface VotesResponse {
+  votes: ProposalVote[];
+  total: number;
+  page: number;
+  pageSize: number;
+  hasMore: boolean;
+}
+
+export async function fetchProposalVotes(
+  proposalId: string,
+  page: number = 0,
+  pageSize: number = 20,
+  sort: "newest" | "weight" | "address" = "newest"
+): Promise<VotesResponse> {
+  return backendFetch<VotesResponse>(
+    `/api/proposals/${proposalId}/votes?page=${page}&pageSize=${pageSize}&sort=${sort}`
+  );
+}
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,6 +11,7 @@ NebGov is a modular on-chain governance framework for Soroban. It is composed of
 - [Treasury Flows](./treasury.md)
 - [Liquidity Contract](./liquidity.md)
 - [Contract Upgrade Mechanism](#contract-upgrade-mechanism)
+- [Proposal States](./proposal-states.md)
 - [Security Considerations](#security-considerations)
 - [Architecture Decision Records](#architecture-decision-records)
 

--- a/docs/proposal-states.md
+++ b/docs/proposal-states.md
@@ -1,0 +1,158 @@
+# Proposal State Machine
+
+The governor contract manages proposals through 8 distinct states, each with specific entry conditions, valid actions, and exit transitions.
+
+## State Diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending : propose()
+    Pending --> Active : start_ledger reached
+    Pending --> Cancelled : proposer cancels
+    Active --> Defeated : voting_period ends, quorum not met OR against >= for
+    Active --> Succeeded : voting_period ends, quorum met AND for > against
+    Active --> Cancelled : guardian cancels
+    Succeeded --> Queued : queue() called within grace period
+    Succeeded --> Expired : grace period elapsed without queue()
+    Queued --> Executed : execute() after timelock delay
+    Queued --> Cancelled : guardian vetoes within veto window
+```
+
+---
+
+## Pending
+
+**Entry Condition**: Proposal created via `propose()` but `voting_delay` ledgers haven't passed yet.
+
+**Valid Actions**:
+- `cancel()` — proposer can cancel at any time before voting starts
+- Update metadata URI
+
+**Exit Conditions**:
+- `start_ledger` reached → transitions to **Active**
+- Proposer calls `cancel()` → transitions to **Cancelled**
+
+**Storage Changes**: None (proposal just created)
+
+---
+
+## Active
+
+**Entry Condition**: `start_ledger` reached and voting period has begun.
+
+**Valid Actions**:
+- `cast_vote()` — any token holder with voting power
+- `queue()` — can only be called after grace period if proposal succeeded
+- `cancel()` — guardian can cancel during active voting
+
+**Exit Conditions**:
+- Voting period ends, quorum **not met** OR `against >= for` → **Defeated**
+- Voting period ends, quorum **met** AND `for > against` → **Succeeded**
+- Guardian calls `cancel()` → **Cancelled**
+
+**Storage Changes**:
+- `voted[address]` — vote records stored
+- `votes_for`, `votes_against`, `votes_abstain` — accumulate
+
+---
+
+## Defeated
+
+**Entry Condition**: Voting period ended without reaching quorum OR majority against.
+
+**Valid Actions**: None (read-only)
+
+**Exit Conditions**: None (terminal state)
+
+**Storage Changes**: None
+
+---
+
+## Succeeded
+
+**Entry Condition**: Voting period ended with quorum met AND `for > against`.
+
+**Valid Actions**:
+- `queue()` — anyone can queue (must call within grace period)
+- `cancel()` — guardian can still cancel before execution
+
+**Exit Conditions**:
+- `queue()` called within grace period → **Queued**
+- Grace period elapsed without `queue()` → **Expired**
+
+**Storage Changes**: `succeeded = true`
+
+---
+
+## Queued
+
+**Entry Condition**: `queue()` called within grace period after success.
+
+**Valid Actions**:
+- `execute()` — can only execute after timelock delay passes
+- `cancel()` — guardian can veto within veto window
+
+**Exit Conditions**:
+- `execute()` after timelock delay → **Executed**
+- Guardian vetoes within veto window → **Cancelled**
+
+**Storage Changes**: `queued = true`
+
+---
+
+## Executed
+
+**Entry Condition**: `execute()` called after timelock delay.
+
+**Valid Actions**: None (terminal state)
+
+**Exit Conditions**: None
+
+**Storage Changes**: `executed = true`, on-chain actions dispatched to target contracts
+
+---
+
+## Cancelled
+
+**Entry Condition**: Cancelled by proposer, guardian, or veto.
+
+**Valid Actions**: None (terminal state)
+
+**Exit Conditions**: None
+
+**Storage Changes**: `cancelled = true`
+
+---
+
+## Expired
+
+**Entry Condition**: Grace period elapsed without `queue()` being called.
+
+**Valid Actions**: None (terminal state)
+
+**Exit Conditions**: None
+
+**Storage Changes**: None
+
+---
+
+## State Summary Table
+
+| State | Entry Action | Exit Actions | Terminal? |
+|-------|------------|------------|----------|
+| Pending | propose() | vote start / cancel | No |
+| Active | start_ledger | defeat / succeed / cancel | No |
+| Defeated | voting result | — | Yes |
+| Succeeded | voting result | queue / expire | No |
+| Queued | queue() | execute / cancel | No |
+| Executed | execute() | — | Yes |
+| Cancelled | cancel() | — | Yes |
+| Expired | timeout | — | Yes |
+
+---
+
+## Related
+
+- Governor contract: `contracts/governor/src/lib.rs`
+- State function: `state()` returns current `ProposalState`
+- [Architecture](./architecture.md)


### PR DESCRIPTION
This PR implements multiple frontend and docs improvements addressing issues #292, #293, #294, and #309:

## Changes

### Issue #294: Proposal Draft Autosave
- Drafts now persist in localStorage (not sessionStorage)
- Shows restoration banner when draft exists on /propose navigation
- Draft includes all wizard state (title, description, actions, current step)
- Drafts older than 7 days are automatically discarded
- Draft cleared after successful submission

### Issue #293: Address Labels System  
- New AddressDisplay component for human-readable names
- Env-var labels via NEXT_PUBLIC_ADDRESS_LABELS
- Custom labels stored in localStorage
- Context menu for add/edit/remove/export/import labels

### Issue #292: Vote List Pagination
- Paginated votes on proposal detail page
- Default page size: 20 votes
- Load more button to append votes
- Sort by: newest, highest weight, or address

### Issue #309: Proposal State Documentation
- New docs/proposal-states.md with Mermaid state diagram
- All 8 proposal states documented with entry/exit conditions
- architecture.md links to new diagram

Closes #292
Closes #293
Closes #294
Closes #309