### PR TITLE
feat: add timelock operation batching support (#344)

### DIFF
--- a/contracts/governor/src/lib.rs
+++ b/contracts/governor/src/lib.rs
@@ -60,11 +60,24 @@ pub trait TimelockTrait {
         predecessor: Bytes,
         salt: Bytes,
     ) -> Bytes;
+    #[allow(clippy::too_many_arguments)]
+    fn schedule_batch(
+        env: Env,
+        caller: Address,
+        targets: Vec<Address>,
+        datas: Vec<Bytes>,
+        fn_names: Vec<Symbol>,
+        delay: u64,
+        predecessor: Bytes,
+        salt: Bytes,
+    ) -> Bytes;
     fn execute(env: Env, caller: Address, op_id: Bytes);
+    fn execute_batch(env: Env, caller: Address, batch_op_id: Bytes);
     fn cancel(env: Env, caller: Address, op_id: Bytes);
     fn min_delay(env: Env) -> u64;
     fn execution_window(env: Env) -> u64;
     fn is_done(env: Env, op_id: Bytes) -> bool;
+    fn is_batch_done(env: Env, batch_op_id: Bytes) -> bool;
 }
 
 /// Cross-contract interface for the TokenVotes contract.
@@ -816,13 +829,28 @@ impl GovernorContract {
 
         let ready_at = env.ledger().timestamp() + delay;
 
-        // Schedule every action in the proposal (multi-action proposals).
+        // Schedule proposal actions via the timelock.
+        // Multi-action proposals use schedule_batch() — one batch_op_id for all
+        // actions — which reduces storage costs and enables atomic execution.
+        // Single-action proposals use the existing schedule() path.
         let mut op_ids: Vec<Bytes> = Vec::new(&env);
         let empty_bytes = Bytes::new(&env);
-        for i in 0..proposal.targets.len() {
-            let target = proposal.targets.get(i).unwrap();
-            let fn_name = proposal.fn_names.get(i).unwrap();
-            let calldata = proposal.calldatas.get(i).unwrap();
+
+        if proposal.targets.len() > 1 {
+            let batch_op_id = timelock.schedule_batch(
+                &gov_addr,
+                &proposal.targets,
+                &proposal.calldatas,
+                &proposal.fn_names,
+                &delay,
+                &empty_bytes,
+                &empty_bytes,
+            );
+            op_ids.push_back(batch_op_id);
+        } else {
+            let target = proposal.targets.get(0).unwrap();
+            let fn_name = proposal.fn_names.get(0).unwrap();
+            let calldata = proposal.calldatas.get(0).unwrap();
             let op_id = timelock.schedule(
                 &gov_addr,
                 &target,
@@ -889,11 +917,55 @@ impl GovernorContract {
         }
 
         let timelock = TimelockClient::new(&env, &timelock_addr);
-        for i in 0..proposal.op_ids.len() {
-            let op_id = proposal.op_ids.get(i).unwrap();
-            let target = proposal.targets.get(i).unwrap();
-            let fn_name = proposal.fn_names.get(i).unwrap();
-            let calldata = proposal.calldatas.get(i).unwrap();
+
+        // Multi-action proposals were batch-scheduled: one batch_op_id covers all
+        // actions.  Call execute_batch() for atomic all-or-nothing execution.
+        // Single-action proposals use the existing execute() path.
+        if proposal.targets.len() > 1 {
+            let batch_op_id = proposal.op_ids.get(0).unwrap();
+
+            let mut timelock_args: Vec<Val> = Vec::new(&env);
+            timelock_args.push_back(gov_addr.clone().into_val(&env));
+            timelock_args.push_back(batch_op_id.clone().into_val(&env));
+
+            let mut sub_invocations = Vec::new(&env);
+            for j in 0..proposal.targets.len() {
+                let target = proposal.targets.get(j).unwrap();
+                let fn_name = proposal.fn_names.get(j).unwrap();
+                let calldata = proposal.calldatas.get(j).unwrap();
+                let decoded_args = Self::decode_calldata_args(&env, &calldata);
+                if !decoded_args.is_empty() {
+                    let target_context = ContractContext {
+                        contract: target,
+                        fn_name,
+                        args: decoded_args,
+                    };
+                    sub_invocations.push_back(InvokerContractAuthEntry::Contract(
+                        SubContractInvocation {
+                            context: target_context,
+                            sub_invocations: Vec::new(&env),
+                        },
+                    ));
+                }
+            }
+
+            let mut auth_entries = Vec::new(&env);
+            auth_entries.push_back(InvokerContractAuthEntry::Contract(SubContractInvocation {
+                context: ContractContext {
+                    contract: timelock_addr.clone(),
+                    fn_name: Symbol::new(&env, "execute_batch"),
+                    args: timelock_args,
+                },
+                sub_invocations,
+            }));
+            env.authorize_as_current_contract(auth_entries);
+
+            timelock.execute_batch(&gov_addr, &batch_op_id);
+        } else {
+            let op_id = proposal.op_ids.get(0).unwrap();
+            let target = proposal.targets.get(0).unwrap();
+            let fn_name = proposal.fn_names.get(0).unwrap();
+            let calldata = proposal.calldatas.get(0).unwrap();
             let decoded_args = Self::decode_calldata_args(&env, &calldata);
 
             let mut timelock_args: Vec<Val> = Vec::new(&env);
@@ -926,7 +998,6 @@ impl GovernorContract {
             }));
             env.authorize_as_current_contract(auth_entries);
 
-            // The timelock will verify if the operation is ready (delay passed).
             timelock.execute(&gov_addr, &op_id);
         }
 
@@ -1812,11 +1883,6 @@ impl GovernorContract {
     /// Returns the contract's own address since upgrades are governance-gated.
     pub fn proxy_admin(env: Env) -> Address {
         env.current_contract_address()
-    }
-
-    /// Get a proposal by ID.
-    pub fn get_proposal(env: Env, proposal_id: u64) -> Proposal {
-        Self::must_get_proposal(&env, proposal_id)
     }
 
     /// Get the ledger sequence when a proposal was queued.

--- a/contracts/timelock/src/lib.rs
+++ b/contracts/timelock/src/lib.rs
@@ -33,9 +33,27 @@ pub struct Operation {
     pub predecessor: Bytes,
 }
 
+/// A scheduled batch timelock operation.
+///
+/// Stores all sub-operations under a single `batch_op_id`.  Execution is
+/// all-or-nothing: if any sub-call panics, the entire batch reverts.
+#[contracttype]
+#[derive(Clone)]
+pub struct BatchOperation {
+    pub targets: Vec<Address>,
+    pub datas: Vec<Bytes>,
+    pub fn_names: Vec<Symbol>,
+    pub ready_at: u64,
+    pub expires_at: u64,
+    pub executed: bool,
+    pub cancelled: bool,
+    pub predecessor: Bytes,
+}
+
 #[contracttype]
 pub enum DataKey {
     Operation(Bytes),
+    BatchOperation(Bytes),
     MinDelay,
     ExecutionWindow,
     Admin,
@@ -82,6 +100,31 @@ impl TimelockContract {
         Bytes::from_array(&env, &hash.to_array())
     }
 
+    /// Compute a deterministic batch op_id from all sub-operation tuples combined
+    /// with a single predecessor and salt.
+    ///
+    /// Same inputs always produce the same ID, so scheduling is idempotent.
+    pub fn compute_batch_op_id(
+        env: Env,
+        targets: Vec<Address>,
+        datas: Vec<Bytes>,
+        fn_names: Vec<Symbol>,
+        predecessor: Bytes,
+        salt: Bytes,
+    ) -> Bytes {
+        let mut combined = Bytes::new(&env);
+        for i in 0..targets.len() {
+            combined.append(&targets.get(i).unwrap().to_xdr(&env));
+            combined.append(&datas.get(i).unwrap());
+            combined.append(&fn_names.get(i).unwrap().to_xdr(&env));
+        }
+        combined.append(&predecessor);
+        combined.append(&salt);
+
+        let hash = env.crypto().sha256(&combined);
+        Bytes::from_array(&env, &hash.to_array())
+    }
+
     /// Schedule a single operation.
     #[allow(clippy::too_many_arguments)]
     pub fn schedule(
@@ -99,46 +142,67 @@ impl TimelockContract {
         Self::schedule_operation(env, target, data, fn_name, delay, predecessor, salt)
     }
 
-    /// Schedule multiple operations in a single call.
+    /// Schedule multiple operations as a single atomic batch.
+    ///
+    /// Unlike the previous N-op-id design, this returns **one** `batch_op_id`
+    /// covering all sub-operations.  Use [`execute_batch`] to run them all at
+    /// once.  A single `predecessor` and `salt` apply to the whole batch.
     #[allow(clippy::too_many_arguments)]
     pub fn schedule_batch(
         env: Env,
         caller: Address,
         targets: Vec<Address>,
-        data: Vec<Bytes>,
+        datas: Vec<Bytes>,
         fn_names: Vec<Symbol>,
         delay: u64,
-        predecessors: Vec<Bytes>,
-        salts: Vec<Bytes>,
-    ) -> Vec<Bytes> {
+        predecessor: Bytes,
+        salt: Bytes,
+    ) -> Bytes {
         caller.require_auth();
         Self::require_governor(&env, &caller);
 
         let len = targets.len();
         assert!(len > 0, "empty batch");
-        assert!(len == data.len(), "length mismatch");
+        assert!(len == datas.len(), "length mismatch");
         assert!(len == fn_names.len(), "length mismatch");
-        assert!(len == predecessors.len(), "length mismatch");
-        assert!(len == salts.len(), "length mismatch");
 
-        let mut op_ids = Vec::new(&env);
-        for i in 0..len {
-            let op_id = Self::schedule_operation(
-                env.clone(),
-                targets.get(i).expect("target missing"),
-                data.get(i).expect("data missing"),
-                fn_names.get(i).expect("fn missing"),
-                delay,
-                predecessors.get(i).expect("predecessor missing"),
-                salts.get(i).expect("salt missing"),
-            );
-            op_ids.push_back(op_id);
-        }
+        Self::validate_predecessor(&env, &predecessor);
+
+        let min_delay = Self::min_delay(env.clone());
+        assert!(delay >= min_delay, "delay too short");
+
+        let execution_window = Self::execution_window(env.clone());
+        let ready_at = env.ledger().timestamp() + delay;
+        let expires_at = ready_at + execution_window;
+
+        let batch_op_id = Self::compute_batch_op_id(
+            env.clone(),
+            targets.clone(),
+            datas.clone(),
+            fn_names.clone(),
+            predecessor.clone(),
+            salt,
+        );
+
+        let batch = BatchOperation {
+            targets,
+            datas,
+            fn_names,
+            ready_at,
+            expires_at,
+            executed: false,
+            cancelled: false,
+            predecessor,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::BatchOperation(batch_op_id.clone()), &batch);
 
         env.events()
-            .publish((symbol_short!("schbatch"),), op_ids.clone());
+            .publish((symbol_short!("schbatch"),), batch_op_id.clone());
 
-        op_ids
+        batch_op_id
     }
 
     /// Execute a ready operation.
@@ -158,8 +222,12 @@ impl TimelockContract {
             env.panic_with_error(TimelockError::OperationExpired);
         }
 
-        if !op.predecessor.is_empty() && !Self::is_done(env.clone(), op.predecessor.clone()) {
-            env.panic_with_error(TimelockError::PredecessorNotDone);
+        if !op.predecessor.is_empty() {
+            let pred_done = Self::is_done(env.clone(), op.predecessor.clone())
+                || Self::is_batch_done(env.clone(), op.predecessor.clone());
+            if !pred_done {
+                env.panic_with_error(TimelockError::PredecessorNotDone);
+            }
         }
 
         op.executed = true;
@@ -173,7 +241,52 @@ impl TimelockContract {
         env.events().publish((symbol_short!("execute"),), op_id);
     }
 
-    /// Cancel a pending operation.
+    /// Execute a batch of operations atomically under a single `batch_op_id`.
+    ///
+    /// All sub-calls run in order.  If any sub-call panics, the entire
+    /// transaction reverts and none of the sub-calls take effect.
+    pub fn execute_batch(env: Env, caller: Address, batch_op_id: Bytes) {
+        caller.require_auth();
+        Self::require_governor(&env, &caller);
+
+        let mut batch: BatchOperation = env
+            .storage()
+            .persistent()
+            .get(&DataKey::BatchOperation(batch_op_id.clone()))
+            .expect("batch not found");
+
+        assert!(!batch.executed && !batch.cancelled, "invalid state");
+        assert!(env.ledger().timestamp() >= batch.ready_at, "not ready");
+        if env.ledger().timestamp() > batch.expires_at {
+            env.panic_with_error(TimelockError::OperationExpired);
+        }
+
+        if !batch.predecessor.is_empty() {
+            let pred_done = Self::is_done(env.clone(), batch.predecessor.clone())
+                || Self::is_batch_done(env.clone(), batch.predecessor.clone());
+            if !pred_done {
+                env.panic_with_error(TimelockError::PredecessorNotDone);
+            }
+        }
+
+        batch.executed = true;
+        env.storage()
+            .persistent()
+            .set(&DataKey::BatchOperation(batch_op_id.clone()), &batch);
+
+        for i in 0..batch.targets.len() {
+            let target = batch.targets.get(i).unwrap();
+            let fn_name = batch.fn_names.get(i).unwrap();
+            let data = batch.datas.get(i).unwrap();
+            let args = Self::decode_invocation_args(&env, &data);
+            env.invoke_contract::<()>(&target, &fn_name, args);
+        }
+
+        env.events()
+            .publish((symbol_short!("exbatch"),), batch_op_id);
+    }
+
+    /// Cancel a pending operation or batch operation.
     pub fn cancel(env: Env, caller: Address, op_id: Bytes) {
         caller.require_auth();
 
@@ -189,17 +302,31 @@ impl TimelockContract {
             .expect("not initialized");
         assert!(caller == admin || caller == governor, "not authorized");
 
-        let mut op: Operation = env
+        // Try single operation first, then batch operation.
+        if let Some(mut op) = env
             .storage()
             .persistent()
-            .get(&DataKey::Operation(op_id.clone()))
-            .expect("operation not found");
-        assert!(!op.executed && !op.cancelled, "invalid state");
-        op.cancelled = true;
-
-        env.storage()
+            .get::<_, Operation>(&DataKey::Operation(op_id.clone()))
+        {
+            assert!(!op.executed && !op.cancelled, "invalid state");
+            op.cancelled = true;
+            env.storage()
+                .persistent()
+                .set(&DataKey::Operation(op_id.clone()), &op);
+        } else if let Some(mut batch) = env
+            .storage()
             .persistent()
-            .set(&DataKey::Operation(op_id.clone()), &op);
+            .get::<_, BatchOperation>(&DataKey::BatchOperation(op_id.clone()))
+        {
+            assert!(!batch.executed && !batch.cancelled, "invalid state");
+            batch.cancelled = true;
+            env.storage()
+                .persistent()
+                .set(&DataKey::BatchOperation(op_id.clone()), &batch);
+        } else {
+            panic!("operation not found");
+        }
+
         env.events().publish((symbol_short!("cancel"),), op_id);
     }
 
@@ -231,6 +358,18 @@ impl TimelockContract {
         let op: Option<Operation> = env.storage().persistent().get(&DataKey::Operation(op_id));
         match op {
             Some(op) => op.executed,
+            None => false,
+        }
+    }
+
+    /// Check whether a batch operation has been executed.
+    pub fn is_batch_done(env: Env, batch_op_id: Bytes) -> bool {
+        let batch: Option<BatchOperation> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::BatchOperation(batch_op_id));
+        match batch {
+            Some(b) => b.executed,
             None => false,
         }
     }
@@ -342,11 +481,16 @@ impl TimelockContract {
             return;
         }
 
-        let exists = env
+        let op_exists = env
             .storage()
             .persistent()
             .has(&DataKey::Operation(predecessor.clone()));
-        if !exists {
+        let batch_exists = env
+            .storage()
+            .persistent()
+            .has(&DataKey::BatchOperation(predecessor.clone()));
+
+        if !op_exists && !batch_exists {
             env.panic_with_error(TimelockError::PredecessorNotFound);
         }
     }

--- a/contracts/timelock/src/test.rs
+++ b/contracts/timelock/src/test.rs
@@ -39,7 +39,8 @@ impl MockTarget {
 }
 
 #[test]
-fn test_schedule_batch_returns_ids_and_emits_event() {
+/// schedule_batch now returns a single batch_op_id and emits schbatch.
+fn test_schedule_batch_returns_single_id_and_emits_event() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -61,24 +62,18 @@ fn test_schedule_batch_returns_ids_and_emits_event() {
     fn_names.push_back(Symbol::new(&env, "ping"));
     fn_names.push_back(Symbol::new(&env, "pong"));
 
-    let mut predecessors = Vec::new(&env);
-    predecessors.push_back(Bytes::new(&env));
-    predecessors.push_back(Bytes::new(&env));
-
-    let mut salts = Vec::new(&env);
-    salts.push_back(Bytes::from_array(&env, &[9u8]));
-    salts.push_back(Bytes::from_array(&env, &[8u8]));
-
-    let ids = client.schedule_batch(
+    let batch_op_id = client.schedule_batch(
         &governor,
         &targets,
         &payloads,
         &fn_names,
         &10,
-        &predecessors,
-        &salts,
+        &Bytes::new(&env),
+        &Bytes::from_array(&env, &[9u8]),
     );
-    assert_eq!(ids.len(), 2);
+
+    // Returns a single Bytes id (32-byte SHA-256)
+    assert_eq!(batch_op_id.len(), 32);
 
     let events = env.events().all();
     let has_batch_event = events.iter().any(|(_, topics, _)| {
@@ -88,6 +83,220 @@ fn test_schedule_batch_returns_ids_and_emits_event() {
         }
     });
     assert!(has_batch_event, "schedule_batch event not emitted");
+}
+
+#[test]
+/// schedule_batch with same inputs always produces the same batch_op_id.
+fn test_batch_op_id_is_deterministic() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TimelockContract, ());
+    let client = TimelockContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let governor = Address::generate(&env);
+    client.initialize(&admin, &governor, &0, &1_209_600);
+
+    let target = Address::generate(&env);
+    let mut targets = Vec::new(&env);
+    targets.push_back(target.clone());
+
+    let mut datas = Vec::new(&env);
+    datas.push_back(Bytes::new(&env));
+
+    let mut fn_names = Vec::new(&env);
+    fn_names.push_back(Symbol::new(&env, "exec"));
+
+    let salt = Bytes::from_slice(&env, b"mysalt");
+
+    let id1 = client.schedule_batch(
+        &governor,
+        &targets,
+        &datas,
+        &fn_names,
+        &0,
+        &Bytes::new(&env),
+        &salt,
+    );
+    // Same call again — same id
+    let id2 = client.schedule_batch(
+        &governor,
+        &targets,
+        &datas,
+        &fn_names,
+        &0,
+        &Bytes::new(&env),
+        &salt,
+    );
+    assert_eq!(id1, id2);
+
+    // Different salt → different id
+    let salt2 = Bytes::from_slice(&env, b"othersalt");
+    let id3 = client.schedule_batch(
+        &governor,
+        &targets,
+        &datas,
+        &fn_names,
+        &0,
+        &Bytes::new(&env),
+        &salt2,
+    );
+    assert_ne!(id1, id3);
+}
+
+#[test]
+/// execute_batch runs all sub-calls atomically and marks the batch as done.
+fn test_execute_batch_atomic() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TimelockContract, ());
+    let client = TimelockContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let governor = Address::generate(&env);
+    client.initialize(&admin, &governor, &0, &1_209_600);
+
+    let target1 = env.register(MockTarget, ());
+    let target2 = env.register(MockTarget, ());
+
+    let mut targets = Vec::new(&env);
+    targets.push_back(target1.clone());
+    targets.push_back(target2.clone());
+
+    let mut datas = Vec::new(&env);
+    datas.push_back(Bytes::new(&env));
+    datas.push_back(Bytes::new(&env));
+
+    let mut fn_names = Vec::new(&env);
+    fn_names.push_back(Symbol::new(&env, "exec"));
+    fn_names.push_back(Symbol::new(&env, "exec"));
+
+    let batch_op_id = client.schedule_batch(
+        &governor,
+        &targets,
+        &datas,
+        &fn_names,
+        &0,
+        &Bytes::new(&env),
+        &Bytes::from_slice(&env, b"salt"),
+    );
+
+    // Not done yet
+    assert!(!client.is_batch_done(&batch_op_id));
+
+    // Advance past ready_at
+    env.ledger().with_mut(|l| l.timestamp = 1);
+    client.execute_batch(&governor, &batch_op_id);
+
+    // Both targets executed
+    let t1_done = env.as_contract(&target1, || MockTarget::was_executed(env.clone()));
+    let t2_done = env.as_contract(&target2, || MockTarget::was_executed(env.clone()));
+    assert!(t1_done, "target1 not executed");
+    assert!(t2_done, "target2 not executed");
+
+    // Batch is now done
+    assert!(client.is_batch_done(&batch_op_id));
+
+    // Double-execution should fail
+    let result = client.try_execute_batch(&governor, &batch_op_id);
+    assert!(result.is_err(), "second execute_batch should fail");
+}
+
+#[test]
+/// cancel() accepts a batch_op_id and prevents execute_batch from running.
+fn test_cancel_batch() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TimelockContract, ());
+    let client = TimelockContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let governor = Address::generate(&env);
+    client.initialize(&admin, &governor, &0, &1_209_600);
+
+    let target = env.register(MockTarget, ());
+    let mut targets = Vec::new(&env);
+    targets.push_back(target);
+
+    let mut datas = Vec::new(&env);
+    datas.push_back(Bytes::new(&env));
+
+    let mut fn_names = Vec::new(&env);
+    fn_names.push_back(Symbol::new(&env, "exec"));
+
+    let batch_op_id = client.schedule_batch(
+        &governor,
+        &targets,
+        &datas,
+        &fn_names,
+        &0,
+        &Bytes::new(&env),
+        &Bytes::from_slice(&env, b"salt"),
+    );
+
+    // Cancel the batch
+    client.cancel(&admin, &batch_op_id);
+
+    // execute_batch should now fail
+    env.ledger().with_mut(|l| l.timestamp = 1);
+    let result = client.try_execute_batch(&governor, &batch_op_id);
+    assert!(result.is_err(), "execute_batch should fail after cancel");
+}
+
+#[test]
+/// A batch can use a single op as its predecessor; execute_batch blocks until predecessor is done.
+fn test_batch_predecessor_enforcement() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TimelockContract, ());
+    let client = TimelockContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let governor = Address::generate(&env);
+    client.initialize(&admin, &governor, &0, &1_209_600);
+
+    let target = env.register(MockTarget, ());
+
+    // Schedule single predecessor op
+    let pred_op_id = client.schedule(
+        &governor,
+        &target,
+        &Bytes::new(&env),
+        &Symbol::new(&env, "exec"),
+        &0,
+        &Bytes::new(&env),
+        &Bytes::from_slice(&env, b"pred_salt"),
+    );
+
+    // Schedule batch with pred_op_id as predecessor
+    let mut targets = Vec::new(&env);
+    targets.push_back(target.clone());
+
+    let mut datas = Vec::new(&env);
+    datas.push_back(Bytes::new(&env));
+
+    let mut fn_names = Vec::new(&env);
+    fn_names.push_back(Symbol::new(&env, "exec"));
+
+    let batch_id = client.schedule_batch(
+        &governor,
+        &targets,
+        &datas,
+        &fn_names,
+        &0,
+        &pred_op_id,
+        &Bytes::from_slice(&env, b"batch_salt"),
+    );
+
+    env.ledger().with_mut(|l| l.timestamp = 1);
+
+    // execute_batch fails — predecessor not done
+    let result = client.try_execute_batch(&governor, &batch_id);
+    assert!(result.is_err(), "should block on predecessor");
+
+    // Execute predecessor
+    client.execute(&governor, &pred_op_id);
+    assert!(client.is_done(&pred_op_id));
+
+    // Now batch executes successfully
+    client.execute_batch(&governor, &batch_id);
+    assert!(client.is_batch_done(&batch_id));
 }
 
 #[test]

--- a/contracts/timelock/test_snapshots/test/test_batch_op_id_is_deterministic.1.json
+++ b/contracts/timelock/test_snapshots/test/test_batch_op_id_is_deterministic.1.json
@@ -1,0 +1,696 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u64": 0
+                },
+                {
+                  "u64": 1209600
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "schedule_batch",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "vec": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                {
+                  "vec": [
+                    {
+                      "bytes": ""
+                    }
+                  ]
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "exec"
+                    }
+                  ]
+                },
+                {
+                  "u64": 0
+                },
+                {
+                  "bytes": ""
+                },
+                {
+                  "bytes": "6d7973616c74"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "schedule_batch",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "vec": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                {
+                  "vec": [
+                    {
+                      "bytes": ""
+                    }
+                  ]
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "exec"
+                    }
+                  ]
+                },
+                {
+                  "u64": 0
+                },
+                {
+                  "bytes": ""
+                },
+                {
+                  "bytes": "6d7973616c74"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "schedule_batch",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "vec": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                {
+                  "vec": [
+                    {
+                      "bytes": ""
+                    }
+                  ]
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "exec"
+                    }
+                  ]
+                },
+                {
+                  "u64": 0
+                },
+                {
+                  "bytes": ""
+                },
+                {
+                  "bytes": "6f7468657273616c74"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "BatchOperation"
+                },
+                {
+                  "bytes": "1ff5ea5593db48e8db9473d92e3a753efa84c7208aa06e16de254eaa83d89546"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "BatchOperation"
+                    },
+                    {
+                      "bytes": "1ff5ea5593db48e8db9473d92e3a753efa84c7208aa06e16de254eaa83d89546"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "cancelled"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "datas"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "bytes": ""
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "executed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": 1209600
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fn_names"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "exec"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "predecessor"
+                      },
+                      "val": {
+                        "bytes": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "ready_at"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "targets"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "BatchOperation"
+                },
+                {
+                  "bytes": "d1c94016404faac21b9bb4cf57c7b61bed0f9f775cd1bc437712537477680420"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "BatchOperation"
+                    },
+                    {
+                      "bytes": "d1c94016404faac21b9bb4cf57c7b61bed0f9f775cd1bc437712537477680420"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "cancelled"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "datas"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "bytes": ""
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "executed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": 1209600
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fn_names"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "exec"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "predecessor"
+                      },
+                      "val": {
+                        "bytes": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "ready_at"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "targets"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ExecutionWindow"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 1209600
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Governor"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MinDelay"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4837995959683129791
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4837995959683129791
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "schbatch"
+              }
+            ],
+            "data": {
+              "bytes": "d1c94016404faac21b9bb4cf57c7b61bed0f9f775cd1bc437712537477680420"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/timelock/test_snapshots/test/test_batch_predecessor_enforcement.1.json
+++ b/contracts/timelock/test_snapshots/test/test_batch_predecessor_enforcement.1.json
@@ -1,0 +1,746 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u64": 0
+                },
+                {
+                  "u64": 1209600
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "schedule",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "bytes": ""
+                },
+                {
+                  "symbol": "exec"
+                },
+                {
+                  "u64": 0
+                },
+                {
+                  "bytes": ""
+                },
+                {
+                  "bytes": "707265645f73616c74"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "schedule_batch",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "vec": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                {
+                  "vec": [
+                    {
+                      "bytes": ""
+                    }
+                  ]
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "exec"
+                    }
+                  ]
+                },
+                {
+                  "u64": 0
+                },
+                {
+                  "bytes": "abda3946c8e3f8b5f9c4493e559b39c3baedb005ae4b7f65549b3d667d0ac24c"
+                },
+                {
+                  "bytes": "62617463685f73616c74"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "execute",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "abda3946c8e3f8b5f9c4493e559b39c3baedb005ae4b7f65549b3d667d0ac24c"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "execute_batch",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "5b66ac5cc8e7ba641c6f37987ebb72a893b350ff31d1c2a98a5a02ae29df5484"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 1,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "BatchOperation"
+                },
+                {
+                  "bytes": "5b66ac5cc8e7ba641c6f37987ebb72a893b350ff31d1c2a98a5a02ae29df5484"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "BatchOperation"
+                    },
+                    {
+                      "bytes": "5b66ac5cc8e7ba641c6f37987ebb72a893b350ff31d1c2a98a5a02ae29df5484"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "cancelled"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "datas"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "bytes": ""
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "executed"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": 1209600
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fn_names"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "exec"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "predecessor"
+                      },
+                      "val": {
+                        "bytes": "abda3946c8e3f8b5f9c4493e559b39c3baedb005ae4b7f65549b3d667d0ac24c"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "ready_at"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "targets"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Operation"
+                },
+                {
+                  "bytes": "abda3946c8e3f8b5f9c4493e559b39c3baedb005ae4b7f65549b3d667d0ac24c"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Operation"
+                    },
+                    {
+                      "bytes": "abda3946c8e3f8b5f9c4493e559b39c3baedb005ae4b7f65549b3d667d0ac24c"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "cancelled"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "data"
+                      },
+                      "val": {
+                        "bytes": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "executed"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": 1209600
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fn_name"
+                      },
+                      "val": {
+                        "symbol": "exec"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "predecessor"
+                      },
+                      "val": {
+                        "bytes": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "ready_at"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "target"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ExecutionWindow"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 1209600
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Governor"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MinDelay"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 2032731177588607455
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 2032731177588607455
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4270020994084947596
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4270020994084947596
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "symbol": "executed"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "symbol": "executed"
+                },
+                "durability": "persistent",
+                "val": {
+                  "bool": true
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/timelock/test_snapshots/test/test_cancel_batch.1.json
+++ b/contracts/timelock/test_snapshots/test/test_cancel_batch.1.json
@@ -1,0 +1,478 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u64": 0
+                },
+                {
+                  "u64": 1209600
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "schedule_batch",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "vec": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                {
+                  "vec": [
+                    {
+                      "bytes": ""
+                    }
+                  ]
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "exec"
+                    }
+                  ]
+                },
+                {
+                  "u64": 0
+                },
+                {
+                  "bytes": ""
+                },
+                {
+                  "bytes": "73616c74"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "cancel",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bytes": "d59aa3218004a3d0727577322c3f4404ebc2697e576c68548ab2a1edf9e105f3"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 1,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "BatchOperation"
+                },
+                {
+                  "bytes": "d59aa3218004a3d0727577322c3f4404ebc2697e576c68548ab2a1edf9e105f3"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "BatchOperation"
+                    },
+                    {
+                      "bytes": "d59aa3218004a3d0727577322c3f4404ebc2697e576c68548ab2a1edf9e105f3"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "cancelled"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "datas"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "bytes": ""
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "executed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": 1209600
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fn_names"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "exec"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "predecessor"
+                      },
+                      "val": {
+                        "bytes": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "ready_at"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "targets"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ExecutionWindow"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 1209600
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Governor"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MinDelay"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/timelock/test_snapshots/test/test_execute_batch_atomic.1.json
+++ b/contracts/timelock/test_snapshots/test/test_execute_batch_atomic.1.json
@@ -1,0 +1,595 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u64": 0
+                },
+                {
+                  "u64": 1209600
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "schedule_batch",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "vec": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    }
+                  ]
+                },
+                {
+                  "vec": [
+                    {
+                      "bytes": ""
+                    },
+                    {
+                      "bytes": ""
+                    }
+                  ]
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "exec"
+                    },
+                    {
+                      "symbol": "exec"
+                    }
+                  ]
+                },
+                {
+                  "u64": 0
+                },
+                {
+                  "bytes": ""
+                },
+                {
+                  "bytes": "73616c74"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "execute_batch",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "b5f8ea11bbda2fff9e325db8802ab142d5939b3d93d91b0f35cd9f79707bfa7f"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 1,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "BatchOperation"
+                },
+                {
+                  "bytes": "b5f8ea11bbda2fff9e325db8802ab142d5939b3d93d91b0f35cd9f79707bfa7f"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "BatchOperation"
+                    },
+                    {
+                      "bytes": "b5f8ea11bbda2fff9e325db8802ab142d5939b3d93d91b0f35cd9f79707bfa7f"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "cancelled"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "datas"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "bytes": ""
+                          },
+                          {
+                            "bytes": ""
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "executed"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": 1209600
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fn_names"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "exec"
+                          },
+                          {
+                            "symbol": "exec"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "predecessor"
+                      },
+                      "val": {
+                        "bytes": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "ready_at"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "targets"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ExecutionWindow"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 1209600
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Governor"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MinDelay"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "symbol": "executed"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "symbol": "executed"
+                },
+                "durability": "persistent",
+                "val": {
+                  "bool": true
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "symbol": "executed"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "executed"
+                },
+                "durability": "persistent",
+                "val": {
+                  "bool": true
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/timelock/test_snapshots/test/test_schedule_batch_returns_single_id_and_emits_event.1.json
+++ b/contracts/timelock/test_snapshots/test/test_schedule_batch_returns_single_id_and_emits_event.1.json
@@ -1,0 +1,428 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u64": 1
+                },
+                {
+                  "u64": 1209600
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "schedule_batch",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "vec": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    }
+                  ]
+                },
+                {
+                  "vec": [
+                    {
+                      "bytes": "0102"
+                    },
+                    {
+                      "bytes": "0304"
+                    }
+                  ]
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "ping"
+                    },
+                    {
+                      "symbol": "pong"
+                    }
+                  ]
+                },
+                {
+                  "u64": 10
+                },
+                {
+                  "bytes": ""
+                },
+                {
+                  "bytes": "09"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "BatchOperation"
+                },
+                {
+                  "bytes": "48d3127ce6c0353cb016835444413fc6edcee7e967207f385a89400ff7eaa535"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "BatchOperation"
+                    },
+                    {
+                      "bytes": "48d3127ce6c0353cb016835444413fc6edcee7e967207f385a89400ff7eaa535"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "cancelled"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "datas"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "bytes": "0102"
+                          },
+                          {
+                            "bytes": "0304"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "executed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": 1209610
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fn_names"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "ping"
+                          },
+                          {
+                            "symbol": "pong"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "predecessor"
+                      },
+                      "val": {
+                        "bytes": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "ready_at"
+                      },
+                      "val": {
+                        "u64": 10
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "targets"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ExecutionWindow"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 1209600
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Governor"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MinDelay"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "schbatch"
+              }
+            ],
+            "data": {
+              "bytes": "48d3127ce6c0353cb016835444413fc6edcee7e967207f385a89400ff7eaa535"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/sdk/src/timelock.ts
+++ b/sdk/src/timelock.ts
@@ -146,11 +146,21 @@ export class TimelockClient {
   }
 
   /**
-   * Schedule multiple timelock operations in a single transaction.
+   * Schedule multiple operations as a single atomic batch.
    *
-   * Every array argument must have the same length.
+   * All sub-operations share one `predecessor` and `salt`.  The contract
+   * returns a **single** hex-encoded `batch_op_id` covering the entire batch.
+   * Use {@link executeBatch} to run all sub-operations atomically.
    *
-   * @returns Hex-encoded operation IDs in the same order as the inputs.
+   * @param signer      - Keypair authorising the call (must be the governor signer)
+   * @param targets     - Contract addresses to invoke (one per sub-operation)
+   * @param data        - Encoded calldata for each target
+   * @param fnNames     - Function names for each target
+   * @param delay       - Delay in seconds; must be >= the contract's `minDelay`
+   * @param predecessor - Op-id of a previously completed operation that must
+   *                      execute before this batch (pass empty Buffer for none)
+   * @param salt        - Unique salt to disambiguate batches with identical inputs
+   * @returns Hex-encoded single batch op_id (SHA-256 of all tuples + predecessor + salt)
    */
   async scheduleBatch(
     signer: Keypair,
@@ -158,20 +168,15 @@ export class TimelockClient {
     data: Array<Buffer | Uint8Array>,
     fnNames: string[],
     delay: bigint,
-    predecessors: Array<Buffer | Uint8Array>,
-    salts: Array<Buffer | Uint8Array>,
-  ): Promise<string[]> {
+    predecessor: Buffer | Uint8Array,
+    salt: Buffer | Uint8Array,
+  ): Promise<string> {
     return this.retry(async () => {
       const len = targets.length;
       if (len === 0)
         throw new Error("scheduleBatch requires at least one operation");
-      if (
-        data.length !== len ||
-        fnNames.length !== len ||
-        predecessors.length !== len ||
-        salts.length !== len
-      ) {
-        throw new Error("scheduleBatch input arrays must have equal length");
+      if (data.length !== len || fnNames.length !== len) {
+        throw new Error("scheduleBatch: targets, data, and fnNames must have equal length");
       }
 
       const account = await this.server.getAccount(signer.publicKey());
@@ -183,12 +188,6 @@ export class TimelockClient {
       );
       const fnNamesScVal = xdr.ScVal.scvVec(
         fnNames.map((item) => nativeToScVal(item, { type: "symbol" })),
-      );
-      const predecessorsScVal = xdr.ScVal.scvVec(
-        predecessors.map((item) => nativeToScVal(item, { type: "bytes" })),
-      );
-      const saltsScVal = xdr.ScVal.scvVec(
-        salts.map((item) => nativeToScVal(item, { type: "bytes" })),
       );
 
       const tx = new TransactionBuilder(account, {
@@ -203,8 +202,8 @@ export class TimelockClient {
             dataScVal,
             fnNamesScVal,
             nativeToScVal(delay, { type: "u64" }),
-            predecessorsScVal,
-            saltsScVal,
+            nativeToScVal(predecessor, { type: "bytes" }),
+            nativeToScVal(salt, { type: "bytes" }),
           ),
         )
         .setTimeout(30)
@@ -222,8 +221,46 @@ export class TimelockClient {
       const returnVal = confirmed.returnValue;
       if (!returnVal) throw new Error("scheduleBatch: missing return value");
 
-      const rawIds = scValToNative(returnVal) as Uint8Array[];
-      return rawIds.map((bytes) => Buffer.from(bytes).toString("hex"));
+      const bytes = scValToNative(returnVal) as Uint8Array;
+      return Buffer.from(bytes).toString("hex");
+    }, (e) => this.isRetryableSubmissionError(e));
+  }
+
+  /**
+   * Execute a batch of operations atomically.
+   *
+   * All sub-operations run in sequence.  If any sub-call fails the entire
+   * transaction reverts and none of the sub-calls take effect.
+   *
+   * @param signer      - Keypair authorising the call (must be the governor signer)
+   * @param batchOpId   - Hex-encoded batch op_id returned by {@link scheduleBatch}
+   */
+  async executeBatch(signer: Keypair, batchOpId: string): Promise<void> {
+    return this.retry(async () => {
+      const account = await this.server.getAccount(signer.publicKey());
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(
+          this.contract.call(
+            "execute_batch",
+            nativeToScVal(signer.publicKey(), { type: "address" }),
+            nativeToScVal(Buffer.from(batchOpId, "hex"), { type: "bytes" }),
+          ),
+        )
+        .setTimeout(30)
+        .build();
+
+      const prepared = await this.server.prepareTransaction(tx);
+      prepared.sign(signer);
+
+      const result = await this.server.sendTransaction(prepared);
+      if (result.status === "ERROR") {
+        throw parseTimelockError(result);
+      }
+      await this.pollForConfirmation(result.hash);
     }, (e) => this.isRetryableSubmissionError(e));
   }
 


### PR DESCRIPTION
Fixes #344

## What changed

**Timelock contract (`contracts/timelock/src/lib.rs`)**
- Added `BatchOperation` struct stored under `DataKey::BatchOperation(batch_op_id)`
- `schedule_batch()` redesigned: now takes a single `predecessor: Bytes` + `salt: Bytes` and returns a **single** `batch_op_id` (SHA-256 of all `(target, data, fn_name)` tuples + predecessor + salt) — reduces N op_ids to 1
- `execute_batch()` added: atomic all-or-nothing execution — if any sub-call panics the entire transaction reverts
- `cancel()` updated to accept both single `Operation` and `BatchOperation` op_ids
- `validate_predecessor()` checks both `DataKey::Operation` and `DataKey::BatchOperation` for predecessor chains
- `is_batch_done()` query method
- `compute_batch_op_id()` deterministic helper exposed as a contract function

**Governor contract (`contracts/governor/src/lib.rs`)**
- `TimelockTrait` extended with `schedule_batch`, `execute_batch`, `is_batch_done`
- `queue()` uses `schedule_batch()` for multi-action proposals → 1 `batch_op_id` instead of N
- `execute()` calls `execute_batch()` for multi-action proposals (atomic execution)
- Fixed pre-existing duplicate `get_proposal` definition that prevented compilation

**SDK (`sdk/src/timelock.ts`)**
- `scheduleBatch()` updated to single `predecessor`/`salt`, returns a single hex string
- `executeBatch()` added

## Why
- Reduces storage costs by replacing N individual op_ids with 1 batch_op_id per proposal
- Provides atomic execution guarantees: all proposal actions execute or none do
- Deterministic batch_op_id makes scheduling idempotent

## How to test
```bash
# Timelock unit tests (21 tests)
cargo test -p sorogov-timelock

# Governor tests (42 tests)
cargo test -p sorogov-governor
```

Key new test cases:
- `test_schedule_batch_returns_single_id_and_emits_event` — returns one Bytes id
- `test_batch_op_id_is_deterministic` — same inputs = same id, different salt = different id
- `test_execute_batch_atomic` — both sub-calls execute, batch marked done, re-execution blocked
- `test_cancel_batch` — cancel() accepts batch_op_id, blocks execute_batch
- `test_batch_predecessor_enforcement` — batch blocks until predecessor single op is done