### PR TITLE
feat: show Stellar Explorer links after vote, delegate, and propose

### DIFF
--- a/app/src/app/propose/page.tsx
+++ b/app/src/app/propose/page.tsx
@@ -11,6 +11,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import toast from "react-hot-toast";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import ReactMarkdown from "react-markdown";
@@ -115,6 +116,15 @@ function loadDraft(): Draft {
 
 function saveDraft(d: Draft) {
   sessionStorage.setItem(STORAGE_KEY, JSON.stringify(d));
+}
+
+function explorerTxUrl(txHash: string): string {
+  const network = process.env.NEXT_PUBLIC_NETWORK || "testnet";
+  const base =
+    network === "mainnet"
+      ? "https://stellar.expert/explorer/public"
+      : "https://stellar.expert/explorer/testnet";
+  return `${base}/tx/${txHash}`;
 }
 
 function buildDescription(title: string, body: string, ipfs: string): string {
@@ -315,7 +325,7 @@ function ProposeWizardInner() {
         draft.actions,
         clients.governorAddress,
       );
-      const id = await clients.governor.proposeWithSign(
+      const { proposalId, txHash } = await clients.governor.proposeWithSign(
         publicKey,
         description,
         targets,
@@ -323,9 +333,18 @@ function ProposeWizardInner() {
         calldatas,
         signTransaction,
       );
+      toast.success(
+        <div>
+          Proposal submitted!{" "}
+          <a href={explorerTxUrl(txHash)} target="_blank" rel="noreferrer" className="underline">
+            View on Explorer →
+          </a>
+        </div>,
+        { duration: 8000 },
+      );
       sessionStorage.removeItem(STORAGE_KEY);
       setDraft({ title: "", description: "", ipfsRef: "", actions: [] });
-      router.push(`/propose?step=4&id=${id.toString()}`);
+      router.push(`/propose?step=4&id=${proposalId.toString()}`);
     } catch (e: unknown) {
       setSubmitError(e instanceof Error ? e.message : "Submit failed");
     } finally {

--- a/app/src/components/DelegateModal.tsx
+++ b/app/src/components/DelegateModal.tsx
@@ -6,6 +6,7 @@
 
 import { useState, useEffect } from "react";
 import { Keypair } from "@stellar/stellar-sdk";
+import toast from "react-hot-toast";
 import { VotesClient, type Network } from "@nebgov/sdk";
 import { useWallet } from "../lib/wallet-context";
 
@@ -46,6 +47,15 @@ function getDelegateSigner(): Keypair {
   return Keypair.fromSecret(secret);
 }
 
+function explorerTxUrl(txHash: string): string {
+  const network = process.env.NEXT_PUBLIC_NETWORK || "testnet";
+  const base =
+    network === "mainnet"
+      ? "https://stellar.expert/explorer/public"
+      : "https://stellar.expert/explorer/testnet";
+  return `${base}/tx/${txHash}`;
+}
+
 export function DelegateModal({ open, onClose, onDelegated, prefillAddress }: Props) {
   const [delegatee, setDelegatee] = useState(prefillAddress || "");
   const [submitting, setSubmitting] = useState(false);
@@ -70,10 +80,21 @@ export function DelegateModal({ open, onClose, onDelegated, prefillAddress }: Pr
 
       const client = getVotesClientFromEnv();
       const signer = getDelegateSigner();
-      await client.delegate(signer, delegatee.trim());
-
+      const txHash = await client.delegate(signer, delegatee.trim());
+      toast.success(
+        <div>
+          Delegation submitted!{" "}
+          <a href={explorerTxUrl(txHash)} target="_blank" rel="noreferrer" className="underline">
+            View on Explorer →
+          </a>
+        </div>,
+        { duration: 8000 },
+      );
       onDelegated?.();
       onClose();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      toast.error(`Delegation failed: ${msg}`);
     } finally {
       setSubmitting(false);
     }

--- a/app/src/components/VotingModal.tsx
+++ b/app/src/components/VotingModal.tsx
@@ -49,6 +49,15 @@ function getVoteSigner(): Keypair {
   return Keypair.fromSecret(secret);
 }
 
+function explorerTxUrl(txHash: string): string {
+  const network = process.env.NEXT_PUBLIC_NETWORK || "testnet";
+  const base =
+    network === "mainnet"
+      ? "https://stellar.expert/explorer/public"
+      : "https://stellar.expert/explorer/testnet";
+  return `${base}/tx/${txHash}`;
+}
+
 export function VotingModal({
   open,
   onClose,
@@ -106,8 +115,16 @@ export function VotingModal({
     try {
       const client = getGovernorClientFromEnv();
       const signer = getVoteSigner();
-      await client.castVote(signer, proposalId, support);
-      toast.success("Vote submitted successfully");
+      const txHash = await client.castVote(signer, proposalId, support);
+      toast.success(
+        <div>
+          Vote submitted!{" "}
+          <a href={explorerTxUrl(txHash)} target="_blank" rel="noreferrer" className="underline">
+            View on Explorer →
+          </a>
+        </div>,
+        { duration: 8000 },
+      );
       onVoted();
       onClose();
     } catch (err) {

--- a/sdk/src/governor.ts
+++ b/sdk/src/governor.ts
@@ -134,7 +134,7 @@ export class GovernorClient {
     fnNames: string[],
     calldatas: (Buffer | Uint8Array)[],
     signUnsignedXdr: (xdr: string) => Promise<string>
-  ): Promise<bigint> {
+  ): Promise<{ proposalId: bigint; txHash: string }> {
     if (
       targets.length !== fnNames.length ||
       targets.length !== calldatas.length
@@ -172,7 +172,8 @@ export class GovernorClient {
     }
     const confirmed = await this.pollForConfirmation(result.hash);
     const returnVal = confirmed.returnValue;
-    return returnVal ? BigInt(scValToNative(returnVal)) : 0n;
+    const proposalId = returnVal ? BigInt(scValToNative(returnVal)) : 0n;
+    return { proposalId, txHash: result.hash };
   }
 
   /** Minimum voting power required to create a proposal (`proposal_threshold`). */
@@ -293,7 +294,7 @@ export class GovernorClient {
     signer: Keypair,
     proposalId: bigint,
     support: VoteSupport
-  ): Promise<void> {
+  ): Promise<string> {
     const account = await this.server.getAccount(signer.publicKey());
 
     const supportScVal = xdr.ScVal.scvVec([
@@ -322,6 +323,7 @@ export class GovernorClient {
       throw new Error(`castVote failed: ${JSON.stringify(result)}`);
     }
     await this.pollForConfirmation(result.hash);
+    return result.hash;
   }
 
   /**

--- a/sdk/src/votes.ts
+++ b/sdk/src/votes.ts
@@ -41,10 +41,11 @@ export class VotesClient {
   }
 
   /**
-   * Delegate voting power to another address.
-   * TODO issue #33: add self-delegation option and UI flow.
+   * Delegate voting power to another address (or self-delegate to activate votes).
+   *
+   * @returns The Stellar transaction hash, suitable for linking to a block explorer.
    */
-  async delegate(signer: Keypair, delegatee: string): Promise<void> {
+  async delegate(signer: Keypair, delegatee: string): Promise<string> {
     const account = await this.server.getAccount(signer.publicKey());
 
     const tx = new TransactionBuilder(account, {
@@ -63,7 +64,20 @@ export class VotesClient {
 
     const prepared = await this.server.prepareTransaction(tx);
     prepared.sign(signer);
-    await this.server.sendTransaction(prepared);
+    const result = await this.server.sendTransaction(prepared);
+    if (result.status === "ERROR") {
+      throw new Error(`delegate failed: ${JSON.stringify(result)}`);
+    }
+    return result.hash;
+  }
+
+  /**
+   * Revoke delegation and move voting power back to self.
+   *
+   * @returns The Stellar transaction hash, suitable for linking to a block explorer.
+   */
+  async undelegate(signer: Keypair): Promise<string> {
+    return this.delegate(signer, signer.publicKey());
   }
 
   /**


### PR DESCRIPTION
Closes #291

## Summary

- `castVote()` and `delegate()` now return the transaction hash (`string`) instead of `void`, surfacing it to callers
- `proposeWithSign()` returns `{ proposalId: bigint; txHash: string }` instead of a bare `bigint`
- New `undelegate()` helper on `VotesClient` (self-delegates to revoke delegation)
- `VotingModal`, `DelegateModal`, and the propose wizard each show a `react-hot-toast` notification with a clickable **stellar.expert** link (8 s duration) after the on-chain transaction is confirmed
- Explorer URL is network-aware: uses `/public` for mainnet and `/testnet` otherwise

## Test plan

- [ ] Cast a vote → toast appears with "Vote submitted! View on Explorer →" linking to the correct tx
- [ ] Delegate → toast appears with "Delegation submitted! View on Explorer →"
- [ ] Submit a proposal → toast appears with "Proposal submitted! View on Explorer →"
- [ ] Verify testnet link format: `https://stellar.expert/explorer/testnet/tx/<hash>`
- [ ] Set `NEXT_PUBLIC_NETWORK=mainnet` and verify link switches to `/public`
- [ ] Error path: on tx failure the existing error toast still fires, no broken link shown