### PR TITLE
feat: implement treasury reads, admin competitions routes, CLI package, and vote reasons

### DIFF
--- a/app/src/app/proposal/[id]/ProposalDetailClient.tsx
+++ b/app/src/app/proposal/[id]/ProposalDetailClient.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState, useCallback } from "react";
 import { VoteSupport, ProposalState, VotesClient, GovernorClient, VoteType, type GovernorSettings, type Network } from "@nebgov/sdk";
-import { AlertTriangle, Info, ExternalLink, Loader2, ChevronUp, ChevronDown } from "lucide-react";
+import { AlertTriangle, Info, ExternalLink, Loader2, MessageSquare } from "lucide-react";
 import { useWallet } from "../../../lib/wallet-context";
 import { DelegateModal } from "../../../components/DelegateModal";
 import { VotingModal } from "../../../components/VotingModal";
@@ -36,6 +36,11 @@ function supportLabel(support: number): string {
   if (support === VoteSupport.For) return "For";
   if (support === VoteSupport.Against) return "Against";
   return "Abstain";
+}
+
+function reasonPreview(reason: string, expanded: boolean): string {
+  if (expanded || reason.length <= 200) return reason;
+  return `${reason.slice(0, 200)}...`;
 }
 
 // Initial state for proposal to avoid undefined errors during loading
@@ -83,6 +88,7 @@ export default function ProposalDetailClient({ params }: Props) {
   const [votesHasMore, setVotesHasMore] = useState(false);
   const [votesSort, setVotesSort] = useState<"newest" | "weight" | "address">("newest");
   const [exportingCsv, setExportingCsv] = useState(false);
+  const [expandedReasons, setExpandedReasons] = useState<Record<number, boolean>>({});
 
   const loadVotes = useCallback(async (pageNum: number, append = false) => {
     setVotesLoading(true);
@@ -674,26 +680,74 @@ export default function ProposalDetailClient({ params }: Props) {
           <p className="text-gray-400 text-sm py-8 text-center">No votes yet</p>
         ) : (
           <ul className="space-y-2">
-            {votes.map((vote) => (
+            {votes.map((vote) => {
+              const reason = vote.reason?.trim() ?? "";
+              const hasReason = reason.length > 0;
+              const expanded = Boolean(expandedReasons[vote.id]);
+              const reasonText = reasonPreview(reason, expanded);
+              return (
               <li
                 key={vote.id}
-                className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-900 rounded-lg"
+                className="group p-3 bg-gray-50 dark:bg-gray-900 rounded-lg"
               >
-                <div className="flex items-center gap-3">
-                  <span className="font-mono text-sm">{vote.voter.slice(0, 6)}...{vote.voter.slice(-4)}</span>
-                  <span className={`text-xs px-2 py-0.5 rounded ${
-                    vote.support === VoteSupport.For ? "bg-green-100 text-green-700" :
-                    vote.support === VoteSupport.Against ? "bg-red-100 text-red-700" :
-                    "bg-gray-200 text-gray-600"
-                  }`}>
-                    {supportLabel(vote.support)}
+                <div className="flex items-center justify-between gap-4">
+                  <div className="flex items-center gap-3">
+                    <span className="font-mono text-sm">{vote.voter.slice(0, 6)}...{vote.voter.slice(-4)}</span>
+                    <span className={`text-xs px-2 py-0.5 rounded ${
+                      vote.support === VoteSupport.For ? "bg-green-100 text-green-700" :
+                      vote.support === VoteSupport.Against ? "bg-red-100 text-red-700" :
+                      "bg-gray-200 text-gray-600"
+                    }`}>
+                      {supportLabel(vote.support)}
+                    </span>
+                    {hasReason && (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setExpandedReasons((prev) => ({
+                            ...prev,
+                            [vote.id]: !prev[vote.id],
+                          }))
+                        }
+                        className="inline-flex items-center gap-1 rounded-full border border-indigo-200 px-2 py-0.5 text-[11px] text-indigo-700 hover:bg-indigo-50"
+                        aria-label={`Toggle vote reason for ${vote.voter}`}
+                      >
+                        <MessageSquare className="w-3 h-3" />
+                        Reason
+                      </button>
+                    )}
+                  </div>
+                  <span className="text-sm font-mono text-gray-600 dark:text-gray-400">
+                    {(Number(vote.weight) / 10 ** 7).toLocaleString()} NEB
                   </span>
                 </div>
-                <span className="text-sm font-mono text-gray-600 dark:text-gray-400">
-                  {(Number(vote.weight) / 10 ** 7).toLocaleString()} NEB
-                </span>
+
+                {hasReason && (
+                  <div
+                    className={`mt-3 rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 ${
+                      expanded ? "block" : "hidden md:group-hover:block"
+                    }`}
+                  >
+                    <p className="whitespace-pre-wrap break-words">{reasonText}</p>
+                    {reason.length > 200 && (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setExpandedReasons((prev) => ({
+                            ...prev,
+                            [vote.id]: !prev[vote.id],
+                          }))
+                        }
+                        className="mt-2 text-xs font-medium text-indigo-600 hover:text-indigo-800"
+                      >
+                        {expanded ? "Show less" : "Show more"}
+                      </button>
+                    )}
+                  </div>
+                )}
               </li>
-            ))}
+              );
+            })}
           </ul>
         )}
 

--- a/app/src/app/treasury/page.tsx
+++ b/app/src/app/treasury/page.tsx
@@ -65,6 +65,7 @@ export default function TreasuryPage() {
 
   const [txs, setTxs] = useState<TreasuryTx[]>([]);
   const [threshold, setThreshold] = useState<number>(1);
+  const [ownerAddresses, setOwnerAddresses] = useState<string[]>([]);
   const [alreadyApproved, setAlreadyApproved] = useState<Record<string, boolean>>(
     {},
   );
@@ -149,8 +150,11 @@ export default function TreasuryPage() {
     async (viewer: string) => {
       if (!treasuryClient || !viewer) return;
 
-      const t = await treasuryClient.threshold(viewer);
+      const t = await treasuryClient.getThreshold(viewer);
       setThreshold(t);
+
+      const owners = await treasuryClient.getOwners(viewer);
+      setOwnerAddresses(owners ?? []);
 
       const count = await treasuryClient.txCount(viewer);
       const scanLimit = count !== null && count > 0 ? count : 50;
@@ -186,8 +190,14 @@ export default function TreasuryPage() {
       setAlreadyApproved(approvedMap);
 
       if (publicKey) {
-        const own = await treasuryClient.isTreasuryOwner(viewer, publicKey);
-        setOwnerOnChain(own);
+        if (owners && owners.length > 0) {
+          setOwnerOnChain(
+            owners.some((owner) => owner.toUpperCase() === publicKey.toUpperCase()),
+          );
+        } else {
+          const own = await treasuryClient.isOwner(viewer, publicKey);
+          setOwnerOnChain(own);
+        }
       } else {
         setOwnerOnChain(null);
       }
@@ -230,6 +240,7 @@ export default function TreasuryPage() {
       setTxs([]);
       setAlreadyApproved({});
       setThreshold(1);
+      setOwnerAddresses([]);
       setOwnerOnChain(null);
       setLoading(false);
       return;
@@ -362,6 +373,18 @@ export default function TreasuryPage() {
             {loading ? "Loading…" : `${xlmBalance} XLM`}
           </p>
         </div>
+      </div>
+
+      <div className="mb-8 bg-white border border-gray-200 rounded-xl p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-1">Multisig configuration</h2>
+        <p className="text-sm text-gray-500">
+          {threshold}-of-{ownerAddresses.length || "?"} multisig
+        </p>
+        {ownerAddresses.length > 0 && (
+          <p className="text-xs text-gray-500 mt-2">
+            On-chain owners: {ownerAddresses.map((address) => `${address.slice(0, 6)}...${address.slice(-4)}`).join(", ")}
+          </p>
+        )}
       </div>
 
       <div className="bg-white border border-gray-200 rounded-xl p-6 mb-8">

--- a/app/src/lib/treasury-client.ts
+++ b/app/src/lib/treasury-client.ts
@@ -112,6 +112,18 @@ export class TreasuryClient {
     return Number(scValToNative(rv));
   }
 
+  async getThreshold(viewer: string): Promise<number> {
+    return this.threshold(viewer);
+  }
+
+  /** Returns `null` when owners entrypoint cannot be simulated. */
+  async getOwners(viewer: string): Promise<string[] | null> {
+    const rv = await this.simulate(viewer, this.contract.call("owners"));
+    if (!rv) return null;
+    const owners = scValToNative(rv) as unknown[];
+    return owners.map((owner) => String(owner));
+  }
+
   async getTx(viewer: string, id: number): Promise<TreasuryTx | null> {
     const rv = await this.simulate(
       viewer,
@@ -171,6 +183,10 @@ export class TreasuryClient {
     );
     if (!rv) return null;
     return Boolean(scValToNative(rv));
+  }
+
+  async isOwner(viewer: string, candidate: string): Promise<boolean | null> {
+    return this.isTreasuryOwner(viewer, candidate);
   }
 
   async getSpendingCap(

--- a/backend/src/middleware/admin.ts
+++ b/backend/src/middleware/admin.ts
@@ -1,0 +1,19 @@
+import { Request, Response, NextFunction } from "express";
+
+export function isAdmin(req: Request, res: Response, next: NextFunction) {
+  const expectedSecret = process.env.ADMIN_SECRET;
+  if (!expectedSecret) {
+    return res.status(503).json({ error: "ADMIN_SECRET is not configured" });
+  }
+
+  const provided =
+    req.header("ADMIN_SECRET") ??
+    req.header("X-ADMIN-SECRET") ??
+    req.header("admin_secret");
+
+  if (!provided || provided !== expectedSecret) {
+    return res.status(403).json({ error: "Admin authorization required" });
+  }
+
+  next();
+}

--- a/backend/src/routes/competitions.test.ts
+++ b/backend/src/routes/competitions.test.ts
@@ -22,6 +22,7 @@ describe("Competitions API", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env.ADMIN_SECRET = "test-admin-secret";
     app = createApp();
   });
 
@@ -395,6 +396,211 @@ describe("Competitions API", () => {
         .expect(400);
 
       expect(response.body).toHaveProperty("errors");
+    });
+  });
+
+  describe("Admin competition routes", () => {
+    const adminHeader = { ADMIN_SECRET: "test-admin-secret" };
+
+    it("blocks create competition without admin secret", async () => {
+      await request(app)
+        .post("/competitions")
+        .send({
+          name: "Q2 Governance Sprint",
+          description: "desc",
+          entry_fee: 1000,
+          start_date: "2030-07-01T00:00:00.000Z",
+          end_date: "2030-07-31T00:00:00.000Z",
+        })
+        .expect(403);
+    });
+
+    it("creates a competition with admin secret", async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{
+          id: 7,
+          name: "Q2 Governance Sprint",
+          description: "desc",
+          entry_fee: "1000",
+          start_date: "2030-07-01T00:00:00.000Z",
+          end_date: "2030-07-31T00:00:00.000Z",
+          is_active: true,
+          created_by: null,
+        }],
+        command: "",
+        rowCount: 1,
+        oid: 0,
+        fields: [],
+      });
+
+      const response = await request(app)
+        .post("/competitions")
+        .set(adminHeader)
+        .send({
+          name: "Q2 Governance Sprint",
+          description: "desc",
+          entry_fee: 1000,
+          start_date: "2030-07-01T00:00:00.000Z",
+          end_date: "2030-07-31T00:00:00.000Z",
+        })
+        .expect(201);
+
+      expect(response.body).toHaveProperty("competition");
+      expect(response.body.competition.name).toBe("Q2 Governance Sprint");
+    });
+
+    it("rejects create when end_date is not in the future", async () => {
+      const response = await request(app)
+        .post("/competitions")
+        .set(adminHeader)
+        .send({
+          name: "Old Competition",
+          description: "desc",
+          entry_fee: 1000,
+          start_date: "2020-01-01T00:00:00.000Z",
+          end_date: "2020-01-02T00:00:00.000Z",
+        })
+        .expect(400);
+
+      expect(response.body).toHaveProperty("errors");
+    });
+
+    it("updates a competition before start_date", async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{
+            id: 7,
+            name: "Existing",
+            description: "desc",
+            entry_fee: "1000",
+            start_date: "2030-07-01T00:00:00.000Z",
+            end_date: "2030-07-31T00:00:00.000Z",
+            is_active: true,
+            created_by: null,
+          }],
+          command: "",
+          rowCount: 1,
+          oid: 0,
+          fields: [],
+        })
+        .mockResolvedValueOnce({
+          rows: [{
+            id: 7,
+            name: "Updated Name",
+            description: "desc",
+            entry_fee: "2000",
+            start_date: "2030-07-01T00:00:00.000Z",
+            end_date: "2030-08-15T00:00:00.000Z",
+            is_active: true,
+            created_by: null,
+          }],
+          command: "",
+          rowCount: 1,
+          oid: 0,
+          fields: [],
+        });
+
+      const response = await request(app)
+        .put("/competitions/7")
+        .set(adminHeader)
+        .send({
+          name: "Updated Name",
+          entry_fee: 2000,
+          end_date: "2030-08-15T00:00:00.000Z",
+        })
+        .expect(200);
+
+      expect(response.body.competition.name).toBe("Updated Name");
+    });
+
+    it("rejects update after competition start_date", async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{
+          id: 8,
+          name: "Started Competition",
+          description: "desc",
+          entry_fee: "1000",
+          start_date: "2020-01-01T00:00:00.000Z",
+          end_date: "2030-01-01T00:00:00.000Z",
+          is_active: true,
+          created_by: null,
+        }],
+        command: "",
+        rowCount: 1,
+        oid: 0,
+        fields: [],
+      });
+
+      const response = await request(app)
+        .put("/competitions/8")
+        .set(adminHeader)
+        .send({ name: "Too Late" })
+        .expect(400);
+
+      expect(response.body.error).toContain("before start_date");
+    });
+
+    it("soft deletes a competition without participants", async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{
+            id: 9,
+            name: "To Delete",
+            start_date: "2030-07-01T00:00:00.000Z",
+          }],
+          command: "",
+          rowCount: 1,
+          oid: 0,
+          fields: [],
+        })
+        .mockResolvedValueOnce({
+          rows: [{ count: "0" }],
+          command: "",
+          rowCount: 1,
+          oid: 0,
+          fields: [],
+        })
+        .mockResolvedValueOnce({
+          rows: [],
+          command: "",
+          rowCount: 1,
+          oid: 0,
+          fields: [],
+        });
+
+      await request(app)
+        .delete("/competitions/9")
+        .set(adminHeader)
+        .expect(204);
+    });
+
+    it("rejects soft delete when participants exist", async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{
+            id: 10,
+            name: "Has Participants",
+            start_date: "2030-07-01T00:00:00.000Z",
+          }],
+          command: "",
+          rowCount: 1,
+          oid: 0,
+          fields: [],
+        })
+        .mockResolvedValueOnce({
+          rows: [{ count: "3" }],
+          command: "",
+          rowCount: 1,
+          oid: 0,
+          fields: [],
+        });
+
+      const response = await request(app)
+        .delete("/competitions/10")
+        .set(adminHeader)
+        .expect(400);
+
+      expect(response.body.error).toContain("existing participants");
     });
   });
 });

--- a/backend/src/routes/competitions.ts
+++ b/backend/src/routes/competitions.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import pool from "../db/pool";
 import { authenticate, AuthRequest } from "../middleware/auth";
 import { validate } from "../middleware/validate";
+import { isAdmin } from "../middleware/admin";
 import { Competition } from "../entities/Competition";
 import { CompetitionParticipant } from "../entities/CompetitionParticipant";
 
@@ -32,6 +33,68 @@ const listParticipantsSchema = z.object({
 const competitionIdSchema = z.object({
   id: z.coerce.number().int().positive(),
 });
+
+const createCompetitionSchema = z
+  .object({
+    name: z.string().trim().min(1).max(100),
+    description: z.string().max(5000).optional(),
+    entry_fee: z.coerce.number().int().min(0),
+    start_date: z.string().datetime(),
+    end_date: z.string().datetime(),
+  })
+  .superRefine((data, ctx) => {
+    const start = new Date(data.start_date);
+    const end = new Date(data.end_date);
+    const now = Date.now();
+
+    if (start.getTime() >= end.getTime()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["start_date"],
+        message: "start_date must be before end_date",
+      });
+    }
+
+    if (end.getTime() <= now) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["end_date"],
+        message: "end_date must be in the future",
+      });
+    }
+  });
+
+const updateCompetitionSchema = z
+  .object({
+    name: z.string().trim().min(1).max(100).optional(),
+    description: z.string().max(5000).optional(),
+    entry_fee: z.coerce.number().int().min(0).optional(),
+    start_date: z.string().datetime().optional(),
+    end_date: z.string().datetime().optional(),
+    is_active: z.boolean().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (Object.keys(data).length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [],
+        message: "At least one field must be provided",
+      });
+      return;
+    }
+
+    if (data.start_date && data.end_date) {
+      const start = new Date(data.start_date);
+      const end = new Date(data.end_date);
+      if (start.getTime() >= end.getTime()) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["start_date"],
+          message: "start_date must be before end_date",
+        });
+      }
+    }
+  });
 
 // GET /competitions - List all competitions with pagination
 router.get(
@@ -318,6 +381,133 @@ router.delete(
       res.status(500).json({ error: "Failed to leave competition" });
     } finally {
       client.release();
+    }
+  },
+);
+
+// POST /competitions - Create competition (admin only)
+router.post(
+  "/",
+  isAdmin,
+  validate({ body: createCompetitionSchema }),
+  async (req, res) => {
+    const { name, description, entry_fee, start_date, end_date } = req.body as z.infer<
+      typeof createCompetitionSchema
+    >;
+
+    try {
+      const result = await pool.query<Competition>(
+        `INSERT INTO competitions (name, description, entry_fee, start_date, end_date, is_active, created_by)
+         VALUES ($1, $2, $3, $4, $5, true, NULL)
+         RETURNING *`,
+        [name, description ?? null, entry_fee, new Date(start_date), new Date(end_date)],
+      );
+
+      return res.status(201).json({ competition: result.rows[0] });
+    } catch (error) {
+      console.error("Error creating competition:", error);
+      return res.status(500).json({ error: "Failed to create competition" });
+    }
+  },
+);
+
+// PUT /competitions/:id - Update competition (admin only)
+router.put(
+  "/:id",
+  isAdmin,
+  validate({ params: competitionIdSchema, body: updateCompetitionSchema }),
+  async (req, res) => {
+    const id = Number((req.params as Record<string, string>).id);
+    const updates = req.body as z.infer<typeof updateCompetitionSchema>;
+
+    try {
+      const existing = await pool.query<Competition>(
+        "SELECT * FROM competitions WHERE id = $1",
+        [id],
+      );
+
+      if (existing.rows.length === 0) {
+        return res.status(404).json({ error: "Competition not found" });
+      }
+
+      const competition = existing.rows[0];
+      if (new Date() >= new Date(competition.start_date)) {
+        return res.status(400).json({
+          error: "Competition can only be updated before start_date",
+        });
+      }
+
+      const fields: string[] = [];
+      const values: unknown[] = [];
+      let idx = 1;
+      const append = (field: string, value: unknown) => {
+        fields.push(`${field} = $${idx}`);
+        values.push(value);
+        idx += 1;
+      };
+
+      if (updates.name !== undefined) append("name", updates.name);
+      if (updates.description !== undefined) append("description", updates.description);
+      if (updates.entry_fee !== undefined) append("entry_fee", updates.entry_fee);
+      if (updates.start_date !== undefined) append("start_date", new Date(updates.start_date));
+      if (updates.end_date !== undefined) append("end_date", new Date(updates.end_date));
+      if (updates.is_active !== undefined) append("is_active", updates.is_active);
+      append("updated_at", new Date());
+
+      const result = await pool.query<Competition>(
+        `UPDATE competitions
+         SET ${fields.join(", ")}
+         WHERE id = $${idx}
+         RETURNING *`,
+        [...values, id],
+      );
+
+      return res.status(200).json({ competition: result.rows[0] });
+    } catch (error) {
+      console.error("Error updating competition:", error);
+      return res.status(500).json({ error: "Failed to update competition" });
+    }
+  },
+);
+
+// DELETE /competitions/:id - Soft delete competition (admin only)
+router.delete(
+  "/:id",
+  isAdmin,
+  validate({ params: competitionIdSchema }),
+  async (req, res) => {
+    const id = Number((req.params as Record<string, string>).id);
+
+    try {
+      const existing = await pool.query<Competition>(
+        "SELECT * FROM competitions WHERE id = $1",
+        [id],
+      );
+
+      if (existing.rows.length === 0) {
+        return res.status(404).json({ error: "Competition not found" });
+      }
+
+      const participantCount = await pool.query<{ count: string }>(
+        "SELECT COUNT(*)::text AS count FROM competition_participants WHERE competition_id = $1",
+        [id],
+      );
+
+      if (Number(participantCount.rows[0]?.count ?? "0") > 0) {
+        return res.status(400).json({
+          error: "Cannot delete competition with existing participants",
+        });
+      }
+
+      await pool.query(
+        "UPDATE competitions SET is_active = false, updated_at = NOW() WHERE id = $1",
+        [id],
+      );
+
+      return res.status(204).send();
+    } catch (error) {
+      console.error("Error deleting competition:", error);
+      return res.status(500).json({ error: "Failed to delete competition" });
     }
   },
 );

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "private": true,
   "workspaces": [
     "sdk",
-    "app"
+    "app",
+    "packages/cli"
   ],
   "scripts": {
     "build:sdk": "pnpm --filter sdk build",
     "build:app": "pnpm --filter app build",
+    "build:cli": "pnpm --filter @nebgov/cli build",
     "dev": "pnpm --filter app dev",
     "test:sdk": "pnpm --filter sdk test",
     "test:app": "pnpm --filter app test"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,101 @@
+# @nebgov/cli
+
+Terminal CLI for NebGov governance operations.
+
+## Install
+
+```bash
+pnpm --filter @nebgov/cli build
+pnpm --filter @nebgov/cli link --global
+```
+
+Then run:
+
+```bash
+nebgov --help
+```
+
+## Configuration
+
+The CLI reads config from:
+
+1. Environment variables
+2. `~/.nebgov/config.json` (or `--config <path>`)
+
+Supported env vars:
+
+- `NEBGOV_NETWORK` (`testnet` | `mainnet` | `futurenet`)
+- `NEBGOV_GOVERNOR_ADDRESS`
+- `NEBGOV_TIMELOCK_ADDRESS`
+- `NEBGOV_VOTES_ADDRESS`
+- `NEBGOV_TREASURY_ADDRESS`
+- `NEBGOV_RPC_URL`
+- `NEBGOV_KEYPAIR_FILE`
+- `NEBGOV_DEFAULT_ACCOUNT`
+
+Example config file:
+
+```json
+{
+  "network": "testnet",
+  "governorAddress": "C...",
+  "timelockAddress": "C...",
+  "votesAddress": "C...",
+  "treasuryAddress": "C...",
+  "rpcUrl": "https://soroban-testnet.stellar.org",
+  "keypairFile": "~/.stellar/keypair.json",
+  "defaultAccount": "G..."
+}
+```
+
+## Output Modes
+
+- Default: JSON
+- `--human`: human-friendly output
+- `--dry-run`: print planned action without submitting transactions
+
+## Commands
+
+### Proposals
+
+```bash
+nebgov proposals list --proposer G...
+nebgov proposals get 42
+nebgov proposals create \
+  --title "Q2 Budget Update" \
+  --description-file ./proposal.md \
+  --target C... \
+  --fn update_config \
+  --keypair ~/.stellar/keypair.json
+```
+
+### Voting
+
+```bash
+nebgov vote cast 42 for --keypair ~/.stellar/keypair.json
+nebgov vote status 42 --voter G...
+```
+
+### Delegation
+
+```bash
+nebgov delegate to G... --keypair ~/.stellar/keypair.json
+nebgov delegate show G...
+```
+
+### Treasury
+
+```bash
+nebgov treasury balance --viewer G...
+nebgov treasury batch-transfer \
+  --token C... \
+  --recipients ./recipients.csv \
+  --keypair ~/.stellar/keypair.json
+```
+
+`recipients.csv` format:
+
+```csv
+GAAAA...,1000000
+GBBBB...,2500000
+```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@nebgov/cli",
+  "version": "0.1.0",
+  "description": "NebGov command-line interface for terminal-based governance workflows",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "nebgov": "dist/index.js"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx src/index.ts",
+    "lint": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@nebgov/sdk": "workspace:*",
+    "@stellar/stellar-sdk": "^12.0.0",
+    "commander": "^12.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,463 @@
+#!/usr/bin/env node
+
+import { Command } from "commander";
+import { GovernorClient, VoteSupport, VotesClient, TreasuryClient, type Network } from "@nebgov/sdk";
+import { Keypair } from "@stellar/stellar-sdk";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+
+type NebGovCliConfig = {
+  network: Network;
+  rpcUrl?: string;
+  governorAddress?: string;
+  timelockAddress?: string;
+  votesAddress?: string;
+  treasuryAddress?: string;
+  keypairFile?: string;
+  defaultAccount?: string;
+};
+
+type GlobalOptions = {
+  human?: boolean;
+  dryRun?: boolean;
+  config?: string;
+};
+
+function output(value: unknown, opts: GlobalOptions): void {
+  if (opts.human) {
+    if (Array.isArray(value)) {
+      console.table(value);
+      return;
+    }
+    if (value && typeof value === "object") {
+      for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+        console.log(`${key}: ${typeof val === "bigint" ? val.toString() : String(val)}`);
+      }
+      return;
+    }
+    console.log(String(value));
+    return;
+  }
+
+  console.log(
+    JSON.stringify(
+      value,
+      (_key, v) => (typeof v === "bigint" ? v.toString() : v),
+      2,
+    ),
+  );
+}
+
+function resolvePath(rawPath: string): string {
+  if (rawPath.startsWith("~/")) {
+    return path.join(homedir(), rawPath.slice(2));
+  }
+  return rawPath;
+}
+
+async function loadConfig(configPathArg?: string): Promise<NebGovCliConfig> {
+  const defaultPath = path.join(homedir(), ".nebgov", "config.json");
+  const configPath = resolvePath(configPathArg ?? process.env.NEBGOV_CONFIG ?? defaultPath);
+
+  let fromFile: Partial<NebGovCliConfig> = {};
+  try {
+    const raw = await readFile(configPath, "utf8");
+    fromFile = JSON.parse(raw) as Partial<NebGovCliConfig>;
+  } catch {
+    // optional config file
+  }
+
+  const fromEnv: Partial<NebGovCliConfig> = {
+    network: (process.env.NEBGOV_NETWORK as Network | undefined),
+    rpcUrl: process.env.NEBGOV_RPC_URL,
+    governorAddress: process.env.NEBGOV_GOVERNOR_ADDRESS,
+    timelockAddress: process.env.NEBGOV_TIMELOCK_ADDRESS,
+    votesAddress: process.env.NEBGOV_VOTES_ADDRESS,
+    treasuryAddress: process.env.NEBGOV_TREASURY_ADDRESS,
+    keypairFile: process.env.NEBGOV_KEYPAIR_FILE,
+    defaultAccount: process.env.NEBGOV_DEFAULT_ACCOUNT,
+  };
+
+  return {
+    network: "testnet",
+    ...fromFile,
+    ...Object.fromEntries(
+      Object.entries(fromEnv).filter(([, val]) => val !== undefined),
+    ),
+  } as NebGovCliConfig;
+}
+
+function required(value: string | undefined, field: string): string {
+  if (!value) {
+    throw new Error(`Missing required config: ${field}`);
+  }
+  return value;
+}
+
+async function loadKeypair(rawPath: string): Promise<Keypair> {
+  const filePath = resolvePath(rawPath);
+  const raw = await readFile(filePath, "utf8");
+
+  try {
+    const parsed = JSON.parse(raw) as
+      | { secret?: string; secretKey?: string; privateKey?: string }
+      | string;
+
+    if (typeof parsed === "string") return Keypair.fromSecret(parsed);
+    const secret = parsed.secret ?? parsed.secretKey ?? parsed.privateKey;
+    if (!secret) throw new Error("No secret key found in keypair file");
+    return Keypair.fromSecret(secret);
+  } catch {
+    return Keypair.fromSecret(raw.trim());
+  }
+}
+
+function getVoteSupport(input: string): VoteSupport {
+  const normalized = input.toLowerCase();
+  if (normalized === "for") return VoteSupport.For;
+  if (normalized === "against") return VoteSupport.Against;
+  if (normalized === "abstain") return VoteSupport.Abstain;
+  throw new Error("support must be one of: for, against, abstain");
+}
+
+async function parseRecipientsCsv(filePathRaw: string): Promise<Array<{ address: string; amount: bigint }>> {
+  const filePath = resolvePath(filePathRaw);
+  const text = await readFile(filePath, "utf8");
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  const out: Array<{ address: string; amount: bigint }> = [];
+  for (const line of lines) {
+    const [address, amount] = line.split(",").map((part) => part.trim());
+    if (!address || !amount) continue;
+    out.push({ address, amount: BigInt(amount) });
+  }
+  return out;
+}
+
+const program = new Command();
+program
+  .name("nebgov")
+  .description("NebGov terminal governance CLI")
+  .option("--human", "human-readable output instead of JSON", false)
+  .option("--dry-run", "simulate actions without submitting transactions", false)
+  .option("--config <path>", "path to config file (defaults to ~/.nebgov/config.json)");
+
+program
+  .command("proposals")
+  .description("Proposal commands")
+  .addCommand(
+    new Command("list")
+      .option("--proposer <address>", "proposer address to list")
+      .option("--limit <number>", "max proposals", "20")
+      .action(async (options) => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const governor = new GovernorClient({
+          network: cfg.network,
+          governorAddress: required(cfg.governorAddress, "governorAddress"),
+          timelockAddress: required(cfg.timelockAddress, "timelockAddress"),
+          votesAddress: required(cfg.votesAddress, "votesAddress"),
+          rpcUrl: cfg.rpcUrl,
+        });
+
+        const proposer =
+          options.proposer ??
+          cfg.defaultAccount ??
+          (cfg.keypairFile ? (await loadKeypair(cfg.keypairFile)).publicKey() : undefined);
+
+        if (!proposer) {
+          throw new Error("Provide --proposer or set NEBGOV_DEFAULT_ACCOUNT / keypair");
+        }
+
+        const proposals = await governor.getProposalsForAddress(proposer, {
+          limit: Number(options.limit),
+        });
+        output(
+          proposals.map((entry: { id: bigint; proposal: { proposer: string; description: string }; state: unknown }) => ({
+            id: entry.id,
+            state: entry.state,
+            proposer: entry.proposal.proposer,
+            description: entry.proposal.description,
+          })),
+          global,
+        );
+      }),
+  )
+  .addCommand(
+    new Command("get")
+      .argument("<id>", "proposal id")
+      .action(async (id: string) => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const governor = new GovernorClient({
+          network: cfg.network,
+          governorAddress: required(cfg.governorAddress, "governorAddress"),
+          timelockAddress: required(cfg.timelockAddress, "timelockAddress"),
+          votesAddress: required(cfg.votesAddress, "votesAddress"),
+          rpcUrl: cfg.rpcUrl,
+        });
+
+        const proposalId = BigInt(id);
+        const [proposal, state, votes] = await Promise.all([
+          governor.getProposal(proposalId),
+          governor.getProposalState(proposalId),
+          governor.getProposalVotes(proposalId),
+        ]);
+        output({ id: proposalId, state, proposal, votes }, global);
+      }),
+  )
+  .addCommand(
+    new Command("create")
+      .requiredOption("--title <title>", "proposal title/summary")
+      .requiredOption("--description-file <file>", "proposal description markdown/text file")
+      .requiredOption("--target <address>", "target contract address")
+      .requiredOption("--fn <name>", "target function name")
+      .option("--calldata-hex <hex>", "hex calldata bytes (default empty)")
+      .option("--keypair <file>", "keypair file path")
+      .action(async (options) => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const governor = new GovernorClient({
+          network: cfg.network,
+          governorAddress: required(cfg.governorAddress, "governorAddress"),
+          timelockAddress: required(cfg.timelockAddress, "timelockAddress"),
+          votesAddress: required(cfg.votesAddress, "votesAddress"),
+          rpcUrl: cfg.rpcUrl,
+        });
+
+        const description = await readFile(resolvePath(options.descriptionFile), "utf8");
+        const descriptionHash = createHash("sha256").update(description).digest("hex");
+        const calldata = Buffer.from((options.calldataHex ?? "").replace(/^0x/i, ""), "hex");
+
+        if (global.dryRun) {
+          output(
+            {
+              action: "proposals.create",
+              title: options.title,
+              descriptionHash,
+              target: options.target,
+              fn: options.fn,
+              calldataHex: calldata.toString("hex"),
+            },
+            global,
+          );
+          return;
+        }
+
+        const keypairPath = options.keypair ?? cfg.keypairFile;
+        if (!keypairPath) throw new Error("Missing --keypair or NEBGOV_KEYPAIR_FILE");
+        const signer = await loadKeypair(keypairPath);
+        const proposalId = await governor.propose(
+          signer,
+          options.title,
+          descriptionHash,
+          "",
+          [options.target],
+          [options.fn],
+          [calldata],
+        );
+        output({ proposalId }, global);
+      }),
+  );
+
+program
+  .command("vote")
+  .description("Vote commands")
+  .addCommand(
+    new Command("cast")
+      .argument("<proposalId>", "proposal id")
+      .argument("<support>", "for|against|abstain")
+      .requiredOption("--keypair <file>", "keypair file path")
+      .action(async (proposalId: string, support: string, options) => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const governor = new GovernorClient({
+          network: cfg.network,
+          governorAddress: required(cfg.governorAddress, "governorAddress"),
+          timelockAddress: required(cfg.timelockAddress, "timelockAddress"),
+          votesAddress: required(cfg.votesAddress, "votesAddress"),
+          rpcUrl: cfg.rpcUrl,
+        });
+
+        const voteSupport = getVoteSupport(support);
+        if (global.dryRun) {
+          output({ action: "vote.cast", proposalId, support: voteSupport }, global);
+          return;
+        }
+
+        const signer = await loadKeypair(options.keypair);
+        await governor.castVote(signer, BigInt(proposalId), voteSupport);
+        output({ ok: true, proposalId, support: voteSupport }, global);
+      }),
+  )
+  .addCommand(
+    new Command("status")
+      .argument("<proposalId>", "proposal id")
+      .option("--voter <address>", "voter address")
+      .action(async (proposalId: string, options) => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const governor = new GovernorClient({
+          network: cfg.network,
+          governorAddress: required(cfg.governorAddress, "governorAddress"),
+          timelockAddress: required(cfg.timelockAddress, "timelockAddress"),
+          votesAddress: required(cfg.votesAddress, "votesAddress"),
+          rpcUrl: cfg.rpcUrl,
+        });
+
+        const voter =
+          options.voter ??
+          cfg.defaultAccount ??
+          (cfg.keypairFile ? (await loadKeypair(cfg.keypairFile)).publicKey() : undefined);
+        if (!voter) throw new Error("Provide --voter or set NEBGOV_DEFAULT_ACCOUNT / keypair");
+
+        const receipt = await governor.getReceipt(BigInt(proposalId), voter);
+        output({ proposalId, voter, receipt }, global);
+      }),
+  );
+
+program
+  .command("delegate")
+  .description("Delegation commands")
+  .addCommand(
+    new Command("to")
+      .argument("<address>", "delegatee address")
+      .requiredOption("--keypair <file>", "keypair file path")
+      .action(async (address: string, options) => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const votes = new VotesClient({
+          governorAddress: required(cfg.governorAddress, "governorAddress"),
+          timelockAddress: required(cfg.timelockAddress, "timelockAddress"),
+          network: cfg.network,
+          votesAddress: required(cfg.votesAddress, "votesAddress"),
+          rpcUrl: cfg.rpcUrl,
+        });
+
+        if (global.dryRun) {
+          output({ action: "delegate.to", delegatee: address }, global);
+          return;
+        }
+
+        const signer = await loadKeypair(options.keypair);
+        await votes.delegate(signer, address);
+        output({ ok: true, delegatee: address, delegator: signer.publicKey() }, global);
+      }),
+  )
+  .addCommand(
+    new Command("show")
+      .argument("<address>", "delegator address")
+      .action(async (address: string) => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const votes = new VotesClient({
+          governorAddress: required(cfg.governorAddress, "governorAddress"),
+          timelockAddress: required(cfg.timelockAddress, "timelockAddress"),
+          network: cfg.network,
+          votesAddress: required(cfg.votesAddress, "votesAddress"),
+          rpcUrl: cfg.rpcUrl,
+        });
+
+        const [delegatee, votingPower] = await Promise.all([
+          votes.getDelegatee(address),
+          votes.getVotes(address),
+        ]);
+        output({ address, delegatee, votingPower }, global);
+      }),
+  );
+
+program
+  .command("treasury")
+  .description("Treasury commands")
+  .addCommand(
+    new Command("balance")
+      .option("--viewer <address>", "simulation viewer account")
+      .option("--token <address>", "token address to inspect spending metrics")
+      .action(async (options) => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const viewer =
+          options.viewer ??
+          cfg.defaultAccount ??
+          (cfg.keypairFile ? (await loadKeypair(cfg.keypairFile)).publicKey() : undefined);
+        if (!viewer) throw new Error("Provide --viewer or set NEBGOV_DEFAULT_ACCOUNT / keypair");
+
+        const treasury = new TreasuryClient({
+          network: cfg.network,
+          treasuryAddress: required(cfg.treasuryAddress, "treasuryAddress"),
+          rpcUrl: cfg.rpcUrl,
+          simulationAccount: viewer,
+        });
+
+        const [owners, threshold, txCount] = await Promise.all([
+          treasury.getOwners(),
+          treasury.getThreshold(),
+          treasury.getTxCount(),
+        ]);
+
+        let spentThisPeriod: bigint | null = null;
+        if (options.token) {
+          spentThisPeriod = await treasury.getSpentThisPeriod(options.token);
+        }
+
+        output(
+          {
+            viewer,
+            owners,
+            threshold,
+            txCount,
+            spentThisPeriod,
+            token: options.token ?? null,
+          },
+          global,
+        );
+      }),
+  )
+  .addCommand(
+    new Command("batch-transfer")
+      .requiredOption("--token <address>", "token contract address")
+      .requiredOption("--recipients <csv>", "CSV file containing address,amount rows")
+      .requiredOption("--keypair <file>", "keypair file path")
+      .action(async (options) => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const treasury = new TreasuryClient({
+          network: cfg.network,
+          treasuryAddress: required(cfg.treasuryAddress, "treasuryAddress"),
+          rpcUrl: cfg.rpcUrl,
+        });
+
+        const recipients = await parseRecipientsCsv(options.recipients);
+        if (recipients.length === 0) {
+          throw new Error("No recipients parsed from CSV");
+        }
+
+        if (global.dryRun) {
+          output(
+            {
+              action: "treasury.batch-transfer",
+              token: options.token,
+              recipients,
+              count: recipients.length,
+            },
+            global,
+          );
+          return;
+        }
+
+        const signer = await loadKeypair(options.keypair);
+        const opHash = await treasury.batchTransfer(signer, options.token, recipients);
+        output({ opHash, recipients: recipients.length }, global);
+      }),
+  );
+
+program.parseAsync(process.argv).catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+});

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,28 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
 
+  packages/cli:
+    dependencies:
+      '@nebgov/sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+      '@stellar/stellar-sdk':
+        specifier: ^12.0.0
+        version: 12.3.0
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.37
+      tsx:
+        specifier: ^4.20.6
+        version: 4.21.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
   packages/indexer:
     dependencies:
       '@asteasolutions/zod-to-openapi':
@@ -2725,6 +2747,10 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -7793,7 +7819,7 @@ snapshots:
   '@stellar/stellar-sdk@13.3.0':
     dependencies:
       '@stellar/stellar-base': 13.1.0
-      axios: 1.13.6
+      axios: 1.14.0
       bignumber.js: 9.3.1
       eventsource: 2.0.2
       feaxios: 0.0.23
@@ -9342,6 +9368,8 @@ snapshots:
       delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
+
+  commander@12.1.0: {}
 
   commander@14.0.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - 'sdk'
   - 'app'
+  - 'packages/cli'
   - 'packages/indexer'
   - 'backend'

--- a/sdk/src/__tests__/treasury.test.ts
+++ b/sdk/src/__tests__/treasury.test.ts
@@ -5,6 +5,7 @@ var mockGetAccount = jest.fn();
 var mockPrepareTransaction = jest.fn();
 var mockSendTransaction = jest.fn();
 var mockGetTransaction = jest.fn();
+var mockSimulateTransaction = jest.fn();
 
 import { TreasuryClient } from "../treasury";
 import { TreasuryError, TreasuryErrorCode, parseTreasuryError } from "../errors";
@@ -22,6 +23,7 @@ jest.mock("@stellar/stellar-sdk", () => {
         prepareTransaction: mockPrepareTransaction,
         sendTransaction: mockSendTransaction,
         getTransaction: mockGetTransaction,
+        simulateTransaction: mockSimulateTransaction,
       })),
       Api: {
         GetTransactionStatus: {
@@ -29,6 +31,7 @@ jest.mock("@stellar/stellar-sdk", () => {
           FAILED: "FAILED",
           NOT_FOUND: "NOT_FOUND",
         },
+        isSimulationError: jest.fn().mockReturnValue(false),
       },
     },
     Contract: jest.fn().mockImplementation((addr) => ({
@@ -57,10 +60,15 @@ describe("TreasuryClient", () => {
     jest.clearAllMocks();
     mockGetAccount.mockResolvedValue(new Account(validGAddr, "1"));
     mockNativeToScVal.mockReturnValue({} as xdr.ScVal);
+    mockSimulateTransaction.mockResolvedValue({
+      result: { retval: {} },
+    });
 
     client = new TreasuryClient({
       treasuryAddress: validCAddr,
       network: "testnet",
+      simulationAccount: validGAddr,
+      maxAttempts: 1,
     });
   });
 
@@ -226,16 +234,11 @@ describe("TreasuryClient", () => {
 
       await expect(
         client.submitWithLimit(mockKeypair, target, calldata, amount)
-      ).rejects.toThrow(TreasuryError);
-
-      try {
-        await client.submitWithLimit(mockKeypair, target, calldata, amount);
-      } catch (e) {
-        if (e instanceof TreasuryError) {
-          expect(e.code).toBe(TreasuryErrorCode.TransactionTimeout);
-        }
-      }
-    });
+      ).rejects.toMatchObject({
+        name: "TreasuryError",
+        code: TreasuryErrorCode.TransactionTimeout,
+      });
+    }, 60000);
 
     it("should handle immediate transaction failure", async () => {
       const target = validCAddr;
@@ -327,6 +330,68 @@ describe("TreasuryClient", () => {
       expect(mockNativeToScVal).toHaveBeenCalledWith(calldata, {
         type: "bytes",
       });
+    });
+  });
+
+  describe("read methods", () => {
+    it("getOwners() should decode owner addresses", async () => {
+      mockScValToNative.mockReturnValue([
+        "GA123OWNER1111111111111111111111111111111111111111111111111111",
+        "GB456OWNER2222222222222222222222222222222222222222222222222222",
+      ]);
+
+      const owners = await client.getOwners();
+
+      expect(Array.isArray(owners)).toBe(true);
+      expect(owners).toHaveLength(2);
+      expect(mockSimulateTransaction).toHaveBeenCalled();
+    });
+
+    it("getThreshold() should decode threshold number", async () => {
+      mockScValToNative.mockReturnValue(2);
+
+      const threshold = await client.getThreshold();
+
+      expect(threshold).toBe(2);
+    });
+
+    it("isOwner() should decode owner boolean", async () => {
+      mockScValToNative.mockReturnValue(true);
+
+      const result = await client.isOwner(validGAddr);
+
+      expect(result).toBe(true);
+      expect(mockNativeToScVal).toHaveBeenCalledWith(validGAddr, {
+        type: "address",
+      });
+    });
+
+    it("getTxCount() should decode tx count bigint", async () => {
+      mockScValToNative.mockReturnValue("17");
+
+      const count = await client.getTxCount();
+
+      expect(count).toBe(17n);
+    });
+
+    it("getTx() should decode treasury tx object", async () => {
+      mockScValToNative.mockReturnValue({
+        id: "9",
+        proposer: validGAddr,
+        target: validCAddr,
+        approvals: "2",
+        executed: false,
+        cancelled: false,
+      });
+
+      const tx = await client.getTx(9n);
+
+      expect(tx.id).toBe(9n);
+      expect(tx.proposer).toBe(validGAddr);
+      expect(tx.target).toBe(validCAddr);
+      expect(tx.approvals).toBe(2);
+      expect(tx.executed).toBe(false);
+      expect(tx.cancelled).toBe(false);
     });
   });
 });

--- a/sdk/src/governor.ts
+++ b/sdk/src/governor.ts
@@ -1607,6 +1607,15 @@ export class GovernorClient {
   }
 
   /**
+   * Return the on-chain vote reason for a voter on a proposal.
+   * Empty string means no reason recorded.
+   */
+  async getVoteReason(proposalId: bigint, voter: string): Promise<string> {
+    const receipt = await this.getReceipt(proposalId, voter);
+    return receipt.reason ?? "";
+  }
+
+  /**
    * Validate settings before building or submitting an update_config proposal.
    */
   validateGovernorSettings(

--- a/sdk/src/treasury.ts
+++ b/sdk/src/treasury.ts
@@ -11,6 +11,7 @@ import {
 } from "@stellar/stellar-sdk";
 import {
   TreasuryConfig,
+  TreasuryTx,
   BatchTransferRecipient,
   BatchTransferEvent,
   Network,
@@ -292,6 +293,157 @@ export class TreasuryClient {
       const raw = (result as SorobanRpc.Api.SimulateTransactionSuccessResponse)
         .result?.retval;
       return raw ? BigInt(scValToNative(raw)) : 0n;
+    });
+  }
+
+  /**
+   * Get current treasury owner addresses from on-chain state.
+   */
+  async getOwners(): Promise<string[]> {
+    return this.retry(async () => {
+      const result = await this.server.simulateTransaction(
+        new TransactionBuilder(
+          await this.server.getAccount(this.readAccount()),
+          { fee: BASE_FEE, networkPassphrase: this.networkPassphrase },
+        )
+          .addOperation(this.contract.call("owners"))
+          .setTimeout(30)
+          .build(),
+      );
+
+      if (SorobanRpc.Api.isSimulationError(result)) return [];
+      const raw = (result as SorobanRpc.Api.SimulateTransactionSuccessResponse)
+        .result?.retval;
+      if (!raw) return [];
+      const owners = scValToNative(raw) as unknown[];
+      return owners.map((owner) => String(owner));
+    });
+  }
+
+  /**
+   * Get treasury approval threshold from on-chain state.
+   */
+  async getThreshold(): Promise<number> {
+    return this.retry(async () => {
+      const result = await this.server.simulateTransaction(
+        new TransactionBuilder(
+          await this.server.getAccount(this.readAccount()),
+          { fee: BASE_FEE, networkPassphrase: this.networkPassphrase },
+        )
+          .addOperation(this.contract.call("threshold"))
+          .setTimeout(30)
+          .build(),
+      );
+
+      if (SorobanRpc.Api.isSimulationError(result)) return 1;
+      const raw = (result as SorobanRpc.Api.SimulateTransactionSuccessResponse)
+        .result?.retval;
+      if (!raw) return 1;
+      return Number(scValToNative(raw));
+    });
+  }
+
+  /**
+   * Check whether an address is currently a treasury owner.
+   */
+  async isOwner(address: string): Promise<boolean> {
+    return this.retry(async () => {
+      const result = await this.server.simulateTransaction(
+        new TransactionBuilder(
+          await this.server.getAccount(this.readAccount()),
+          { fee: BASE_FEE, networkPassphrase: this.networkPassphrase },
+        )
+          .addOperation(
+            this.contract.call(
+              "is_treasury_owner",
+              nativeToScVal(address, { type: "address" }),
+            ),
+          )
+          .setTimeout(30)
+          .build(),
+      );
+
+      if (SorobanRpc.Api.isSimulationError(result)) return false;
+      const raw = (result as SorobanRpc.Api.SimulateTransactionSuccessResponse)
+        .result?.retval;
+      if (!raw) return false;
+      return Boolean(scValToNative(raw));
+    });
+  }
+
+  /**
+   * Get total number of treasury transactions.
+   */
+  async getTxCount(): Promise<bigint> {
+    return this.retry(async () => {
+      const result = await this.server.simulateTransaction(
+        new TransactionBuilder(
+          await this.server.getAccount(this.readAccount()),
+          { fee: BASE_FEE, networkPassphrase: this.networkPassphrase },
+        )
+          .addOperation(this.contract.call("tx_count"))
+          .setTimeout(30)
+          .build(),
+      );
+
+      if (SorobanRpc.Api.isSimulationError(result)) return 0n;
+      const raw = (result as SorobanRpc.Api.SimulateTransactionSuccessResponse)
+        .result?.retval;
+      if (!raw) return 0n;
+      return BigInt(scValToNative(raw) as number | bigint | string);
+    });
+  }
+
+  /**
+   * Get a treasury transaction by ID.
+   */
+  async getTx(txId: bigint): Promise<TreasuryTx> {
+    return this.retry(async () => {
+      const result = await this.server.simulateTransaction(
+        new TransactionBuilder(
+          await this.server.getAccount(this.readAccount()),
+          { fee: BASE_FEE, networkPassphrase: this.networkPassphrase },
+        )
+          .addOperation(
+            this.contract.call("get_tx", nativeToScVal(txId, { type: "u64" })),
+          )
+          .setTimeout(30)
+          .build(),
+      );
+
+      if (SorobanRpc.Api.isSimulationError(result)) {
+        throw new TreasuryError(
+          TreasuryErrorCode.InvalidArguments,
+          `Treasury transaction ${txId} not found`,
+        );
+      }
+
+      const raw = (result as SorobanRpc.Api.SimulateTransactionSuccessResponse)
+        .result?.retval;
+      if (!raw) {
+        throw new TreasuryError(
+          TreasuryErrorCode.MissingReturnValue,
+          `No return value from get_tx(${txId})`,
+        );
+      }
+
+      const tx = scValToNative(raw) as {
+        id: bigint | number | string;
+        proposer: string;
+        target: string;
+        approvals: number | bigint | string;
+        executed: boolean;
+        cancelled: boolean;
+      };
+
+      return {
+        id: BigInt(tx.id),
+        proposer: tx.proposer,
+        target: tx.target,
+        approvals: Number(tx.approvals),
+        executed: Boolean(tx.executed),
+        cancelled: Boolean(tx.cancelled),
+      };
     });
   }
 


### PR DESCRIPTION
Summary
- add SDK treasury read methods and tests for owners, threshold, owner check, tx count, and tx lookup
- update treasury frontend to use on-chain owner reads as primary and env fallback only when on-chain check is unavailable, and display X-of-Y multisig threshold
- add proposal vote reason display with reason icon, collapsed-by-default behavior, click/tap expansion, and 200-char show more
- add admin middleware and admin-only competition routes for create/update/soft-delete with validation and tests
- add new @nebgov/cli package with proposals, vote, delegate, and treasury command groups; env/config file loading; human/json output; dry-run mode

Validation
- pnpm --filter @nebgov/sdk build passed
- pnpm --filter @nebgov/sdk test -- src/__tests__/treasury.test.ts passed
- pnpm --filter nebgov-backend test -- src/routes/competitions.test.ts passed
- pnpm --filter @nebgov/cli build passed
- pnpm --filter nebgov-app build fails due pre-existing unrelated module resolution issue in src/app/security/page.tsx
- pnpm --filter nebgov-app lint is interactive in this repo and could not run non-interactively

Closes #333
Closes #336
Closes #341
Closes #343