### PR TITLE
feat(ui): add skeleton loading states for all data-fetching pages (#347)

### DIFF
--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -1,0 +1,8 @@
+import createNextIntlPlugin from "next-intl/plugin";
+
+const withNextIntl = createNextIntlPlugin("./src/i18n.ts");
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default withNextIntl(nextConfig);

--- a/app/src/app/analytics/page.tsx
+++ b/app/src/app/analytics/page.tsx
@@ -19,14 +19,11 @@ import {
 import { useTheme } from "../../hooks/useTheme";
 import { useEffect, useMemo, useState } from "react";
 import { Network, VotesClient } from "@nebgov/sdk";
+import { Skeleton } from "../../components/ui/Skeleton";
 
 const COLORS = ["#60a5fa", "#34d399", "#f97316", "#f87171", "#a78bfa"];
 
 type TimeRange = "7d" | "30d" | "all";
-
-function Skeleton({ className }: { className?: string }) {
-  return <div className={`bg-gray-200 dark:bg-gray-700 animate-pulse rounded ${className ?? ""}`} />;
-}
 
 export default function AnalyticsPage() {
   const { theme } = useTheme();

--- a/app/src/app/analytics/page.tsx
+++ b/app/src/app/analytics/page.tsx
@@ -32,7 +32,9 @@ export default function AnalyticsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [proposals, setProposals] = useState<any[]>([]);
-  const [topDelegates, setTopDelegates] = useState<Array<{ name: string; votes: number }>>([]);
+  const [topDelegates, setTopDelegates] = useState<
+    Array<{ name: string; votes: number }>
+  >([]);
   const [summary, setSummary] = useState<{
     totalProposals: number;
     totalUniqueVoters: number;
@@ -69,14 +71,19 @@ export default function AnalyticsPage() {
         const governorAddress = process.env.NEXT_PUBLIC_GOVERNOR_ADDRESS;
         const timelockAddress = process.env.NEXT_PUBLIC_TIMELOCK_ADDRESS;
         const votesAddress = process.env.NEXT_PUBLIC_VOTES_ADDRESS;
-        const network = (process.env.NEXT_PUBLIC_NETWORK || "testnet") as Network;
+        const network = (process.env.NEXT_PUBLIC_NETWORK ||
+          "testnet") as Network;
         const rpcUrl = process.env.NEXT_PUBLIC_RPC_URL;
 
         if (!indexerUrl) {
-          throw new Error("Missing NEXT_PUBLIC_INDEXER_URL. Analytics requires the indexer API.");
+          throw new Error(
+            "Missing NEXT_PUBLIC_INDEXER_URL. Analytics requires the indexer API.",
+          );
         }
         if (!governorAddress || !timelockAddress || !votesAddress) {
-          throw new Error("Missing required environment variables. Please check .env.local configuration.");
+          throw new Error(
+            "Missing required environment variables. Please check .env.local configuration.",
+          );
         }
 
         const votesClient = new VotesClient({
@@ -87,16 +94,20 @@ export default function AnalyticsPage() {
           ...(rpcUrl && { rpcUrl }),
         });
 
-        const [summaryResp, delegatesResp, statsResp, supply] = await Promise.all([
-          fetch(`${indexerUrl}/analytics/summary`, { cache: "no-store" }),
-          fetch(`${indexerUrl}/delegates?top=10`, { cache: "no-store" }),
-          fetch(`${indexerUrl}/stats`, { cache: "no-store" }),
-          votesClient.getTotalSupply(),
-        ]);
+        const [summaryResp, delegatesResp, statsResp, supply] =
+          await Promise.all([
+            fetch(`${indexerUrl}/analytics/summary`, { cache: "no-store" }),
+            fetch(`${indexerUrl}/delegates?top=10`, { cache: "no-store" }),
+            fetch(`${indexerUrl}/stats`, { cache: "no-store" }),
+            votesClient.getTotalSupply(),
+          ]);
 
-        if (!summaryResp.ok) throw new Error(`Indexer error: ${summaryResp.status}`);
-        if (!delegatesResp.ok) throw new Error(`Indexer error: ${delegatesResp.status}`);
-        if (!statsResp.ok) throw new Error(`Indexer error: ${statsResp.status}`);
+        if (!summaryResp.ok)
+          throw new Error(`Indexer error: ${summaryResp.status}`);
+        if (!delegatesResp.ok)
+          throw new Error(`Indexer error: ${delegatesResp.status}`);
+        if (!statsResp.ok)
+          throw new Error(`Indexer error: ${statsResp.status}`);
 
         const [summaryJson, delegatesJson, statsJson] = await Promise.all([
           summaryResp.json(),
@@ -180,7 +191,9 @@ export default function AnalyticsPage() {
           Number(p.votes_against ?? 0) +
           Number(p.votes_abstain ?? 0);
         const participation = supply > 0 ? (totalVotes / supply) * 100 : 0;
-        const date = p.created_at ? new Date(p.created_at).toLocaleDateString() : `#${p.id}`;
+        const date = p.created_at
+          ? new Date(p.created_at).toLocaleDateString()
+          : `#${p.id}`;
         return { date, participation: Number(participation.toFixed(2)) };
       });
   }, [proposals, totalSupply]);
@@ -189,7 +202,10 @@ export default function AnalyticsPage() {
     const executed = summary?.outcomes.executed ?? 0;
     const cancelled = summary?.outcomes.cancelled ?? 0;
     const queued = summary?.outcomes.queued ?? 0;
-    const other = Math.max(0, (summary?.totalProposals ?? 0) - executed - cancelled - queued);
+    const other = Math.max(
+      0,
+      (summary?.totalProposals ?? 0) - executed - cancelled - queued,
+    );
     return [
       { name: "Executed", value: executed },
       { name: "Cancelled", value: cancelled },
@@ -201,15 +217,24 @@ export default function AnalyticsPage() {
   const avgParticipationPct = useMemo(() => {
     if (!summary) return 0;
     if (totalSupply <= 0n) return 0;
-    return Number(((Number(summary.averageVotesPerProposal) / Number(totalSupply)) * 100).toFixed(2));
+    return Number(
+      (
+        (Number(summary.averageVotesPerProposal) / Number(totalSupply)) *
+        100
+      ).toFixed(2),
+    );
   }, [summary, totalSupply]);
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-8">
       <div className="flex items-center justify-between mb-8">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Analytics</h1>
-          <p className="text-gray-500 dark:text-gray-400 mt-1">Participation and voting trends.</p>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+            Analytics
+          </h1>
+          <p className="text-gray-500 dark:text-gray-400 mt-1">
+            Participation and voting trends.
+          </p>
         </div>
         <div className="flex gap-3">
           <a
@@ -267,70 +292,105 @@ export default function AnalyticsPage() {
 
       {error && (
         <div className="mb-6 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl p-4">
-          <p className="text-red-800 dark:text-red-200 font-medium">Failed to load analytics</p>
+          <p className="text-red-800 dark:text-red-200 font-medium">
+            Failed to load analytics
+          </p>
           <p className="text-red-700 dark:text-red-300 text-sm mt-1">{error}</p>
         </div>
       )}
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
         <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4">
-          <p className="text-sm text-gray-500 dark:text-gray-400">Total proposals</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Total proposals
+          </p>
           {loading ? (
             <Skeleton className="h-7 w-16 mt-2" />
           ) : (
-            <p className="text-2xl font-semibold text-gray-900 dark:text-white">{stats?.total_proposals ?? summary?.totalProposals ?? 0}</p>
+            <p className="text-2xl font-semibold text-gray-900 dark:text-white">
+              {stats?.total_proposals ?? summary?.totalProposals ?? 0}
+            </p>
           )}
         </div>
         <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4">
-          <p className="text-sm text-gray-500 dark:text-gray-400">Active proposals</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Active proposals
+          </p>
           {loading ? (
             <Skeleton className="h-7 w-16 mt-2" />
           ) : (
-            <p className="text-2xl font-semibold text-gray-900 dark:text-white">{stats?.active_proposals ?? 0}</p>
+            <p className="text-2xl font-semibold text-gray-900 dark:text-white">
+              {stats?.active_proposals ?? 0}
+            </p>
           )}
         </div>
         <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4">
-          <p className="text-sm text-gray-500 dark:text-gray-400">Unique voters</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Unique voters
+          </p>
           {loading ? (
             <Skeleton className="h-7 w-20 mt-2" />
           ) : (
-            <p className="text-2xl font-semibold text-gray-900 dark:text-white">{stats?.unique_voters ?? summary?.totalUniqueVoters ?? 0}</p>
+            <p className="text-2xl font-semibold text-gray-900 dark:text-white">
+              {stats?.unique_voters ?? summary?.totalUniqueVoters ?? 0}
+            </p>
           )}
         </div>
         <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4">
-          <p className="text-sm text-gray-500 dark:text-gray-400">Participation rate</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Participation rate
+          </p>
           {loading ? (
             <Skeleton className="h-7 w-16 mt-2" />
           ) : (
-            <p className="text-2xl font-semibold text-gray-900 dark:text-white">{((stats?.participation_rate ?? avgParticipationPct) * 100).toFixed(1)}%</p>
+            <p className="text-2xl font-semibold text-gray-900 dark:text-white">
+              {(
+                (stats?.participation_rate ?? avgParticipationPct) * 100
+              ).toFixed(1)}
+              %
+            </p>
           )}
         </div>
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
         <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4">
-          <p className="text-sm text-gray-500 dark:text-gray-400">Total votes cast</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Total votes cast
+          </p>
           {loading ? (
             <Skeleton className="h-7 w-16 mt-2" />
           ) : (
-            <p className="text-2xl font-semibold text-gray-900 dark:text-white">{stats?.total_votes_cast ?? 0}</p>
+            <p className="text-2xl font-semibold text-gray-900 dark:text-white">
+              {stats?.total_votes_cast ?? 0}
+            </p>
           )}
         </div>
         <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4">
-          <p className="text-sm text-gray-500 dark:text-gray-400">Total delegates</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Total delegates
+          </p>
           {loading ? (
             <Skeleton className="h-7 w-16 mt-2" />
           ) : (
-            <p className="text-2xl font-semibold text-gray-900 dark:text-white">{stats?.total_delegates ?? 0}</p>
+            <p className="text-2xl font-semibold text-gray-900 dark:text-white">
+              {stats?.total_delegates ?? 0}
+            </p>
           )}
         </div>
         <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4">
-          <p className="text-sm text-gray-500 dark:text-gray-400">Most active proposer</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Most active proposer
+          </p>
           {loading ? (
             <Skeleton className="h-7 w-32 mt-2" />
           ) : (
             <p className="text-sm font-semibold text-gray-900 dark:text-white mt-2">
-              {(summary?.mostActiveProposers?.[0]?.proposer ?? "—").slice(0, 10)}…
+              {(summary?.mostActiveProposers?.[0]?.proposer ?? "—").slice(
+                0,
+                10,
+              )}
+              …
               <span className="text-gray-500 dark:text-gray-400 font-normal">
                 {" "}
                 ({summary?.mostActiveProposers?.[0]?.count ?? 0})
@@ -339,12 +399,16 @@ export default function AnalyticsPage() {
           )}
         </div>
         <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4">
-          <p className="text-sm text-gray-500 dark:text-gray-400">Last updated</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Last updated
+          </p>
           {loading ? (
             <Skeleton className="h-7 w-28 mt-2" />
           ) : (
             <p className="text-sm font-semibold text-gray-900 dark:text-white mt-2">
-              {stats?.last_updated ? new Date(stats.last_updated).toLocaleDateString() : "—"}
+              {stats?.last_updated
+                ? new Date(stats.last_updated).toLocaleDateString()
+                : "—"}
             </p>
           )}
         </div>
@@ -352,35 +416,75 @@ export default function AnalyticsPage() {
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4">
-          <h3 className="text-sm font-semibold text-gray-600 dark:text-gray-400 mb-4">Participation Over Time</h3>
+          <h3 className="text-sm font-semibold text-gray-600 dark:text-gray-400 mb-4">
+            Participation Over Time
+          </h3>
           <div style={{ width: "100%", height: 240 }}>
             <ResponsiveContainer width="100%" height={240}>
-              <LineChart data={participationData} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
-                <XAxis dataKey="date" tick={{ fill: chartTheme.textColor }} axisLine={{ stroke: chartTheme.gridColor }} tickLine={{ stroke: chartTheme.gridColor }} />
-                <YAxis tick={{ fill: chartTheme.textColor }} axisLine={{ stroke: chartTheme.gridColor }} tickLine={{ stroke: chartTheme.gridColor }} unit="%" />
-                <Tooltip 
-                  contentStyle={{ backgroundColor: chartTheme.tooltipBg, borderColor: chartTheme.tooltipBorder, color: isDark ? '#fff' : '#000' }}
-                  itemStyle={{ color: isDark ? '#fff' : '#000' }}
+              <LineChart
+                data={participationData}
+                margin={{ top: 5, right: 20, left: 0, bottom: 5 }}
+              >
+                <XAxis
+                  dataKey="date"
+                  tick={{ fill: chartTheme.textColor }}
+                  axisLine={{ stroke: chartTheme.gridColor }}
+                  tickLine={{ stroke: chartTheme.gridColor }}
                 />
-                <Line type="monotone" dataKey="participation" stroke="#6366f1" strokeWidth={2} />
+                <YAxis
+                  tick={{ fill: chartTheme.textColor }}
+                  axisLine={{ stroke: chartTheme.gridColor }}
+                  tickLine={{ stroke: chartTheme.gridColor }}
+                  unit="%"
+                />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: chartTheme.tooltipBg,
+                    borderColor: chartTheme.tooltipBorder,
+                    color: isDark ? "#fff" : "#000",
+                  }}
+                  itemStyle={{ color: isDark ? "#fff" : "#000" }}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="participation"
+                  stroke="#6366f1"
+                  strokeWidth={2}
+                />
               </LineChart>
             </ResponsiveContainer>
           </div>
         </div>
 
         <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4">
-          <h3 className="text-sm font-semibold text-gray-600 dark:text-gray-400 mb-4">Proposal Outcomes</h3>
+          <h3 className="text-sm font-semibold text-gray-600 dark:text-gray-400 mb-4">
+            Proposal Outcomes
+          </h3>
           <div style={{ width: "100%", height: 220 }}>
             <ResponsiveContainer width="100%" height={220}>
               <PieChart>
-                <Pie data={outcomeData} dataKey="value" nameKey="name" innerRadius={40} outerRadius={80} paddingAngle={4}>
+                <Pie
+                  data={outcomeData}
+                  dataKey="value"
+                  nameKey="name"
+                  innerRadius={40}
+                  outerRadius={80}
+                  paddingAngle={4}
+                >
                   {outcomeData.map((entry, index) => (
-                    <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                    <Cell
+                      key={`cell-${index}`}
+                      fill={COLORS[index % COLORS.length]}
+                    />
                   ))}
                 </Pie>
-                <Tooltip 
-                  contentStyle={{ backgroundColor: chartTheme.tooltipBg, borderColor: chartTheme.tooltipBorder, color: isDark ? '#fff' : '#000' }}
-                  itemStyle={{ color: isDark ? '#fff' : '#000' }}
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: chartTheme.tooltipBg,
+                    borderColor: chartTheme.tooltipBorder,
+                    color: isDark ? "#fff" : "#000",
+                  }}
+                  itemStyle={{ color: isDark ? "#fff" : "#000" }}
                 />
                 <Legend />
               </PieChart>
@@ -389,20 +493,48 @@ export default function AnalyticsPage() {
         </div>
 
         <div className="lg:col-span-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4">
-          <h3 className="text-sm font-semibold text-gray-600 dark:text-gray-400 mb-4">Top Delegates (by delegators)</h3>
+          <h3 className="text-sm font-semibold text-gray-600 dark:text-gray-400 mb-4">
+            Top Delegates (by delegators)
+          </h3>
           <div style={{ width: "100%", height: 220 }}>
             <ResponsiveContainer width="100%" height={220}>
-              <BarChart data={topDelegates} layout="vertical" margin={{ top: 5, right: 30, left: 50, bottom: 5 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke={chartTheme.gridColor} />
-                <XAxis type="number" tick={{ fill: chartTheme.textColor }} axisLine={{ stroke: chartTheme.gridColor }} tickLine={{ stroke: chartTheme.gridColor }} />
-                <YAxis type="category" dataKey="name" width={120} tick={{ fill: chartTheme.textColor }} axisLine={{ stroke: chartTheme.gridColor }} tickLine={{ stroke: chartTheme.gridColor }} />
-                <Tooltip 
-                  contentStyle={{ backgroundColor: chartTheme.tooltipBg, borderColor: chartTheme.tooltipBorder, color: isDark ? '#fff' : '#000' }}
-                  itemStyle={{ color: isDark ? '#fff' : '#000' }}
+              <BarChart
+                data={topDelegates}
+                layout="vertical"
+                margin={{ top: 5, right: 30, left: 50, bottom: 5 }}
+              >
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  stroke={chartTheme.gridColor}
+                />
+                <XAxis
+                  type="number"
+                  tick={{ fill: chartTheme.textColor }}
+                  axisLine={{ stroke: chartTheme.gridColor }}
+                  tickLine={{ stroke: chartTheme.gridColor }}
+                />
+                <YAxis
+                  type="category"
+                  dataKey="name"
+                  width={120}
+                  tick={{ fill: chartTheme.textColor }}
+                  axisLine={{ stroke: chartTheme.gridColor }}
+                  tickLine={{ stroke: chartTheme.gridColor }}
+                />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: chartTheme.tooltipBg,
+                    borderColor: chartTheme.tooltipBorder,
+                    color: isDark ? "#fff" : "#000",
+                  }}
+                  itemStyle={{ color: isDark ? "#fff" : "#000" }}
                 />
                 <Bar dataKey="votes" fill="#60a5fa">
                   {topDelegates.map((_, idx) => (
-                    <Cell key={`bar-${idx}`} fill={COLORS[idx % COLORS.length]} />
+                    <Cell
+                      key={`bar-${idx}`}
+                      fill={COLORS[idx % COLORS.length]}
+                    />
                   ))}
                 </Bar>
               </BarChart>

--- a/app/src/app/delegates/page.tsx
+++ b/app/src/app/delegates/page.tsx
@@ -5,15 +5,16 @@ import Link from "next/link";
 import { VotesClient, type TopDelegate, type Network } from "@nebgov/sdk";
 import { useWallet } from "../../lib/wallet-context";
 import { DelegateModal } from "../../components/DelegateModal";
+import { Skeleton } from "../../components/ui/Skeleton";
 
 function DelegateSkeleton() {
   return (
-    <tr className="animate-pulse">
-      <td className="py-4 px-4"><div className="h-4 bg-gray-200 rounded w-6"></div></td>
-      <td className="py-4 px-4"><div className="h-4 bg-gray-200 rounded w-32"></div></td>
-      <td className="py-4 px-4"><div className="h-4 bg-gray-200 rounded w-20"></div></td>
-      <td className="py-4 px-4"><div className="h-2 bg-gray-200 rounded w-full"></div></td>
-      <td className="py-4 px-4"><div className="h-8 bg-gray-200 rounded w-20"></div></td>
+    <tr>
+      <td className="py-4 px-4"><Skeleton className="h-4 w-6" /></td>
+      <td className="py-4 px-4"><Skeleton className="h-4 w-32" /></td>
+      <td className="py-4 px-4"><Skeleton className="h-4 w-20" /></td>
+      <td className="py-4 px-4"><Skeleton className="h-2 w-full" /></td>
+      <td className="py-4 px-4"><Skeleton className="h-8 w-20" /></td>
     </tr>
   );
 }

--- a/app/src/app/delegates/page.tsx
+++ b/app/src/app/delegates/page.tsx
@@ -10,11 +10,21 @@ import { Skeleton } from "../../components/ui/Skeleton";
 function DelegateSkeleton() {
   return (
     <tr>
-      <td className="py-4 px-4"><Skeleton className="h-4 w-6" /></td>
-      <td className="py-4 px-4"><Skeleton className="h-4 w-32" /></td>
-      <td className="py-4 px-4"><Skeleton className="h-4 w-20" /></td>
-      <td className="py-4 px-4"><Skeleton className="h-2 w-full" /></td>
-      <td className="py-4 px-4"><Skeleton className="h-8 w-20" /></td>
+      <td className="py-4 px-4">
+        <Skeleton className="h-4 w-6" />
+      </td>
+      <td className="py-4 px-4">
+        <Skeleton className="h-4 w-32" />
+      </td>
+      <td className="py-4 px-4">
+        <Skeleton className="h-4 w-20" />
+      </td>
+      <td className="py-4 px-4">
+        <Skeleton className="h-2 w-full" />
+      </td>
+      <td className="py-4 px-4">
+        <Skeleton className="h-8 w-20" />
+      </td>
     </tr>
   );
 }
@@ -47,7 +57,8 @@ export default function DelegatesPage() {
         const governorAddress = process.env.NEXT_PUBLIC_GOVERNOR_ADDRESS;
         const timelockAddress = process.env.NEXT_PUBLIC_TIMELOCK_ADDRESS;
         const votesAddress = process.env.NEXT_PUBLIC_VOTES_ADDRESS;
-        const network = (process.env.NEXT_PUBLIC_NETWORK || "testnet") as Network;
+        const network = (process.env.NEXT_PUBLIC_NETWORK ||
+          "testnet") as Network;
         const rpcUrl = process.env.NEXT_PUBLIC_RPC_URL;
 
         if (!governorAddress || !timelockAddress || !votesAddress) {
@@ -77,7 +88,9 @@ export default function DelegatesPage() {
         }
       } catch (err) {
         console.error("Error fetching delegates:", err);
-        setError(err instanceof Error ? err.message : "Failed to load delegates");
+        setError(
+          err instanceof Error ? err.message : "Failed to load delegates",
+        );
       } finally {
         setLoading(false);
       }
@@ -91,9 +104,10 @@ export default function DelegatesPage() {
     setModalOpen(true);
   }
 
-  const delegatedPercent = totalSupply > 0n
-    ? Number((totalDelegated * 10000n) / totalSupply) / 100
-    : 0;
+  const delegatedPercent =
+    totalSupply > 0n
+      ? Number((totalDelegated * 10000n) / totalSupply) / 100
+      : 0;
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8">
@@ -120,7 +134,8 @@ export default function DelegatesPage() {
           <div className="flex justify-between items-center mb-2">
             <span className="text-sm text-gray-600">Total Delegated</span>
             <span className="text-sm font-medium text-gray-900">
-              {formatVotes(totalDelegated)} / {formatVotes(totalSupply)} ({delegatedPercent.toFixed(1)}%)
+              {formatVotes(totalDelegated)} / {formatVotes(totalSupply)} (
+              {delegatedPercent.toFixed(1)}%)
             </span>
           </div>
           <div className="w-full bg-gray-200 rounded-full h-2">
@@ -134,7 +149,9 @@ export default function DelegatesPage() {
 
       {error && (
         <div className="bg-red-50 border border-red-200 rounded-xl p-4 mb-6">
-          <p className="text-red-800 text-sm font-medium">Error loading delegates</p>
+          <p className="text-red-800 text-sm font-medium">
+            Error loading delegates
+          </p>
           <p className="text-red-600 text-sm mt-1">{error}</p>
         </div>
       )}
@@ -143,11 +160,21 @@ export default function DelegatesPage() {
         <table className="w-full">
           <thead className="bg-gray-50 border-b border-gray-200">
             <tr>
-              <th className="py-3 px-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">#</th>
-              <th className="py-3 px-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Delegate</th>
-              <th className="py-3 px-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Votes</th>
-              <th className="py-3 px-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">% of Supply</th>
-              <th className="py-3 px-4 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Action</th>
+              <th className="py-3 px-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                #
+              </th>
+              <th className="py-3 px-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Delegate
+              </th>
+              <th className="py-3 px-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Votes
+              </th>
+              <th className="py-3 px-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                % of Supply
+              </th>
+              <th className="py-3 px-4 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Action
+              </th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-200">
@@ -167,57 +194,65 @@ export default function DelegatesPage() {
               </tr>
             )}
 
-            {!loading && delegates.map((delegate, index) => {
-              const isCurrentUser = publicKey === delegate.address;
-              const percentOfSupply =
-                totalSupply > 0n
-                  ? Number((delegate.votingPower * 10000n) / totalSupply) / 100
-                  : 0;
-              return (
-                <tr
-                  key={delegate.address}
-                  className={isCurrentUser ? "bg-indigo-50" : "hover:bg-gray-50"}
-                >
-                  <td className="py-4 px-4 text-sm text-gray-500">{index + 1}</td>
-                  <td className="py-4 px-4">
-                    <div className="flex items-center gap-2">
-                      <span className="font-mono text-sm text-gray-900">
-                        {formatAddress(delegate.address)}
-                      </span>
-                      {isCurrentUser && (
-                        <span className="text-xs bg-indigo-100 text-indigo-700 px-2 py-0.5 rounded">
-                          You
+            {!loading &&
+              delegates.map((delegate, index) => {
+                const isCurrentUser = publicKey === delegate.address;
+                const percentOfSupply =
+                  totalSupply > 0n
+                    ? Number((delegate.votingPower * 10000n) / totalSupply) /
+                      100
+                    : 0;
+                return (
+                  <tr
+                    key={delegate.address}
+                    className={
+                      isCurrentUser ? "bg-indigo-50" : "hover:bg-gray-50"
+                    }
+                  >
+                    <td className="py-4 px-4 text-sm text-gray-500">
+                      {index + 1}
+                    </td>
+                    <td className="py-4 px-4">
+                      <div className="flex items-center gap-2">
+                        <span className="font-mono text-sm text-gray-900">
+                          {formatAddress(delegate.address)}
                         </span>
-                      )}
-                    </div>
-                  </td>
-                  <td className="py-4 px-4 text-sm font-medium text-gray-900">
-                    {formatVotes(delegate.votingPower)}
-                  </td>
-                  <td className="py-4 px-4">
-                    <div className="flex items-center gap-2">
-                      <div className="flex-1 bg-gray-200 rounded-full h-2 max-w-[100px]">
-                        <div
-                          className="bg-indigo-600 h-2 rounded-full"
-                          style={{ width: `${Math.min(percentOfSupply * 2, 100)}%` }}
-                        />
+                        {isCurrentUser && (
+                          <span className="text-xs bg-indigo-100 text-indigo-700 px-2 py-0.5 rounded">
+                            You
+                          </span>
+                        )}
                       </div>
-                      <span className="text-sm text-gray-500">
-                        {percentOfSupply.toFixed(1)}%
-                      </span>
-                    </div>
-                  </td>
-                  <td className="py-4 px-4 text-right">
-                    <button
-                      onClick={() => handleDelegateClick(delegate.address)}
-                      className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
-                    >
-                      Delegate
-                    </button>
-                  </td>
-                </tr>
-              );
-            })}
+                    </td>
+                    <td className="py-4 px-4 text-sm font-medium text-gray-900">
+                      {formatVotes(delegate.votingPower)}
+                    </td>
+                    <td className="py-4 px-4">
+                      <div className="flex items-center gap-2">
+                        <div className="flex-1 bg-gray-200 rounded-full h-2 max-w-[100px]">
+                          <div
+                            className="bg-indigo-600 h-2 rounded-full"
+                            style={{
+                              width: `${Math.min(percentOfSupply * 2, 100)}%`,
+                            }}
+                          />
+                        </div>
+                        <span className="text-sm text-gray-500">
+                          {percentOfSupply.toFixed(1)}%
+                        </span>
+                      </div>
+                    </td>
+                    <td className="py-4 px-4 text-right">
+                      <button
+                        onClick={() => handleDelegateClick(delegate.address)}
+                        className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+                      >
+                        Delegate
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
           </tbody>
         </table>
       </div>

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -40,7 +40,9 @@ function ProposalsPageInner() {
   const searchParams = useSearchParams();
 
   const search = searchParams.get("q") ?? "";
-  const stateFilter = (searchParams.get("state") ?? "all") as ProposalState | "all";
+  const stateFilter = (searchParams.get("state") ?? "all") as
+    | ProposalState
+    | "all";
   const sort = (searchParams.get("sort") ?? "newest") as SortOption;
 
   const [proposals, setProposals] = useState<ProposalSummary[]>([]);
@@ -74,10 +76,12 @@ function ProposalsPageInner() {
       sorted.sort((a, b) => (b.id > a.id ? 1 : b.id < a.id ? -1 : 0));
     } else if (sort === "most-votes") {
       sorted.sort((a, b) =>
-        Number((b.votesFor + b.votesAgainst) - (a.votesFor + a.votesAgainst))
+        Number(b.votesFor + b.votesAgainst - (a.votesFor + a.votesAgainst)),
       );
     } else if (sort === "ending-soon") {
-      sorted.sort((a, b) => (a.endLedger || Infinity) - (b.endLedger || Infinity));
+      sorted.sort(
+        (a, b) => (a.endLedger || Infinity) - (b.endLedger || Infinity),
+      );
     }
     return sorted;
   }, [proposals, stateFilter, search, sort]);
@@ -123,7 +127,10 @@ function ProposalsPageInner() {
             return;
           }
         } catch (indexerError) {
-          console.warn("Indexer failed, falling back to on-chain queries:", indexerError);
+          console.warn(
+            "Indexer failed, falling back to on-chain queries:",
+            indexerError,
+          );
         }
       }
 
@@ -175,7 +182,9 @@ function ProposalsPageInner() {
       }
 
       const results = await Promise.all(proposalPromises);
-      const validProposals = results.filter((p): p is ProposalSummary => p !== null);
+      const validProposals = results.filter(
+        (p): p is ProposalSummary => p !== null,
+      );
 
       if (append) {
         setProposals((prev) => [...prev, ...validProposals]);
@@ -215,7 +224,9 @@ function ProposalsPageInner() {
       <div className="flex items-center justify-between mb-6">
         <div>
           <h1 className="text-3xl font-bold text-gray-900">Proposals</h1>
-          <p className="text-gray-500 mt-1">Vote on governance decisions for this protocol.</p>
+          <p className="text-gray-500 mt-1">
+            Vote on governance decisions for this protocol.
+          </p>
         </div>
         <Link
           href="/propose"
@@ -248,7 +259,11 @@ function ProposalsPageInner() {
       </div>
 
       {/* Status filter tabs */}
-      <div className="flex flex-wrap gap-2 mb-6" role="group" aria-label="Filter by status">
+      <div
+        className="flex flex-wrap gap-2 mb-6"
+        role="group"
+        aria-label="Filter by status"
+      >
         <button
           onClick={() => setParam("state", "all", "all")}
           className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-colors ${
@@ -277,7 +292,9 @@ function ProposalsPageInner() {
       {/* Error */}
       {error && (
         <div className="bg-red-50 border border-red-200 rounded-xl p-4 mb-6">
-          <p className="text-red-800 text-sm font-medium">Error loading proposals</p>
+          <p className="text-red-800 text-sm font-medium">
+            Error loading proposals
+          </p>
           <p className="text-red-600 text-sm mt-1">{error}</p>
         </div>
       )}
@@ -294,12 +311,25 @@ function ProposalsPageInner() {
       {/* Empty — no proposals at all */}
       {!loading && !error && proposals.length === 0 && (
         <div className="text-center py-16">
-          <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+          <svg
+            className="mx-auto h-12 w-12 text-gray-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+            />
           </svg>
-          <h3 className="mt-2 text-sm font-medium text-gray-900">No proposals</h3>
-          <p className="mt-1 text-sm text-gray-500">Get started by creating a new proposal.</p>
+          <h3 className="mt-2 text-sm font-medium text-gray-900">
+            No proposals
+          </h3>
+          <p className="mt-1 text-sm text-gray-500">
+            Get started by creating a new proposal.
+          </p>
           <div className="mt-6">
             <Link
               href="/propose"
@@ -314,7 +344,9 @@ function ProposalsPageInner() {
       {/* Empty — filters produced no results */}
       {!loading && !error && proposals.length > 0 && filtered.length === 0 && (
         <div className="text-center py-12">
-          <p className="text-gray-500 text-sm">No proposals match your current filters.</p>
+          <p className="text-gray-500 text-sm">
+            No proposals match your current filters.
+          </p>
           <button
             onClick={() => router.replace("?")}
             className="mt-3 text-indigo-600 text-sm hover:underline"
@@ -336,13 +368,20 @@ function ProposalsPageInner() {
               >
                 <div className="flex items-start justify-between">
                   <div className="flex-1 min-w-0">
-                    <p className="text-xs text-gray-400 mb-1">Proposal #{p.id.toString()}</p>
+                    <p className="text-xs text-gray-400 mb-1">
+                      Proposal #{p.id.toString()}
+                    </p>
                     <h2 className="text-lg font-semibold text-gray-900 truncate">
                       {p.description}
                     </h2>
                     <div className="mt-3 flex items-center gap-4 text-sm text-gray-500">
-                      <span>For: {(Number(p.votesFor) / 1e7).toLocaleString()}</span>
-                      <span>Against: {(Number(p.votesAgainst) / 1e7).toLocaleString()}</span>
+                      <span>
+                        For: {(Number(p.votesFor) / 1e7).toLocaleString()}
+                      </span>
+                      <span>
+                        Against:{" "}
+                        {(Number(p.votesAgainst) / 1e7).toLocaleString()}
+                      </span>
                     </div>
                   </div>
                   <span

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -8,6 +8,7 @@ import { useState, useEffect, useMemo, Suspense } from "react";
 import Link from "next/link";
 import { useSearchParams, useRouter } from "next/navigation";
 import { GovernorClient, ProposalState, Network } from "@nebgov/sdk";
+import { ProposalCardSkeleton } from "../components/ui/ProposalCardSkeleton";
 
 interface ProposalSummary {
   id: bigint;
@@ -33,24 +34,6 @@ const ALL_STATES = Object.values(ProposalState);
 type SortOption = "newest" | "most-votes" | "ending-soon";
 
 const PROPOSALS_PER_PAGE = 10;
-
-function ProposalSkeleton() {
-  return (
-    <div className="block bg-white border border-gray-200 rounded-xl p-6 animate-pulse">
-      <div className="flex items-start justify-between">
-        <div className="flex-1 min-w-0">
-          <div className="h-3 bg-gray-200 rounded w-24 mb-2"></div>
-          <div className="h-5 bg-gray-200 rounded w-3/4 mb-3"></div>
-          <div className="flex items-center gap-4">
-            <div className="h-4 bg-gray-200 rounded w-20"></div>
-            <div className="h-4 bg-gray-200 rounded w-20"></div>
-          </div>
-        </div>
-        <div className="ml-4 h-6 bg-gray-200 rounded-full w-20"></div>
-      </div>
-    </div>
-  );
-}
 
 function ProposalsPageInner() {
   const router = useRouter();
@@ -302,8 +285,8 @@ function ProposalsPageInner() {
       {/* Loading skeleton */}
       {loading && (
         <div className="space-y-4">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <ProposalSkeleton key={i} />
+          {Array.from({ length: 10 }).map((_, i) => (
+            <ProposalCardSkeleton key={i} />
           ))}
         </div>
       )}
@@ -397,11 +380,8 @@ export default function ProposalsPage() {
       fallback={
         <div className="max-w-4xl mx-auto px-4 py-8">
           <div className="space-y-4">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <div key={i} className="block bg-white border border-gray-200 rounded-xl p-6 animate-pulse">
-                <div className="h-5 bg-gray-200 rounded w-3/4 mb-3"></div>
-                <div className="h-4 bg-gray-200 rounded w-1/2"></div>
-              </div>
+            {Array.from({ length: 10 }).map((_, i) => (
+              <ProposalCardSkeleton key={i} />
             ))}
           </div>
         </div>

--- a/app/src/app/profile/[address]/page.tsx
+++ b/app/src/app/profile/[address]/page.tsx
@@ -50,7 +50,11 @@ interface ProfileData {
 }
 
 function Skeleton({ className }: { className?: string }) {
-  return <div className={`bg-gray-200 dark:bg-gray-700 animate-pulse rounded ${className}`} />;
+  return (
+    <div
+      className={`bg-gray-200 dark:bg-gray-700 animate-pulse rounded ${className}`}
+    />
+  );
 }
 
 function VoterProfilePageContent() {
@@ -95,7 +99,7 @@ function VoterProfilePageContent() {
 
         if (!governorAddress || !timelockAddress || !votesAddress) {
           throw new Error(
-            "Missing required environment variables. Please check .env.local configuration."
+            "Missing required environment variables. Please check .env.local configuration.",
           );
         }
 
@@ -150,7 +154,10 @@ function VoterProfilePageContent() {
 
         const [votingHistory, createdProposalsHydrated] = await Promise.all([
           governorClient.getVotesCastByAddress(address, {
-            fromLedger: Math.max(1, (await governorClient.getLatestLedger()) - 17_280 * 30),
+            fromLedger: Math.max(
+              1,
+              (await governorClient.getLatestLedger()) - 17_280 * 30,
+            ),
             limit: 50,
           }),
           governorClient.getProposalsForAddress(address, {
@@ -191,7 +198,8 @@ function VoterProfilePageContent() {
         const snapshots = await Promise.all(
           points.map(async (ledger) => ({
             ledger,
-            votingPower: Number(await votesClient.getPastVotes(address, ledger)) / 1e7,
+            votingPower:
+              Number(await votesClient.getPastVotes(address, ledger)) / 1e7,
           })),
         );
 
@@ -243,9 +251,16 @@ function VoterProfilePageContent() {
     return (
       <div className="max-w-4xl mx-auto px-4 py-8">
         <div className="bg-red-50 border border-red-200 rounded-xl p-4">
-          <p className="text-red-800 text-lg font-medium">Error Loading Profile</p>
-          <p className="text-red-600 text-sm mt-1">{error || "Invalid Stellar address format"}</p>
-          <Link href="/" className="text-red-600 hover:text-red-700 text-sm mt-3 inline-block underline">
+          <p className="text-red-800 text-lg font-medium">
+            Error Loading Profile
+          </p>
+          <p className="text-red-600 text-sm mt-1">
+            {error || "Invalid Stellar address format"}
+          </p>
+          <Link
+            href="/"
+            className="text-red-600 hover:text-red-700 text-sm mt-3 inline-block underline"
+          >
             ← Back to proposals
           </Link>
         </div>
@@ -385,9 +400,7 @@ function VoterProfilePageContent() {
               Snapshot of voting power over recent ledgers
             </p>
           </div>
-          <p className="text-xs text-gray-500">
-            {history.length} points
-          </p>
+          <p className="text-xs text-gray-500">{history.length} points</p>
         </div>
 
         {historyLoading ? (
@@ -399,7 +412,10 @@ function VoterProfilePageContent() {
         ) : (
           <div className="h-72">
             <ResponsiveContainer width="100%" height="100%">
-              <LineChart data={history} margin={{ top: 10, right: 20, bottom: 0, left: -10 }}>
+              <LineChart
+                data={history}
+                margin={{ top: 10, right: 20, bottom: 0, left: -10 }}
+              >
                 <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
                 <XAxis
                   dataKey="ledger"
@@ -416,7 +432,12 @@ function VoterProfilePageContent() {
                   width={50}
                   tickFormatter={(value) => String(value)}
                 />
-                <Tooltip formatter={(value) => [`${Number(value).toFixed(2)} XLM`, "Voting Power"]} />
+                <Tooltip
+                  formatter={(value) => [
+                    `${Number(value).toFixed(2)} XLM`,
+                    "Voting Power",
+                  ]}
+                />
                 <Line
                   type="monotone"
                   dataKey="votingPower"
@@ -451,7 +472,8 @@ function VoterProfilePageContent() {
                     Proposal #{record.proposalId.toString()}
                   </p>
                   <p className="text-xs text-gray-500 mt-1">
-                    {record.support} · {formatVotingPower(record.weight)} · ledger #{record.ledger}
+                    {record.support} · {formatVotingPower(record.weight)} ·
+                    ledger #{record.ledger}
                   </p>
                 </div>
                 <div className="text-right">
@@ -490,9 +512,7 @@ function VoterProfilePageContent() {
                   </p>
                   <p className="text-xs text-gray-500 mt-1">{p.state}</p>
                 </div>
-                <span className="text-xs text-gray-600">
-                  View →
-                </span>
+                <span className="text-xs text-gray-600">View →</span>
               </Link>
             ))}
           </div>

--- a/app/src/app/profile/[address]/page.tsx
+++ b/app/src/app/profile/[address]/page.tsx
@@ -50,7 +50,7 @@ interface ProfileData {
 }
 
 function Skeleton({ className }: { className?: string }) {
-  return <div className={`bg-gray-200 animate-pulse rounded ${className}`} />;
+  return <div className={`bg-gray-200 dark:bg-gray-700 animate-pulse rounded ${className}`} />;
 }
 
 function VoterProfilePageContent() {

--- a/app/src/app/proposal/[id]/ProposalDetailClient.tsx
+++ b/app/src/app/proposal/[id]/ProposalDetailClient.tsx
@@ -1,12 +1,29 @@
 "use client";
 
 import { useEffect, useMemo, useState, useCallback } from "react";
-import { VoteSupport, ProposalState, VotesClient, GovernorClient, VoteType, type GovernorSettings, type Network } from "@nebgov/sdk";
-import { AlertTriangle, Info, ExternalLink, Loader2, MessageSquare } from "lucide-react";
+import {
+  VoteSupport,
+  ProposalState,
+  VotesClient,
+  GovernorClient,
+  VoteType,
+  type GovernorSettings,
+  type Network,
+} from "@nebgov/sdk";
+import {
+  AlertTriangle,
+  Info,
+  ExternalLink,
+  Loader2,
+  MessageSquare,
+} from "lucide-react";
 import { useWallet } from "../../../lib/wallet-context";
 import { DelegateModal } from "../../../components/DelegateModal";
 import { VotingModal } from "../../../components/VotingModal";
-import { fetchProposalMetadata, verifyMetadataHash } from "../../../lib/metadata";
+import {
+  fetchProposalMetadata,
+  verifyMetadataHash,
+} from "../../../lib/metadata";
 import { fetchProposalVotes, type ProposalVote } from "../../../lib/backend";
 import { ShareButton } from "../../../components/ShareButton";
 import {
@@ -17,7 +34,7 @@ import {
   Tooltip,
   ResponsiveContainer,
   Cell,
-  ReferenceLine
+  ReferenceLine,
 } from "recharts";
 
 import { useTheme } from "../../../hooks/useTheme";
@@ -29,7 +46,7 @@ interface Props {
 
 function csvEscape(value: unknown): string {
   const s = value === null || value === undefined ? "" : String(value);
-  if (/[",\n]/.test(s)) return `"${s.replaceAll("\"", "\"\"")}"`;
+  if (/[",\n]/.test(s)) return `"${s.replaceAll('"', '""')}"`;
   return s;
 }
 
@@ -69,7 +86,9 @@ export default function ProposalDetailClient({ params }: Props) {
   const [fetchError, setFetchError] = useState<string | null>(null);
 
   const [voted, setVoted] = useState(false);
-  const [selectedSupport, setSelectedSupport] = useState<VoteSupport | null>(null);
+  const [selectedSupport, setSelectedSupport] = useState<VoteSupport | null>(
+    null,
+  );
   const [delegateModalOpen, setDelegateModalOpen] = useState(false);
   const [voteModalOpen, setVoteModalOpen] = useState(false);
   const [votingPower, setVotingPower] = useState<bigint>(0n);
@@ -87,32 +106,39 @@ export default function ProposalDetailClient({ params }: Props) {
   const [votesLoading, setVotesLoading] = useState(false);
   const [votesTotal, setVotesTotal] = useState(0);
   const [votesHasMore, setVotesHasMore] = useState(false);
-  const [votesSort, setVotesSort] = useState<"newest" | "weight" | "address">("newest");
+  const [votesSort, setVotesSort] = useState<"newest" | "weight" | "address">(
+    "newest",
+  );
   const [exportingCsv, setExportingCsv] = useState(false);
-  const [expandedReasons, setExpandedReasons] = useState<Record<number, boolean>>({});
+  const [expandedReasons, setExpandedReasons] = useState<
+    Record<number, boolean>
+  >({});
 
-  const loadVotes = useCallback(async (pageNum: number, append = false) => {
-    setVotesLoading(true);
-    try {
-      const result = await fetchProposalVotes(
-        params.id,
-        pageNum,
-        20,
-        votesSort
-      );
-      if (append) {
-        setVotes((prev) => [...prev, ...result.votes]);
-      } else {
-        setVotes(result.votes);
+  const loadVotes = useCallback(
+    async (pageNum: number, append = false) => {
+      setVotesLoading(true);
+      try {
+        const result = await fetchProposalVotes(
+          params.id,
+          pageNum,
+          20,
+          votesSort,
+        );
+        if (append) {
+          setVotes((prev) => [...prev, ...result.votes]);
+        } else {
+          setVotes(result.votes);
+        }
+        setVotesTotal(result.total);
+        setVotesHasMore(result.hasMore);
+      } catch (err) {
+        console.error("Failed to load votes:", err);
+      } finally {
+        setVotesLoading(false);
       }
-      setVotesTotal(result.total);
-      setVotesHasMore(result.hasMore);
-    } catch (err) {
-      console.error("Failed to load votes:", err);
-    } finally {
-      setVotesLoading(false);
-    }
-  }, [params.id, votesSort]);
+    },
+    [params.id, votesSort],
+  );
 
   const loadMoreVotes = () => {
     if (!votesLoading && votesHasMore) {
@@ -149,8 +175,14 @@ export default function ProposalDetailClient({ params }: Props) {
     };
   }, []);
 
-  const votesClient = useMemo(() => config ? new VotesClient(config) : null, [config]);
-  const governorClient = useMemo(() => config ? new GovernorClient(config) : null, [config]);
+  const votesClient = useMemo(
+    () => (config ? new VotesClient(config) : null),
+    [config],
+  );
+  const governorClient = useMemo(
+    () => (config ? new GovernorClient(config) : null),
+    [config],
+  );
 
   const loadProposal = useCallback(async () => {
     if (!governorClient) return;
@@ -158,6 +190,7 @@ export default function ProposalDetailClient({ params }: Props) {
     try {
       const p = await governorClient.getProposal(proposalId);
       setProposal({
+        ...INITIAL_PROPOSAL,
         ...p,
         state: await governorClient.getProposalState(proposalId),
       });
@@ -174,7 +207,10 @@ export default function ProposalDetailClient({ params }: Props) {
 
   useEffect(() => {
     if (!governorClient) return;
-    governorClient.getSettings().then((s: GovernorSettings) => setVoteType(s.voteType)).catch(() => {});
+    governorClient
+      .getSettings()
+      .then((s: GovernorSettings) => setVoteType(s.voteType))
+      .catch(() => {});
   }, [governorClient]);
 
   useEffect(() => {
@@ -205,7 +241,10 @@ export default function ProposalDetailClient({ params }: Props) {
     try {
       const content = await fetchProposalMetadata(proposal.metadataUri);
       setMetadata(content);
-      const isMatch = await verifyMetadataHash(content, proposal.descriptionHash);
+      const isMatch = await verifyMetadataHash(
+        content,
+        proposal.descriptionHash,
+      );
       setHashMismatched(!isMatch);
     } catch (err: any) {
       setFetchError(err.message);
@@ -244,22 +283,27 @@ export default function ProposalDetailClient({ params }: Props) {
   }, [loadVotes]);
 
   // Transform data for Recharts
-  const chartData = useMemo(() => [
-    { name: "For", votes: Number(proposal.votesFor) },
-    { name: "Against", votes: Number(proposal.votesAgainst) },
-    { name: "Abstain", votes: Number(proposal.votesAbstain) },
-  ], [proposal.votesFor, proposal.votesAgainst, proposal.votesAbstain]);
+  const chartData = useMemo(
+    () => [
+      { name: "For", votes: Number(proposal.votesFor) },
+      { name: "Against", votes: Number(proposal.votesAgainst) },
+      { name: "Abstain", votes: Number(proposal.votesAbstain) },
+    ],
+    [proposal.votesFor, proposal.votesAgainst, proposal.votesAbstain],
+  );
 
   const COLORS: Record<string, string> = {
-    For: "#10b981",    // green-500
+    For: "#10b981", // green-500
     Against: "#f43f5e", // rose-500
     Abstain: isDark ? "#475569" : "#94a3b8", // slate-600 : slate-400
   };
 
-  const totalVotes = proposal.votesFor + proposal.votesAgainst + proposal.votesAbstain;
+  const totalVotes =
+    proposal.votesFor + proposal.votesAgainst + proposal.votesAbstain;
 
   async function handleCastVote() {
-    if (selectedSupport === null || !governorClient || !publicKey || isVoting) return;
+    if (selectedSupport === null || !governorClient || !publicKey || isVoting)
+      return;
 
     setIsVoting(true);
     setVoteError(null);
@@ -270,7 +314,7 @@ export default function ProposalDetailClient({ params }: Props) {
         publicKey,
         proposalId,
         selectedSupport,
-        signTransaction
+        signTransaction,
       );
 
       setVoteSuccess(true);
@@ -282,12 +326,24 @@ export default function ProposalDetailClient({ params }: Props) {
       let message = "An unknown error occurred while casting your vote.";
 
       const errStr = String(err);
-      if (errStr.includes("already voted") || errStr.includes("Already voted") || errStr.includes("Error(Contract, #1)")) {
+      if (
+        errStr.includes("already voted") ||
+        errStr.includes("Already voted") ||
+        errStr.includes("Error(Contract, #1)")
+      ) {
         message = "You have already voted on this proposal.";
-      } else if (errStr.includes("Proposal not active") || errStr.includes("Error(Contract, #2)")) {
+      } else if (
+        errStr.includes("Proposal not active") ||
+        errStr.includes("Error(Contract, #2)")
+      ) {
         message = "This proposal is no longer accepting votes.";
-      } else if (errStr.includes("zero voting power") || errStr.includes("Insufficient voting power") || errStr.includes("Error(Contract, #3)")) {
-        message = "You do not have sufficient voting power to vote on this proposal.";
+      } else if (
+        errStr.includes("zero voting power") ||
+        errStr.includes("Insufficient voting power") ||
+        errStr.includes("Error(Contract, #3)")
+      ) {
+        message =
+          "You do not have sufficient voting power to vote on this proposal.";
       }
 
       setVoteError(message);
@@ -302,13 +358,20 @@ export default function ProposalDetailClient({ params }: Props) {
       const rows: ProposalVote[] = [];
       let page = 0;
       while (true) {
-        const result = await fetchProposalVotes(params.id, page, 100, votesSort);
+        const result = await fetchProposalVotes(
+          params.id,
+          page,
+          100,
+          votesSort,
+        );
         rows.push(...result.votes);
         if (!result.hasMore) break;
         page += 1;
       }
 
-      const header = ["voter", "support", "weight", "reason", "ledger"].join(",");
+      const header = ["voter", "support", "weight", "reason", "ledger"].join(
+        ",",
+      );
       const lines = rows.map((v: any) =>
         [
           csvEscape(v.voter),
@@ -353,7 +416,9 @@ export default function ProposalDetailClient({ params }: Props) {
             {ProposalState[proposal.state]}
           </div>
         </div>
-        {shareUrl ? <ShareButton url={shareUrl} title={`Proposal #${params.id}`} /> : null}
+        {shareUrl ? (
+          <ShareButton url={shareUrl} title={`Proposal #${params.id}`} />
+        ) : null}
       </div>
 
       <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
@@ -374,7 +439,8 @@ export default function ProposalDetailClient({ params }: Props) {
                 Veto Window Open
               </p>
               <p className="text-xs text-blue-700 mt-1">
-                The guardian can cancel this proposal during the veto window before execution becomes possible.
+                The guardian can cancel this proposal during the veto window
+                before execution becomes possible.
               </p>
             </div>
           </div>
@@ -386,13 +452,18 @@ export default function ProposalDetailClient({ params }: Props) {
         <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-6 flex gap-3">
           <AlertTriangle className="w-5 h-5 text-amber-600 shrink-0 mt-0.5" />
           <div className="text-sm">
-            <h3 className="font-semibold text-amber-800">Content Integrity Warning</h3>
+            <h3 className="font-semibold text-amber-800">
+              Content Integrity Warning
+            </h3>
             <p className="text-amber-700 mt-0.5">
-              The external content fetched for this proposal does not match the hash stored on-chain.
-              The displayed description may have been tampered with.
+              The external content fetched for this proposal does not match the
+              hash stored on-chain. The displayed description may have been
+              tampered with.
             </p>
             <div className="mt-2 space-y-1 font-mono text-[11px]">
-              <p className="text-gray-500">On-chain: {proposal.descriptionHash.substring(0, 16)}...</p>
+              <p className="text-gray-500">
+                On-chain: {proposal.descriptionHash.substring(0, 16)}...
+              </p>
             </div>
           </div>
         </div>
@@ -404,8 +475,12 @@ export default function ProposalDetailClient({ params }: Props) {
           <Info className="w-5 h-5 text-blue-600 shrink-0 mt-0.5" />
           <div className="text-blue-700">
             <p className="font-semibold text-blue-800">Metadata Unreachable</p>
-            <p className="mt-0.5">Could not load the full description. Check the URI directly below.</p>
-            <p className="mt-2 font-mono text-[11px] text-gray-500">Hash: {proposal.descriptionHash}</p>
+            <p className="mt-0.5">
+              Could not load the full description. Check the URI directly below.
+            </p>
+            <p className="mt-2 font-mono text-[11px] text-gray-500">
+              Hash: {proposal.descriptionHash}
+            </p>
           </div>
         </div>
       )}
@@ -418,9 +493,11 @@ export default function ProposalDetailClient({ params }: Props) {
           </h2>
           {proposal.metadataUri && (
             <a
-              href={proposal.metadataUri.startsWith('ipfs://')
-                ? `https://ipfs.io/ipfs/${proposal.metadataUri.replace('ipfs://', '')}`
-                : proposal.metadataUri}
+              href={
+                proposal.metadataUri.startsWith("ipfs://")
+                  ? `https://ipfs.io/ipfs/${proposal.metadataUri.replace("ipfs://", "")}`
+                  : proposal.metadataUri
+              }
               target="_blank"
               rel="noopener noreferrer"
               className="text-indigo-600 flex items-center gap-1 text-xs hover:underline"
@@ -432,7 +509,8 @@ export default function ProposalDetailClient({ params }: Props) {
 
         {metadataLoading ? (
           <div className="flex items-center gap-2 text-gray-400 text-sm py-4">
-            <Loader2 className="w-4 h-4 animate-spin" /> Fetching off-chain content...
+            <Loader2 className="w-4 h-4 animate-spin" /> Fetching off-chain
+            content...
           </div>
         ) : metadata ? (
           <div className="prose prose-sm max-w-none text-gray-800 dark:text-gray-200 whitespace-pre-wrap">
@@ -454,7 +532,9 @@ export default function ProposalDetailClient({ params }: Props) {
             </h2>
             <div className="flex items-center gap-2">
               <span className="text-2xl font-bold text-gray-900 dark:text-white font-mono">
-                {delegationLoading ? "..." : (Number(votingPower) / 10 ** 7).toLocaleString()}
+                {delegationLoading
+                  ? "..."
+                  : (Number(votingPower) / 10 ** 7).toLocaleString()}
               </span>
               <span className="text-sm text-gray-400">NEB</span>
             </div>
@@ -474,13 +554,15 @@ export default function ProposalDetailClient({ params }: Props) {
           <h2 className="text-sm font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">
             Current Votes
           </h2>
-          <span className={`px-2 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider ${
-            voteType === VoteType.Quadratic
-              ? "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300"
-              : voteType === VoteType.Extended
-              ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
-              : "bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300"
-          }`}>
+          <span
+            className={`px-2 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider ${
+              voteType === VoteType.Quadratic
+                ? "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300"
+                : voteType === VoteType.Extended
+                  ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
+                  : "bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+            }`}
+          >
             {voteType}
           </span>
         </div>
@@ -498,18 +580,24 @@ export default function ProposalDetailClient({ params }: Props) {
                 dataKey="name"
                 axisLine={false}
                 tickLine={false}
-                tick={{ fontSize: 12, fontWeight: 500, fill: isDark ? '#94a3b8' : '#64748b' }}
-              />
-               <Tooltip
-                cursor={{ fill: isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.02)' }}
-                contentStyle={{ 
-                  borderRadius: '12px', 
-                  border: 'none', 
-                  boxShadow: '0 10px 15px -3px rgba(0,0,0,0.1)',
-                  backgroundColor: isDark ? '#1f2937' : '#ffffff',
-                  color: isDark ? '#f3f4f6' : '#111827'
+                tick={{
+                  fontSize: 12,
+                  fontWeight: 500,
+                  fill: isDark ? "#94a3b8" : "#64748b",
                 }}
-                itemStyle={{ color: isDark ? '#f3f4f6' : '#111827' }}
+              />
+              <Tooltip
+                cursor={{
+                  fill: isDark ? "rgba(255,255,255,0.05)" : "rgba(0,0,0,0.02)",
+                }}
+                contentStyle={{
+                  borderRadius: "12px",
+                  border: "none",
+                  boxShadow: "0 10px 15px -3px rgba(0,0,0,0.1)",
+                  backgroundColor: isDark ? "#1f2937" : "#ffffff",
+                  color: isDark ? "#f3f4f6" : "#111827",
+                }}
+                itemStyle={{ color: isDark ? "#f3f4f6" : "#111827" }}
               />
               <Bar
                 dataKey="votes"
@@ -526,7 +614,12 @@ export default function ProposalDetailClient({ params }: Props) {
                   x={Number(proposal.quorum)}
                   stroke="#ef4444"
                   strokeDasharray="3 3"
-                  label={{ position: 'top', value: 'Quorum', fill: '#ef4444', fontSize: 10 }}
+                  label={{
+                    position: "top",
+                    value: "Quorum",
+                    fill: "#ef4444",
+                    fontSize: 10,
+                  }}
                 />
               )}
             </BarChart>
@@ -535,16 +628,28 @@ export default function ProposalDetailClient({ params }: Props) {
 
         <div className="grid grid-cols-3 gap-4 border-t border-gray-100 dark:border-gray-700 pt-6">
           <div>
-            <p className="text-xs text-gray-400 font-medium mb-1 uppercase">For</p>
-            <p className="font-mono text-lg font-bold text-emerald-600">{(Number(proposal.votesFor) / 10 ** 7).toLocaleString()}</p>
+            <p className="text-xs text-gray-400 font-medium mb-1 uppercase">
+              For
+            </p>
+            <p className="font-mono text-lg font-bold text-emerald-600">
+              {(Number(proposal.votesFor) / 10 ** 7).toLocaleString()}
+            </p>
           </div>
           <div>
-            <p className="text-xs text-gray-400 font-medium mb-1 uppercase">Against</p>
-            <p className="font-mono text-lg font-bold text-rose-600">{(Number(proposal.votesAgainst) / 10 ** 7).toLocaleString()}</p>
+            <p className="text-xs text-gray-400 font-medium mb-1 uppercase">
+              Against
+            </p>
+            <p className="font-mono text-lg font-bold text-rose-600">
+              {(Number(proposal.votesAgainst) / 10 ** 7).toLocaleString()}
+            </p>
           </div>
           <div>
-            <p className="text-xs text-gray-400 font-medium mb-1 uppercase">Abstain</p>
-            <p className="font-mono text-lg font-bold text-slate-500 dark:text-slate-400">{(Number(proposal.votesAbstain) / 10 ** 7).toLocaleString()}</p>
+            <p className="text-xs text-gray-400 font-medium mb-1 uppercase">
+              Abstain
+            </p>
+            <p className="font-mono text-lg font-bold text-slate-500 dark:text-slate-400">
+              {(Number(proposal.votesAbstain) / 10 ** 7).toLocaleString()}
+            </p>
           </div>
         </div>
       </div>
@@ -556,7 +661,7 @@ export default function ProposalDetailClient({ params }: Props) {
             Cast Your Vote
           </h2>
 
-              {!isConnected ? (
+          {!isConnected ? (
             <div className="bg-indigo-50 dark:bg-slate-900/80 border border-indigo-200 dark:border-indigo-800 rounded-2xl p-5 mb-4">
               <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                 <div>
@@ -591,8 +696,16 @@ export default function ProposalDetailClient({ params }: Props) {
               <div className="flex flex-col sm:flex-row gap-3 mb-4">
                 {[
                   { label: "For", value: VoteSupport.For, aria: "Vote For" },
-                  { label: "Against", value: VoteSupport.Against, aria: "Vote Against" },
-                  { label: "Abstain", value: VoteSupport.Abstain, aria: "Vote Abstain" },
+                  {
+                    label: "Against",
+                    value: VoteSupport.Against,
+                    aria: "Vote Against",
+                  },
+                  {
+                    label: "Abstain",
+                    value: VoteSupport.Abstain,
+                    aria: "Vote Abstain",
+                  },
                 ].map(({ label, value, aria }) => (
                   <button
                     key={label}
@@ -600,9 +713,11 @@ export default function ProposalDetailClient({ params }: Props) {
                     disabled={isVoting}
                     aria-label={aria}
                     className={`flex-1 py-3 rounded-lg border-2 font-medium transition-all
-                      ${selectedSupport === value
-                        ? "border-indigo-600 bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300"
-                        : "border-gray-100 dark:border-gray-700 hover:border-gray-200 dark:hover:border-gray-600 text-gray-600 dark:text-gray-400"}
+                      ${
+                        selectedSupport === value
+                          ? "border-indigo-600 bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300"
+                          : "border-gray-100 dark:border-gray-700 hover:border-gray-200 dark:hover:border-gray-600 text-gray-600 dark:text-gray-400"
+                      }
                       ${isVoting ? "opacity-50 cursor-not-allowed" : ""}`}
                   >
                     {label}
@@ -611,7 +726,10 @@ export default function ProposalDetailClient({ params }: Props) {
               </div>
 
               {voteError && (
-                <div role="alert" className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700 flex gap-2 items-start">
+                <div
+                  role="alert"
+                  className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700 flex gap-2 items-start"
+                >
                   <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
                   {voteError}
                 </div>
@@ -638,9 +756,14 @@ export default function ProposalDetailClient({ params }: Props) {
       )}
 
       {voted && (
-        <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4 text-center" aria-live="polite">
+        <div
+          className="bg-emerald-50 border border-emerald-200 rounded-xl p-4 text-center"
+          aria-live="polite"
+        >
           <p className="text-emerald-800 font-medium">
-            Your vote {votedSupport !== null ? `(${VoteSupport[votedSupport]})` : ""} has been recorded!
+            Your vote{" "}
+            {votedSupport !== null ? `(${VoteSupport[votedSupport]})` : ""} has
+            been recorded!
           </p>
         </div>
       )}
@@ -669,19 +792,28 @@ export default function ProposalDetailClient({ params }: Props) {
         <div className="flex items-center gap-2 mb-4">
           <span className="text-xs text-gray-500">Sort by:</span>
           <button
-            onClick={() => { setVotesSort("newest"); setVotesPage(0); }}
+            onClick={() => {
+              setVotesSort("newest");
+              setVotesPage(0);
+            }}
             className={`px-2 py-1 text-xs rounded ${votesSort === "newest" ? "bg-indigo-600 text-white" : "bg-gray-100 dark:bg-gray-700"}`}
           >
             Newest
           </button>
           <button
-            onClick={() => { setVotesSort("weight"); setVotesPage(0); }}
+            onClick={() => {
+              setVotesSort("weight");
+              setVotesPage(0);
+            }}
             className={`px-2 py-1 text-xs rounded ${votesSort === "weight" ? "bg-indigo-600 text-white" : "bg-gray-100 dark:bg-gray-700"}`}
           >
             Weight
           </button>
           <button
-            onClick={() => { setVotesSort("address"); setVotesPage(0); }}
+            onClick={() => {
+              setVotesSort("address");
+              setVotesPage(0);
+            }}
             className={`px-2 py-1 text-xs rounded ${votesSort === "address" ? "bg-indigo-600 text-white" : "bg-gray-100 dark:bg-gray-700"}`}
           >
             Address
@@ -702,66 +834,74 @@ export default function ProposalDetailClient({ params }: Props) {
               const expanded = Boolean(expandedReasons[vote.id]);
               const reasonText = reasonPreview(reason, expanded);
               return (
-              <li
-                key={vote.id}
-                className="group p-3 bg-gray-50 dark:bg-gray-900 rounded-lg"
-              >
-                <div className="flex items-center justify-between gap-4">
-                  <div className="flex items-center gap-3">
-                    <span className="font-mono text-sm">{vote.voter.slice(0, 6)}...{vote.voter.slice(-4)}</span>
-                    <span className={`text-xs px-2 py-0.5 rounded ${
-                      vote.support === VoteSupport.For ? "bg-green-100 text-green-700" :
-                      vote.support === VoteSupport.Against ? "bg-red-100 text-red-700" :
-                      "bg-gray-200 text-gray-600"
-                    }`}>
-                      {supportLabel(vote.support)}
+                <li
+                  key={vote.id}
+                  className="group p-3 bg-gray-50 dark:bg-gray-900 rounded-lg"
+                >
+                  <div className="flex items-center justify-between gap-4">
+                    <div className="flex items-center gap-3">
+                      <span className="font-mono text-sm">
+                        {vote.voter.slice(0, 6)}...{vote.voter.slice(-4)}
+                      </span>
+                      <span
+                        className={`text-xs px-2 py-0.5 rounded ${
+                          vote.support === VoteSupport.For
+                            ? "bg-green-100 text-green-700"
+                            : vote.support === VoteSupport.Against
+                              ? "bg-red-100 text-red-700"
+                              : "bg-gray-200 text-gray-600"
+                        }`}
+                      >
+                        {supportLabel(vote.support)}
+                      </span>
+                      {hasReason && (
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setExpandedReasons((prev) => ({
+                              ...prev,
+                              [vote.id]: !prev[vote.id],
+                            }))
+                          }
+                          className="inline-flex items-center gap-1 rounded-full border border-indigo-200 px-2 py-0.5 text-[11px] text-indigo-700 hover:bg-indigo-50"
+                          aria-label={`Toggle vote reason for ${vote.voter}`}
+                        >
+                          <MessageSquare className="w-3 h-3" />
+                          Reason
+                        </button>
+                      )}
+                    </div>
+                    <span className="text-sm font-mono text-gray-600 dark:text-gray-400">
+                      {(Number(vote.weight) / 10 ** 7).toLocaleString()} NEB
                     </span>
-                    {hasReason && (
-                      <button
-                        type="button"
-                        onClick={() =>
-                          setExpandedReasons((prev) => ({
-                            ...prev,
-                            [vote.id]: !prev[vote.id],
-                          }))
-                        }
-                        className="inline-flex items-center gap-1 rounded-full border border-indigo-200 px-2 py-0.5 text-[11px] text-indigo-700 hover:bg-indigo-50"
-                        aria-label={`Toggle vote reason for ${vote.voter}`}
-                      >
-                        <MessageSquare className="w-3 h-3" />
-                        Reason
-                      </button>
-                    )}
                   </div>
-                  <span className="text-sm font-mono text-gray-600 dark:text-gray-400">
-                    {(Number(vote.weight) / 10 ** 7).toLocaleString()} NEB
-                  </span>
-                </div>
 
-                {hasReason && (
-                  <div
-                    className={`mt-3 rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 ${
-                      expanded ? "block" : "hidden md:group-hover:block"
-                    }`}
-                  >
-                    <p className="whitespace-pre-wrap break-words">{reasonText}</p>
-                    {reason.length > 200 && (
-                      <button
-                        type="button"
-                        onClick={() =>
-                          setExpandedReasons((prev) => ({
-                            ...prev,
-                            [vote.id]: !prev[vote.id],
-                          }))
-                        }
-                        className="mt-2 text-xs font-medium text-indigo-600 hover:text-indigo-800"
-                      >
-                        {expanded ? "Show less" : "Show more"}
-                      </button>
-                    )}
-                  </div>
-                )}
-              </li>
+                  {hasReason && (
+                    <div
+                      className={`mt-3 rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 ${
+                        expanded ? "block" : "hidden md:group-hover:block"
+                      }`}
+                    >
+                      <p className="whitespace-pre-wrap break-words">
+                        {reasonText}
+                      </p>
+                      {reason.length > 200 && (
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setExpandedReasons((prev) => ({
+                              ...prev,
+                              [vote.id]: !prev[vote.id],
+                            }))
+                          }
+                          className="mt-2 text-xs font-medium text-indigo-600 hover:text-indigo-800"
+                        >
+                          {expanded ? "Show less" : "Show more"}
+                        </button>
+                      )}
+                    </div>
+                  )}
+                </li>
               );
             })}
           </ul>

--- a/app/src/app/proposal/[id]/ProposalDetailClient.tsx
+++ b/app/src/app/proposal/[id]/ProposalDetailClient.tsx
@@ -21,6 +21,7 @@ import {
 } from "recharts";
 
 import { useTheme } from "../../../hooks/useTheme";
+import { ProposalDetailSkeleton } from "../../../components/ui/ProposalDetailSkeleton";
 
 interface Props {
   params: { id: string };
@@ -334,12 +335,7 @@ export default function ProposalDetailClient({ params }: Props) {
   }
 
   if (loading) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-[400px] text-gray-500">
-        <Loader2 className="w-8 h-8 animate-spin mb-4" />
-        <p>Loading proposal data...</p>
-      </div>
-    );
+    return <ProposalDetailSkeleton />;
   }
 
   return (

--- a/app/src/app/security/page.tsx
+++ b/app/src/app/security/page.tsx
@@ -12,7 +12,7 @@ import {
   ExternalLink,
   Info
 } from "lucide-react";
-import { backendBaseUrl } from "@/lib/backend";
+import { backendBaseUrl } from "../../lib/backend";
 
 interface SecurityAlert {
   id: number;

--- a/app/src/app/settings/page.tsx
+++ b/app/src/app/settings/page.tsx
@@ -140,7 +140,7 @@ export default function SettingsPage() {
       setError(null);
       const nextSettings = toGovernorSettings(form);
       const { target, fnName, calldata } = governor.buildUpdateConfigProposal(nextSettings);
-      const encodedArg = xdr.ScVal.fromXDR(calldata);
+      const encodedArg = xdr.ScVal.fromXDR(Buffer.from(calldata));
       const source = publicKey ?? config.governorAddress;
       const simulation = await governor.simulateTargetInvocation(source, target, fnName, [encodedArg]);
       if (!simulation.ok) {

--- a/app/src/app/treasury/page.tsx
+++ b/app/src/app/treasury/page.tsx
@@ -7,7 +7,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import toast from "react-hot-toast";
 import { useWallet } from "../../lib/wallet-context";
-import { TreasuryClient, type TreasurySpendingCap, type TreasuryTx } from "../../lib/treasury-client";
+import {
+  TreasuryClient,
+  type TreasurySpendingCap,
+  type TreasuryTx,
+} from "../../lib/treasury-client";
 import { TreasuryBalanceSkeleton } from "../../components/ui/TreasuryBalanceSkeleton";
 import {
   type CalldataArgKind,
@@ -67,11 +71,13 @@ export default function TreasuryPage() {
   const [txs, setTxs] = useState<TreasuryTx[]>([]);
   const [threshold, setThreshold] = useState<number>(1);
   const [ownerAddresses, setOwnerAddresses] = useState<string[]>([]);
-  const [alreadyApproved, setAlreadyApproved] = useState<Record<string, boolean>>(
-    {},
-  );
+  const [alreadyApproved, setAlreadyApproved] = useState<
+    Record<string, boolean>
+  >({});
   const [ownerOnChain, setOwnerOnChain] = useState<boolean | null>(null);
-  const [spendingCap, setSpendingCap] = useState<TreasurySpendingCap | null>(null);
+  const [spendingCap, setSpendingCap] = useState<TreasurySpendingCap | null>(
+    null,
+  );
   const [spentThisPeriod, setSpentThisPeriod] = useState<bigint>(0n);
   const [loading, setLoading] = useState(true);
   const [approving, setApproving] = useState<Record<string, boolean>>({});
@@ -86,13 +92,16 @@ export default function TreasuryPage() {
   const [submitDataHex, setSubmitDataHex] = useState("");
   const [argRows, setArgRows] = useState<CalldataArgRow[]>([]);
 
-  const network = (process.env.NEXT_PUBLIC_NETWORK || "testnet") as StellarNetwork;
+  const network = (process.env.NEXT_PUBLIC_NETWORK ||
+    "testnet") as StellarNetwork;
   const horizonBaseUrl = HORIZON_URLS[network];
 
-  const treasuryContractAddress = process.env.NEXT_PUBLIC_TREASURY_ADDRESS || "";
+  const treasuryContractAddress =
+    process.env.NEXT_PUBLIC_TREASURY_ADDRESS || "";
   const treasuryAccountId = process.env.NEXT_PUBLIC_TREASURY_ACCOUNT || "";
   const usdcIssuer = process.env.NEXT_PUBLIC_USDC_ISSUER || "";
-  const treasuryTokenAddress = process.env.NEXT_PUBLIC_TREASURY_TOKEN_ADDRESS || usdcIssuer;
+  const treasuryTokenAddress =
+    process.env.NEXT_PUBLIC_TREASURY_TOKEN_ADDRESS || usdcIssuer;
   const rpcUrl = process.env.NEXT_PUBLIC_RPC_URL || undefined;
 
   const treasuryClient = useMemo(() => {
@@ -108,9 +117,9 @@ export default function TreasuryPage() {
 
   const canWrite = Boolean(
     isConnected &&
-      publicKey &&
-      (ownerOnChain === true ||
-        (ownerOnChain === null && isEnvFallbackOwner(publicKey))),
+    publicKey &&
+    (ownerOnChain === true ||
+      (ownerOnChain === null && isEnvFallbackOwner(publicKey))),
   );
 
   async function fetchBalances() {
@@ -119,7 +128,8 @@ export default function TreasuryPage() {
     const res = await fetch(`${horizonBaseUrl}/accounts/${treasuryAccountId}`, {
       method: "GET",
     });
-    if (!res.ok) throw new Error(`Failed to fetch treasury balances: ${res.status}`);
+    if (!res.ok)
+      throw new Error(`Failed to fetch treasury balances: ${res.status}`);
 
     const json = (await res.json()) as { balances?: HorizonBalance[] };
     const balances = json.balances ?? [];
@@ -130,7 +140,10 @@ export default function TreasuryPage() {
     setXlmBalance(native?.balance ?? "0");
 
     const usdc = balances.find((b) => {
-      if (b.asset_type !== "credit_alphanum4" && b.asset_type !== "credit_alphanum12") {
+      if (
+        b.asset_type !== "credit_alphanum4" &&
+        b.asset_type !== "credit_alphanum12"
+      ) {
         return false;
       }
       if (b.asset_code !== "USDC") return false;
@@ -193,7 +206,9 @@ export default function TreasuryPage() {
       if (publicKey) {
         if (owners && owners.length > 0) {
           setOwnerOnChain(
-            owners.some((owner) => owner.toUpperCase() === publicKey.toUpperCase()),
+            owners.some(
+              (owner) => owner.toUpperCase() === publicKey.toUpperCase(),
+            ),
           );
         } else {
           const own = await treasuryClient.isOwner(viewer, publicKey);
@@ -204,10 +219,18 @@ export default function TreasuryPage() {
       }
 
       if (treasuryTokenAddress) {
-        const cap = await treasuryClient.getSpendingCap(viewer, treasuryTokenAddress);
+        const cap = await treasuryClient.getSpendingCap(
+          viewer,
+          treasuryTokenAddress,
+        );
         setSpendingCap(cap);
         if (cap) {
-          setSpentThisPeriod(await treasuryClient.getSpentThisPeriod(viewer, treasuryTokenAddress));
+          setSpentThisPeriod(
+            await treasuryClient.getSpentThisPeriod(
+              viewer,
+              treasuryTokenAddress,
+            ),
+          );
         } else {
           setSpentThisPeriod(0n);
         }
@@ -229,7 +252,8 @@ export default function TreasuryPage() {
     try {
       await Promise.all([fetchBalances(), fetchPendingTxs(readViewer)]);
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : "Failed to load treasury data";
+      const msg =
+        e instanceof Error ? e.message : "Failed to load treasury data";
       setError(msg);
     } finally {
       setLoading(false);
@@ -257,9 +281,12 @@ export default function TreasuryPage() {
     try {
       await treasuryClient.approve(publicKey, Number(txId), signTransaction);
       await fetchPendingTxs(readViewer);
-      const executedNow = before !== undefined && before.approvals + 1 >= threshold;
+      const executedNow =
+        before !== undefined && before.approvals + 1 >= threshold;
       if (executedNow) {
-        toast.success("Transaction executed — multi-sig threshold was reached.");
+        toast.success(
+          "Transaction executed — multi-sig threshold was reached.",
+        );
       } else {
         toast.success("Approval recorded.");
       }
@@ -335,28 +362,31 @@ export default function TreasuryPage() {
 
       {!treasuryContractAddress && (
         <div className="mb-6 bg-yellow-50 border border-yellow-200 rounded-xl p-4 text-sm text-yellow-800">
-          Missing <span className="font-mono">NEXT_PUBLIC_TREASURY_ADDRESS</span> in{" "}
+          Missing{" "}
+          <span className="font-mono">NEXT_PUBLIC_TREASURY_ADDRESS</span> in{" "}
           <span className="font-mono">app/.env.local</span>.
         </div>
       )}
 
       {!treasuryAccountId && (
         <div className="mb-6 bg-yellow-50 border border-yellow-200 rounded-xl p-4 text-sm text-yellow-800">
-          Missing <span className="font-mono">NEXT_PUBLIC_TREASURY_ACCOUNT</span> (treasury Stellar
-          account for Horizon balance queries).
+          Missing{" "}
+          <span className="font-mono">NEXT_PUBLIC_TREASURY_ACCOUNT</span>{" "}
+          (treasury Stellar account for Horizon balance queries).
         </div>
       )}
 
       {!isConnected && (
         <div className="mb-6 bg-gray-100 border border-gray-200 rounded-xl p-4 text-sm text-gray-700">
-          Connect an owner wallet to submit or approve. Balances and pending transactions load using
-          the treasury account when configured.
+          Connect an owner wallet to submit or approve. Balances and pending
+          transactions load using the treasury account when configured.
         </div>
       )}
 
       {isConnected && publicKey && !canWrite && ownerOnChain === false && (
         <div className="mb-6 bg-gray-50 border border-gray-200 rounded-xl p-4 text-sm text-gray-600">
-          This wallet is not a treasury owner — you can view balances and pending transactions only.
+          This wallet is not a treasury owner — you can view balances and
+          pending transactions only.
         </div>
       )}
 
@@ -367,54 +397,65 @@ export default function TreasuryPage() {
         <div className="grid grid-cols-2 gap-4 mb-8">
           <div className="bg-white border border-gray-200 rounded-xl p-6">
             <p className="text-sm text-gray-500">USDC Balance</p>
-            <p className="text-2xl font-bold mt-1">
-              {`${usdcBalance} USDC`}
-            </p>
+            <p className="text-2xl font-bold mt-1">{`${usdcBalance} USDC`}</p>
           </div>
           <div className="bg-white border border-gray-200 rounded-xl p-6">
             <p className="text-sm text-gray-500">XLM Balance</p>
-            <p className="text-2xl font-bold mt-1">
-              {`${xlmBalance} XLM`}
-            </p>
+            <p className="text-2xl font-bold mt-1">{`${xlmBalance} XLM`}</p>
           </div>
         </div>
       )}
 
       <div className="mb-8 bg-white border border-gray-200 rounded-xl p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-1">Multisig configuration</h2>
+        <h2 className="text-lg font-semibold text-gray-900 mb-1">
+          Multisig configuration
+        </h2>
         <p className="text-sm text-gray-500">
           {threshold}-of-{ownerAddresses.length || "?"} multisig
         </p>
         {ownerAddresses.length > 0 && (
           <p className="text-xs text-gray-500 mt-2">
-            On-chain owners: {ownerAddresses.map((address) => `${address.slice(0, 6)}...${address.slice(-4)}`).join(", ")}
+            On-chain owners:{" "}
+            {ownerAddresses
+              .map((address) => `${address.slice(0, 6)}...${address.slice(-4)}`)
+              .join(", ")}
           </p>
         )}
       </div>
 
       <div className="bg-white border border-gray-200 rounded-xl p-6 mb-8">
-        <h2 className="text-lg font-semibold text-gray-900 mb-1">Spending cap</h2>
+        <h2 className="text-lg font-semibold text-gray-900 mb-1">
+          Spending cap
+        </h2>
         <p className="text-sm text-gray-500 mb-4">
-          Current per-period treasury cap and utilization for the configured token.
+          Current per-period treasury cap and utilization for the configured
+          token.
         </p>
 
         {treasuryTokenAddress ? (
           spendingCap ? (
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
               <div>
-                <p className="text-xs uppercase tracking-wide text-gray-500">Token</p>
+                <p className="text-xs uppercase tracking-wide text-gray-500">
+                  Token
+                </p>
                 <p className="mt-1 font-mono text-sm text-gray-800 break-all">
                   {spendingCap.token}
                 </p>
               </div>
               <div>
-                <p className="text-xs uppercase tracking-wide text-gray-500">Cap</p>
+                <p className="text-xs uppercase tracking-wide text-gray-500">
+                  Cap
+                </p>
                 <p className="mt-1 text-sm text-gray-800">
-                  {spendingCap.maxAmount.toString()} units / {spendingCap.periodLedgers} ledgers
+                  {spendingCap.maxAmount.toString()} units /{" "}
+                  {spendingCap.periodLedgers} ledgers
                 </p>
               </div>
               <div>
-                <p className="text-xs uppercase tracking-wide text-gray-500">Used</p>
+                <p className="text-xs uppercase tracking-wide text-gray-500">
+                  Used
+                </p>
                 <p className="mt-1 text-sm text-gray-800">
                   {spentThisPeriod.toString()} units
                 </p>
@@ -422,23 +463,31 @@ export default function TreasuryPage() {
             </div>
           ) : (
             <p className="text-sm text-gray-500">
-              No spending cap is configured for <span className="font-mono">{treasuryTokenAddress}</span>.
+              No spending cap is configured for{" "}
+              <span className="font-mono">{treasuryTokenAddress}</span>.
             </p>
           )
         ) : (
           <p className="text-sm text-gray-500">
-            Set <span className="font-mono">NEXT_PUBLIC_TREASURY_TOKEN_ADDRESS</span> or
-            <span className="font-mono"> NEXT_PUBLIC_USDC_ISSUER</span> to show utilization.
+            Set{" "}
+            <span className="font-mono">
+              NEXT_PUBLIC_TREASURY_TOKEN_ADDRESS
+            </span>{" "}
+            or
+            <span className="font-mono"> NEXT_PUBLIC_USDC_ISSUER</span> to show
+            utilization.
           </p>
         )}
       </div>
 
       {/* Submit */}
       <div className="bg-white border border-gray-200 rounded-xl p-6 mb-8">
-        <h2 className="text-lg font-semibold text-gray-900 mb-1">Submit transaction</h2>
+        <h2 className="text-lg font-semibold text-gray-900 mb-1">
+          Submit transaction
+        </h2>
         <p className="text-sm text-gray-500 mb-4">
-          Owners propose a target contract and calldata. Approvals execute automatically when the
-          threshold is met.
+          Owners propose a target contract and calldata. Approvals execute
+          automatically when the threshold is met.
         </p>
 
         {!canWrite && (
@@ -449,7 +498,9 @@ export default function TreasuryPage() {
 
         <form onSubmit={handleSubmitTx} className="space-y-4">
           <div>
-            <label className="block text-xs text-gray-500 mb-1">Target contract / account</label>
+            <label className="block text-xs text-gray-500 mb-1">
+              Target contract / account
+            </label>
             <input
               type="text"
               value={submitTarget}
@@ -491,7 +542,9 @@ export default function TreasuryPage() {
           {calldataMode === "builder" ? (
             <>
               <div>
-                <label className="block text-xs text-gray-500 mb-1">Function name</label>
+                <label className="block text-xs text-gray-500 mb-1">
+                  Function name
+                </label>
                 <input
                   type="text"
                   value={submitFn}
@@ -526,7 +579,9 @@ export default function TreasuryPage() {
                         onChange={(e) => {
                           const kind = e.target.value as CalldataArgKind;
                           setArgRows((rows) =>
-                            rows.map((x) => (x.id === row.id ? { ...x, kind } : x)),
+                            rows.map((x) =>
+                              x.id === row.id ? { ...x, kind } : x,
+                            ),
                           );
                         }}
                         className="border border-gray-200 rounded-md text-xs py-1.5 px-2"
@@ -544,18 +599,26 @@ export default function TreasuryPage() {
                         onChange={(e) => {
                           const v = e.target.value;
                           setArgRows((rows) =>
-                            rows.map((x) => (x.id === row.id ? { ...x, value: v } : x)),
+                            rows.map((x) =>
+                              x.id === row.id ? { ...x, value: v } : x,
+                            ),
                           );
                         }}
                         placeholder={
-                          row.kind === "bool" ? "true / false" : `value ${idx + 1}`
+                          row.kind === "bool"
+                            ? "true / false"
+                            : `value ${idx + 1}`
                         }
                         className="flex-1 min-w-[8rem] border border-gray-200 rounded-md text-sm px-2 py-1.5 font-mono"
                       />
                       <button
                         type="button"
                         disabled={!canWrite}
-                        onClick={() => setArgRows((rows) => rows.filter((x) => x.id !== row.id))}
+                        onClick={() =>
+                          setArgRows((rows) =>
+                            rows.filter((x) => x.id !== row.id),
+                          )
+                        }
                         className="text-xs text-red-600 hover:text-red-800 disabled:opacity-50"
                       >
                         Remove
@@ -567,7 +630,9 @@ export default function TreasuryPage() {
             </>
           ) : (
             <div>
-              <label className="block text-xs text-gray-500 mb-1">Calldata (hex)</label>
+              <label className="block text-xs text-gray-500 mb-1">
+                Calldata (hex)
+              </label>
               <textarea
                 value={submitDataHex}
                 onChange={(e) => setSubmitDataHex(e.target.value)}
@@ -584,7 +649,9 @@ export default function TreasuryPage() {
             <span className="text-xs font-semibold text-slate-500 uppercase tracking-wide">
               Preview
             </span>
-            <p className="mt-1 font-mono text-xs sm:text-sm break-all">{preview}</p>
+            <p className="mt-1 font-mono text-xs sm:text-sm break-all">
+              {preview}
+            </p>
           </div>
 
           <button
@@ -598,7 +665,9 @@ export default function TreasuryPage() {
       </div>
 
       {/* Pending */}
-      <h2 className="text-lg font-semibold text-gray-900 mb-4">Pending transactions</h2>
+      <h2 className="text-lg font-semibold text-gray-900 mb-4">
+        Pending transactions
+      </h2>
       <div className="space-y-3">
         {txs.length === 0 && !loading && (
           <div className="bg-white border border-gray-200 rounded-xl p-5 text-sm text-gray-500">
@@ -610,7 +679,9 @@ export default function TreasuryPage() {
           const approvals = tx.approvals;
           const has = alreadyApproved[tx.id.toString()] ?? false;
           const pct =
-            threshold > 0 ? Math.min(100, Math.round((approvals / threshold) * 100)) : 0;
+            threshold > 0
+              ? Math.min(100, Math.round((approvals / threshold) * 100))
+              : 0;
           const oneMore = threshold - approvals;
           const atThresholdVisual = oneMore <= 1 && oneMore > 0;
 
@@ -618,14 +689,18 @@ export default function TreasuryPage() {
             <div
               key={tx.id.toString()}
               className={`bg-white border rounded-xl p-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 ${
-                atThresholdVisual ? "border-amber-300 ring-1 ring-amber-100" : "border-gray-200"
+                atThresholdVisual
+                  ? "border-amber-300 ring-1 ring-amber-100"
+                  : "border-gray-200"
               }`}
             >
               <div className="min-w-0 flex-1">
                 <p className="text-sm font-medium text-gray-900 leading-snug">
                   {labelPendingTx(tx.target, tx.dataHex)}
                 </p>
-                <p className="text-xs text-gray-400 font-mono mt-1">#{tx.id.toString()}</p>
+                <p className="text-xs text-gray-400 font-mono mt-1">
+                  #{tx.id.toString()}
+                </p>
                 <div className="mt-3 flex items-center gap-3 flex-wrap">
                   <span className="text-sm text-gray-700 font-medium tabular-nums">
                     {approvals}/{threshold}

--- a/app/src/app/treasury/page.tsx
+++ b/app/src/app/treasury/page.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import toast from "react-hot-toast";
 import { useWallet } from "../../lib/wallet-context";
 import { TreasuryClient, type TreasurySpendingCap, type TreasuryTx } from "../../lib/treasury-client";
+import { TreasuryBalanceSkeleton } from "../../components/ui/TreasuryBalanceSkeleton";
 import {
   type CalldataArgKind,
   type CalldataArgRow,
@@ -360,20 +361,24 @@ export default function TreasuryPage() {
       )}
 
       {/* Balances */}
-      <div className="grid grid-cols-2 gap-4 mb-8">
-        <div className="bg-white border border-gray-200 rounded-xl p-6">
-          <p className="text-sm text-gray-500">USDC Balance</p>
-          <p className="text-2xl font-bold mt-1">
-            {loading ? "Loading…" : `${usdcBalance} USDC`}
-          </p>
+      {loading ? (
+        <TreasuryBalanceSkeleton />
+      ) : (
+        <div className="grid grid-cols-2 gap-4 mb-8">
+          <div className="bg-white border border-gray-200 rounded-xl p-6">
+            <p className="text-sm text-gray-500">USDC Balance</p>
+            <p className="text-2xl font-bold mt-1">
+              {`${usdcBalance} USDC`}
+            </p>
+          </div>
+          <div className="bg-white border border-gray-200 rounded-xl p-6">
+            <p className="text-sm text-gray-500">XLM Balance</p>
+            <p className="text-2xl font-bold mt-1">
+              {`${xlmBalance} XLM`}
+            </p>
+          </div>
         </div>
-        <div className="bg-white border border-gray-200 rounded-xl p-6">
-          <p className="text-sm text-gray-500">XLM Balance</p>
-          <p className="text-2xl font-bold mt-1">
-            {loading ? "Loading…" : `${xlmBalance} XLM`}
-          </p>
-        </div>
-      </div>
+      )}
 
       <div className="mb-8 bg-white border border-gray-200 rounded-xl p-6">
         <h2 className="text-lg font-semibold text-gray-900 mb-1">Multisig configuration</h2>

--- a/app/src/components/ShareButton.tsx
+++ b/app/src/components/ShareButton.tsx
@@ -5,13 +5,19 @@ import toast from "react-hot-toast";
 export function ShareButton({ url, title }: { url: string; title?: string }) {
   async function onShare() {
     try {
-      if (typeof navigator !== "undefined" && "share" in navigator) {
+      const nav = typeof navigator !== "undefined" ? navigator : null;
+
+      if (nav && "share" in nav) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await (navigator as any).share({ url, title });
+        await (nav as any).share({ url, title });
         return;
       }
 
-      await navigator.clipboard.writeText(url);
+      if (!nav) {
+        throw new Error("Navigator is unavailable in this environment.");
+      }
+
+      await nav.clipboard.writeText(url);
       toast.success("Link copied!", {
         style: { borderRadius: "10px", background: "#1e1b4b", color: "#fff" },
         iconTheme: { primary: "#818cf8", secondary: "#fff" },

--- a/app/src/lib/address-labels.ts
+++ b/app/src/lib/address-labels.ts
@@ -105,14 +105,23 @@ export function exportCustomLabels(): string {
 export function importCustomLabels(jsonString: string): boolean {
   if (typeof window === "undefined") return false;
   try {
-    const imported = JSON.parse(jsonString);
+    const imported = JSON.parse(jsonString) as Record<string, unknown>;
     const existing = getCustomLabels();
-    const merged = { ...existing, ...imported };
-    const labels: AddressLabel[] = Object.entries(merged).map(([address, label]) => ({
-      address,
-      label,
-      createdAt: Date.now(),
-    }));
+    const merged: Record<string, string> = { ...existing };
+
+    for (const [address, label] of Object.entries(imported)) {
+      if (typeof label === "string") {
+        merged[address] = label;
+      }
+    }
+
+    const labels: AddressLabel[] = Object.entries(merged).map(
+      ([address, label]) => ({
+        address,
+        label,
+        createdAt: Date.now(),
+      }),
+    );
     localStorage.setItem(LS_ADDRESS_LABELS, JSON.stringify(labels));
     return true;
   } catch {

--- a/sdk/src/governor.ts
+++ b/sdk/src/governor.ts
@@ -1054,6 +1054,10 @@ export class GovernorClient {
       .result?.retval;
     if (!raw) throw new Error("No return value");
 
+    const quorum = BigInt(scValToNative(raw));
+    return quorum;
+  }
+
   /**
    * Check if a proposal has reached quorum.
    * Returns true if the sum of for and abstain votes meets or exceeds the required quorum.

--- a/sdk/tsconfig.json
+++ b/sdk/tsconfig.json
@@ -14,5 +14,5 @@
     "sourceMap": true
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/__tests__"]
 }


### PR DESCRIPTION
- Treasury page: Added TreasuryBalanceSkeleton for USDC/XLM balance cards
- Proposal detail: Replaced Loader2 spinner with ProposalDetailSkeleton for full layout preview
- Proposal list: Consolidated inline ProposalSkeleton to use reusable ProposalCardSkeleton component (10 items shown during load)
- Delegates page: Updated DelegateSkeleton to use Skeleton utility component for consistency
- Analytics page: Consolidated local Skeleton definition to use reusable ui component
- Profile page: Fixed dark mode colors (dark:bg-gray-700) for skeleton placeholders

All pages now show consistent skeleton loading states with:
- Skeleton components matching approximate shape and size of actual content
- animate-pulse animation for visual feedback
- Correct dark mode colors (bg-gray-200 / dark:bg-gray-700)
- No external skeleton library dependency (Tailwind CSS only)


Closes #347 