### PR TITLE
feat(indexer): add ConfigUpdated and GovernorUpgraded event indexing

### DIFF
--- a/app/src/app/analytics/page.tsx
+++ b/app/src/app/analytics/page.tsx
@@ -69,6 +69,25 @@ export default function AnalyticsPage() {
           <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Analytics</h1>
           <p className="text-gray-500 dark:text-gray-400 mt-1">Participation and voting trends.</p>
         </div>
+        <div className="flex gap-3">
+          <a
+            href="/api/upgrade-history"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            Upgrade History
+          </a>
+          <span className="text-gray-400">|</span>
+          <a
+            href="/api/config-history"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            Config History
+          </a>
+        </div>
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">

--- a/packages/indexer/package-lock.json
+++ b/packages/indexer/package-lock.json
@@ -8,10 +8,13 @@
       "name": "@nebgov/indexer",
       "version": "0.1.0",
       "dependencies": {
+        "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@stellar/stellar-sdk": "^12.0.0",
         "dotenv": "^16.0.0",
         "express": "^4.18.0",
-        "pg": "^8.11.0"
+        "pg": "^8.11.0",
+        "swagger-ui-express": "^5.0.1",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/express": "^4.17.0",
@@ -19,11 +22,24 @@
         "@types/node": "^20.0.0",
         "@types/pg": "^8.10.0",
         "@types/supertest": "^2.0.12",
+        "@types/swagger-ui-express": "^4.1.8",
         "jest": "^29.0.0",
         "supertest": "^6.3.3",
         "ts-jest": "^29.0.0",
         "ts-node": "^10.9.0",
         "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@asteasolutions/zod-to-openapi": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-8.5.0.tgz",
+      "integrity": "sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi3-ts": "^4.1.2"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -988,6 +1004,13 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -1346,6 +1369,17 @@
       "license": "MIT",
       "dependencies": {
         "@types/superagent": "*"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@types/yargs": {
@@ -4333,6 +4367,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi3-ts": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.5.0.tgz",
+      "integrity": "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -5355,6 +5398,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.4.tgz",
+      "integrity": "sha512-0AADFFQNJzExEN49SrD/34Nn9cxNxVLiydYl2MBwSZFPVXNkVwC/EFAjoezGGqE8oDegiDC+p47t8lKObCinMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -5838,6 +5905,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -5888,6 +5970,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/packages/indexer/src/__tests__/governor-events.int.test.ts
+++ b/packages/indexer/src/__tests__/governor-events.int.test.ts
@@ -1,0 +1,191 @@
+import { SorobanRpc, nativeToScVal } from "@stellar/stellar-sdk";
+import { initDb, pool } from "../db";
+import { processEvents } from "../events";
+
+class FakeServer {
+  constructor(private events: SorobanRpc.Api.EventResponse[]) {}
+  async getEvents() {
+    return { events: this.events };
+  }
+}
+
+function makeEvent(params: {
+  contractId: string;
+  ledger: number;
+  type: string;
+  topicArgs?: any[];
+  value: unknown;
+}): SorobanRpc.Api.EventResponse {
+  const topic = [
+    nativeToScVal(params.type, { type: "symbol" }),
+    ...(params.topicArgs ?? []).map((a) => nativeToScVal(a, { type: "symbol" })),
+  ];
+  const value = nativeToScVal(params.value);
+  return {
+    type: "contract",
+    ledger: params.ledger,
+    contractId: params.contractId as any,
+    topic,
+    value,
+  } as any;
+}
+
+describe("governor event indexing (integration)", () => {
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) {
+    it.skip("DATABASE_URL not set", () => undefined);
+    return;
+  }
+
+  const GOVERNOR = "CGOVERNORTESTADDRESS00000000000000000000000000000000000000";
+
+  beforeAll(async () => {
+    await initDb();
+    await pool.query("DELETE FROM config_updates");
+    await pool.query("DELETE FROM governor_upgrades");
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("indexes ConfigUpdated event into config_updates", async () => {
+    const configUpdated = makeEvent({
+      contractId: GOVERNOR,
+      ledger: 200,
+      type: "ConfigUpdated",
+      value: {
+        old_settings: {
+          voting_delay: 1,
+          voting_period: 2,
+          quorum_numerator: 30,
+          proposal_threshold: 1000n,
+          guardian: "GOLDGUARDIAN1111111111111111111111111111",
+          proposal_grace_period: 3,
+        },
+        new_settings: {
+          voting_delay: 2,
+          voting_period: 3,
+          quorum_numerator: 35,
+          proposal_threshold: 2000n,
+          guardian: "GNEWGUARDIAN111111111111111111111111111",
+          proposal_grace_period: 4,
+        },
+      },
+    });
+
+    const server = new FakeServer([configUpdated]) as unknown as SorobanRpc.Server;
+    const latest = await processEvents(
+      server,
+      { rpcUrl: "http://fake", governorAddress: GOVERNOR, pollIntervalMs: 1 },
+      1,
+    );
+
+    expect(latest).toBe(200);
+
+    const rows = await pool.query(
+      "SELECT ledger, new_settings FROM config_updates ORDER BY id DESC LIMIT 1",
+    );
+    expect(rows.rows.length).toBe(1);
+    expect(rows.rows[0].ledger).toBe(200);
+    const settings = rows.rows[0].new_settings;
+    expect(settings.voting_delay).toBe(2);
+    expect(settings.voting_period).toBe(3);
+    expect(settings.quorum_numerator).toBe(35);
+  });
+
+  it("indexes GovernorUpgraded event into governor_upgrades", async () => {
+    const newHashBytes = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) {
+      newHashBytes[i] = i;
+    }
+
+    const upgraded = makeEvent({
+      contractId: GOVERNOR,
+      ledger: 201,
+      type: "GovernorUpgraded",
+      value: {
+        old_hash: new Uint8Array([0, 1, 2]),
+        new_hash: newHashBytes,
+      },
+    });
+
+    const server = new FakeServer([upgraded]) as unknown as SorobanRpc.Server;
+    const latest = await processEvents(
+      server,
+      { rpcUrl: "http://fake", governorAddress: GOVERNOR, pollIntervalMs: 1 },
+      1,
+    );
+
+    expect(latest).toBe(201);
+
+    const rows = await pool.query(
+      "SELECT ledger, new_wasm_hash FROM governor_upgrades ORDER BY id DESC LIMIT 1",
+    );
+    expect(rows.rows.length).toBe(1);
+    expect(rows.rows[0].ledger).toBe(201);
+    expect(rows.rows[0].new_wasm_hash).toBe(
+      "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+    );
+  });
+
+  it("indexes legacy config_updated short-form event", async () => {
+    const configUpdatedLegacy = makeEvent({
+      contractId: GOVERNOR,
+      ledger: 202,
+      type: "config_updated",
+      topicArgs: [],
+      value: {
+        new_settings: {
+          voting_delay: 3,
+          voting_period: 4,
+          quorum_numerator: 40,
+          proposal_threshold: 3000n,
+          guardian: "GLEGACYGUARDIAN1111111111111111111111111",
+          proposal_grace_period: 5,
+        },
+      },
+    });
+
+    const server = new FakeServer([configUpdatedLegacy]) as unknown as SorobanRpc.Server;
+    const latest = await processEvents(
+      server,
+      { rpcUrl: "http://fake", governorAddress: GOVERNOR, pollIntervalMs: 1 },
+      1,
+    );
+
+    expect(latest).toBe(202);
+
+    const rows = await pool.query(
+      "SELECT new_settings FROM config_updates WHERE ledger = 202 ORDER BY id DESC LIMIT 1",
+    );
+    expect(rows.rows.length).toBe(1);
+    expect(rows.rows[0].new_settings.voting_delay).toBe(3);
+  });
+
+  it("indexes legacy upgraded short-form event", async () => {
+    const upgradedLegacy = makeEvent({
+      contractId: GOVERNOR,
+      ledger: 203,
+      type: "upgraded",
+      value: {
+        new_hash: new Uint8Array([255, 254, 253]),
+      },
+    });
+
+    const server = new FakeServer([upgradedLegacy]) as unknown as SorobanRpc.Server;
+    const latest = await processEvents(
+      server,
+      { rpcUrl: "http://fake", governorAddress: GOVERNOR, pollIntervalMs: 1 },
+      1,
+    );
+
+    expect(latest).toBe(203);
+
+    const rows = await pool.query(
+      "SELECT new_wasm_hash FROM governor_upgrades WHERE ledger = 203 ORDER BY id DESC LIMIT 1",
+    );
+    expect(rows.rows.length).toBe(1);
+    expect(rows.rows[0].new_wasm_hash).toBe("fffefdj");
+  });
+});

--- a/packages/indexer/src/api.ts
+++ b/packages/indexer/src/api.ts
@@ -314,5 +314,47 @@ export function createApp(server: SorobanRpc.Server): express.Application {
     },
   );
 
+  // GET /config-history?limit&offset — paginated list of config updates
+  app.get(
+    "/config-history",
+    async (req: Request, res: Response): Promise<void> => {
+      const limit = Math.min(Number(req.query.limit ?? 20), 100);
+      const offset = Number(req.query.offset ?? 0);
+      try {
+        const result = await pool.query(
+          `SELECT * FROM config_updates ORDER BY ledger DESC, id DESC LIMIT $1 OFFSET $2`,
+          [limit, offset],
+        );
+        res.json({
+          data: result.rows,
+          pagination: { limit, offset, hasMore: result.rows.length === limit },
+        });
+      } catch {
+        res.status(500).json({ error: "Internal server error" });
+      }
+    },
+  );
+
+  // GET /upgrade-history?limit&offset — paginated list of governor upgrades
+  app.get(
+    "/upgrade-history",
+    async (req: Request, res: Response): Promise<void> => {
+      const limit = Math.min(Number(req.query.limit ?? 20), 100);
+      const offset = Number(req.query.offset ?? 0);
+      try {
+        const result = await pool.query(
+          `SELECT * FROM governor_upgrades ORDER BY ledger DESC, id DESC LIMIT $1 OFFSET $2`,
+          [limit, offset],
+        );
+        res.json({
+          data: result.rows,
+          pagination: { limit, offset, hasMore: result.rows.length === limit },
+        });
+      } catch {
+        res.status(500).json({ error: "Internal server error" });
+      }
+    },
+  );
+
   return app;
 }

--- a/packages/indexer/src/db.ts
+++ b/packages/indexer/src/db.ts
@@ -93,5 +93,22 @@ export async function initDb(): Promise<void> {
 
     CREATE INDEX IF NOT EXISTS idx_wrapper_deposits_account ON wrapper_deposits(account);
     CREATE INDEX IF NOT EXISTS idx_wrapper_withdrawals_account ON wrapper_withdrawals(account);
+
+    CREATE TABLE IF NOT EXISTS config_updates (
+      id SERIAL PRIMARY KEY,
+      ledger INT NOT NULL,
+      new_settings JSONB NOT NULL,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS governor_upgrades (
+      id SERIAL PRIMARY KEY,
+      ledger INT NOT NULL,
+      new_wasm_hash TEXT NOT NULL,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_config_updates_ledger ON config_updates(ledger DESC);
+    CREATE INDEX IF NOT EXISTS idx_governor_upgrades_ledger ON governor_upgrades(ledger DESC);
   `);
 }

--- a/packages/indexer/src/events.ts
+++ b/packages/indexer/src/events.ts
@@ -108,6 +108,14 @@ export async function processEvents(
             case "delegate":
               await handleDelegateChanged(event, topics);
               break;
+            case "config_updated":
+            case "ConfigUpdated":
+              await handleConfigUpdated(event, topics);
+              break;
+            case "upgraded":
+            case "GovernorUpgraded":
+              await handleGovernorUpgraded(event, topics);
+              break;
             default:
               break;
           }
@@ -272,5 +280,119 @@ async function handleTreasuryBatchTransfer(
      VALUES ($1, $2, $3, $4, $5)
      ON CONFLICT DO NOTHING`,
     [opHash, token, recipientCount, totalAmount, event.ledger],
+  );
+}
+
+interface GovernorSettings {
+  voting_delay: number;
+  voting_period: number;
+  quorum_numerator: number;
+  proposal_threshold: bigint;
+  guardian: string;
+  voteType: number;
+  proposal_grace_period: number;
+  use_dynamic_quorum?: boolean;
+  reflector_oracle?: string | null;
+  min_quorum_usd?: bigint;
+  max_calldata_size?: number;
+  proposal_cooldown?: number;
+  max_proposals_per_period?: number;
+  proposal_period_duration?: number;
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === "number") return value;
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "string" && value.length > 0) {
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
+}
+
+function toGovernorSettings(value: unknown): GovernorSettings | null {
+  if (!value || typeof value !== "object") return null;
+
+  const obj = value as Record<string, unknown>;
+  const votingDelay = toNumber(obj.voting_delay);
+  const votingPeriod = toNumber(obj.voting_period);
+  const quorumNumerator = toNumber(obj.quorum_numerator);
+  const proposalThreshold =
+    typeof obj.proposal_threshold === "bigint"
+      ? Number(obj.proposal_threshold)
+      : obj.proposal_threshold
+      ? Number(obj.proposal_threshold)
+      : null;
+  const proposalGracePeriod = toNumber(obj.proposal_grace_period);
+
+  if (
+    votingDelay === null ||
+    votingPeriod === null ||
+    quorumNumerator === null ||
+    proposalThreshold === null ||
+    proposalGracePeriod === null
+  ) {
+    return null;
+  }
+
+  return {
+    voting_delay: votingDelay,
+    voting_period: votingPeriod,
+    quorum_numerator: quorumNumerator,
+    proposal_threshold: BigInt(proposalThreshold),
+    guardian: String(obj.guardian ?? ""),
+    voteType: 0,
+    proposal_grace_period: proposalGracePeriod,
+    use_dynamic_quorum: Boolean(obj.use_dynamic_quorum),
+    reflector_oracle:
+      obj.reflector_oracle === undefined || obj.reflector_oracle === null
+        ? null
+        : String(obj.reflector_oracle),
+    min_quorum_usd: obj.min_quorum_usd
+      ? BigInt(Number(obj.min_quorum_usd))
+      : 0n,
+    max_calldata_size: toNumber(obj.max_calldata_size) ?? 10000,
+    proposal_cooldown: toNumber(obj.proposal_cooldown) ?? 100,
+    max_proposals_per_period: toNumber(obj.max_proposals_per_period) ?? 5,
+    proposal_period_duration:
+      toNumber(obj.proposal_period_duration) ?? 10000,
+  };
+}
+
+async function handleConfigUpdated(
+  event: SorobanRpc.Api.EventResponse,
+  topics: unknown[],
+): Promise<void> {
+  const data = scValToNative(event.value) as Record<string, unknown>;
+  const newSettings = toGovernorSettings(data.new_settings);
+
+  if (!newSettings) {
+    console.error("Failed to parse new_settings from ConfigUpdated event");
+    return;
+  }
+
+  await pool.query(
+    `INSERT INTO config_updates (ledger, new_settings)
+     VALUES ($1, $2)`,
+    [event.ledger, JSON.stringify(newSettings)],
+  );
+}
+
+async function handleGovernorUpgraded(
+  event: SorobanRpc.Api.EventResponse,
+  topics: unknown[],
+): Promise<void> {
+  const data = scValToNative(event.value) as Record<string, unknown>;
+  const newHash = data.new_hash;
+
+  const hashStr =
+    newHash instanceof Uint8Array
+      ? Buffer.from(newHash).toString("hex")
+      : String(newHash ?? "");
+
+  await pool.query(
+    `INSERT INTO governor_upgrades (ledger, new_wasm_hash)
+     VALUES ($1, $2)`,
+    [event.ledger, hashStr],
   );
 }


### PR DESCRIPTION
Closes #300

---

DB Schema:
- Add config_updates table (id, ledger, new_settings JSONB, created_at)
- Add governor_upgrades table (id, ledger, new_wasm_hash, created_at)
- Add indexes on ledger DESC for efficient pagination

Event Processing:
- Add toGovernorSettings() helper to parse GovernorSettings XDR → JSON
- Add handleConfigUpdated() - parses new_settings from event data
- Add handleGovernorUpgraded() - extracts new_wasm_hash from event data
- Handle both legacy (config_updated, upgraded) and long-form topics (ConfigUpdated, GovernorUpgraded)

API Endpoints:
- GET /config-history?limit=20&offset=0 - paginated config updates, newest first
- GET /upgrade-history?limit=20&offset=0 - paginated governor upgrades, newest first

Tests:
- Add governor-events.int.test.ts with 4 test cases
- Tests for ConfigUpdated, GovernorUpgraded, and legacy short-form topics

Analytics Page:
- Add Upgrade History and Config History links in analytics header