### PR TITLE
fix: harden governance security — queue quorum check, DelegateChanged event, indexer shutdown, factory validation

### DIFF
--- a/contracts/governor-factory/src/lib.rs
+++ b/contracts/governor-factory/src/lib.rs
@@ -3,8 +3,19 @@
 #![allow(deprecated)]
 
 use soroban_sdk::{
-    contract, contractclient, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
+    contract, contractclient, contractimpl, contracterror, contracttype, symbol_short, Address,
+    BytesN, Env,
 };
+
+/// Error codes returned by the governor factory.
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FactoryError {
+    InvalidVotingPeriod = 1,
+    InvalidQuorumNumerator = 2,
+    InvalidTimelockDelay = 3,
+    InvalidVoteType = 4,
+}
 
 #[contracttype]
 #[derive(Clone)]
@@ -114,6 +125,21 @@ impl GovernorFactoryContract {
         proposal_grace_period: u32,
     ) -> u64 {
         deployer.require_auth();
+
+        // Validate settings before deploying so misconfigured governors are
+        // rejected before any contract deployment takes place.
+        if voting_period == 0 {
+            env.panic_with_error(FactoryError::InvalidVotingPeriod);
+        }
+        if quorum_numerator == 0 {
+            env.panic_with_error(FactoryError::InvalidQuorumNumerator);
+        }
+        if timelock_delay == 0 {
+            env.panic_with_error(FactoryError::InvalidTimelockDelay);
+        }
+        if vote_type > 2 {
+            env.panic_with_error(FactoryError::InvalidVoteType);
+        }
 
         let count: u64 = env
             .storage()

--- a/contracts/governor-factory/src/tests.rs
+++ b/contracts/governor-factory/src/tests.rs
@@ -177,3 +177,145 @@ fn test_second_deploy_has_different_addresses() {
     assert_eq!(e1.id, 1);
     assert_eq!(e2.id, 2);
 }
+
+// ─── settings validation tests (issue #477) ───────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_deploy_rejects_zero_voting_period() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    env.register(GovernorContract, ());
+    env.register(TimelockContract, ());
+    env.register(TokenVotesContract, ());
+
+    let (governor_hash, timelock_hash, token_votes_hash) = upload_wasms(&env);
+
+    let admin = Address::generate(&env);
+    let deployer = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let factory_id = env.register(GovernorFactoryContract, ());
+    let factory = GovernorFactoryContractClient::new(&env, &factory_id);
+    factory.initialize(&admin, &governor_hash, &timelock_hash, &token_votes_hash);
+
+    let guardian = Address::generate(&env);
+    factory.deploy(
+        &deployer,
+        &token,
+        &100u32,
+        &0u32,    // zero voting_period — must be rejected
+        &50u32,
+        &0i128,
+        &3600u64,
+        &guardian,
+        &1u32,
+        &120_960u32,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_deploy_rejects_zero_quorum_numerator() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    env.register(GovernorContract, ());
+    env.register(TimelockContract, ());
+    env.register(TokenVotesContract, ());
+
+    let (governor_hash, timelock_hash, token_votes_hash) = upload_wasms(&env);
+
+    let admin = Address::generate(&env);
+    let deployer = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let factory_id = env.register(GovernorFactoryContract, ());
+    let factory = GovernorFactoryContractClient::new(&env, &factory_id);
+    factory.initialize(&admin, &governor_hash, &timelock_hash, &token_votes_hash);
+
+    let guardian = Address::generate(&env);
+    factory.deploy(
+        &deployer,
+        &token,
+        &100u32,
+        &1000u32,
+        &0u32,    // zero quorum_numerator — must be rejected
+        &0i128,
+        &3600u64,
+        &guardian,
+        &1u32,
+        &120_960u32,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_deploy_rejects_zero_timelock_delay() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    env.register(GovernorContract, ());
+    env.register(TimelockContract, ());
+    env.register(TokenVotesContract, ());
+
+    let (governor_hash, timelock_hash, token_votes_hash) = upload_wasms(&env);
+
+    let admin = Address::generate(&env);
+    let deployer = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let factory_id = env.register(GovernorFactoryContract, ());
+    let factory = GovernorFactoryContractClient::new(&env, &factory_id);
+    factory.initialize(&admin, &governor_hash, &timelock_hash, &token_votes_hash);
+
+    let guardian = Address::generate(&env);
+    factory.deploy(
+        &deployer,
+        &token,
+        &100u32,
+        &1000u32,
+        &50u32,
+        &0i128,
+        &0u64,    // zero timelock_delay — must be rejected
+        &guardian,
+        &1u32,
+        &120_960u32,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_deploy_rejects_invalid_vote_type() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    env.register(GovernorContract, ());
+    env.register(TimelockContract, ());
+    env.register(TokenVotesContract, ());
+
+    let (governor_hash, timelock_hash, token_votes_hash) = upload_wasms(&env);
+
+    let admin = Address::generate(&env);
+    let deployer = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let factory_id = env.register(GovernorFactoryContract, ());
+    let factory = GovernorFactoryContractClient::new(&env, &factory_id);
+    factory.initialize(&admin, &governor_hash, &timelock_hash, &token_votes_hash);
+
+    let guardian = Address::generate(&env);
+    factory.deploy(
+        &deployer,
+        &token,
+        &100u32,
+        &1000u32,
+        &50u32,
+        &0i128,
+        &3600u64,
+        &guardian,
+        &99u32,   // invalid vote_type — must be rejected
+        &120_960u32,
+    );
+}

--- a/contracts/governor/src/lib.rs
+++ b/contracts/governor/src/lib.rs
@@ -834,6 +834,15 @@ impl GovernorContract {
 
         let mut proposal = Self::must_get_proposal(&env, proposal_id);
 
+        // Independently re-verify quorum and threshold against the final vote
+        // tally so that stale cached state cannot allow a failed proposal through.
+        let required_quorum = Self::quorum(env.clone(), proposal_id);
+        let quorum_met = proposal.votes_for + proposal.votes_abstain >= required_quorum;
+        let for_wins = proposal.votes_for > proposal.votes_against;
+        if !quorum_met || !for_wins {
+            env.panic_with_error(GovernorError::ProposalNotSucceeded);
+        }
+
         let timelock_addr: Address = env
             .storage()
             .instance()

--- a/contracts/governor/src/tests/transitions.rs
+++ b/contracts/governor/src/tests/transitions.rs
@@ -436,3 +436,45 @@ fn test_execute_batch_executes_all_in_order() {
     assert_eq!(client.state(&proposal_1), ProposalState::Executed);
     assert_eq!(client.state(&proposal_2), ProposalState::Executed);
 }
+
+#[test]
+#[should_panic(expected = "Error(Contract, #14)")]
+/// Verifies that queue() independently re-checks quorum so a defeated proposal
+/// (votes_for == 0) cannot be queued even if the state machine were bypassed.
+/// Issue #461: queue() must independently verify quorum and threshold.
+fn test_queue_rejects_proposal_failing_quorum() {
+    let (env, client, admin, proposer, _voter) = setup();
+    let proposal_id = make_proposal(&env, &client, &proposer);
+
+    // Register a real timelock so queue() can proceed to the vote-tally check.
+    let timelock_id = env.register(sorogov_timelock::TimelockContract, ());
+    let timelock_client = sorogov_timelock::TimelockContractClient::new(&env, &timelock_id);
+    timelock_client.initialize(&admin, &client.address, &0u64, &1_209_600u64);
+
+    let votes_token_id = env.register(MockVotesContract, ());
+    let guardian = Address::generate(&env);
+    // quorum_numerator = 10 means 10% of 10_000_000 = 1_000_000 required.
+    // No votes cast → votes_for = 0 < 1_000_000 quorum.
+    client.initialize(
+        &admin,
+        &votes_token_id,
+        &timelock_id,
+        &10,
+        &100,
+        &10,
+        &0,
+        &guardian,
+        &VoteType::Extended,
+        &120_960,
+    );
+
+    // Advance past end_ledger without any For votes.
+    env.ledger().set_sequence_number(111);
+
+    // state() should return Defeated since quorum is not met.
+    assert_eq!(client.state(&proposal_id), ProposalState::Defeated);
+
+    // queue() must panic with ProposalNotSucceeded (#14) because the
+    // independent quorum re-check also fails.
+    client.queue(&proposal_id);
+}

--- a/contracts/token-votes/src/lib.rs
+++ b/contracts/token-votes/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env,
+    contract, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env, Symbol,
 };
 
 #[cfg(test)]
@@ -183,7 +183,7 @@ impl TokenVotesContract {
             .set(&DataKey::DelegatorRecord(delegator.clone()), &new_record);
 
         env.events().publish(
-            (symbol_short!("del_chsh"), delegator.clone()),
+            (Symbol::new(env, "DelegateChanged"), delegator.clone()),
             (previous_delegate, delegatee),
         );
     }
@@ -1055,6 +1055,7 @@ mod tests {
 
     #[test]
     fn test_delegation_emits_events() {
+        use soroban_sdk::{testutils::Events as _, TryIntoVal as _};
         let env = Env::default();
         env.mock_all_auths();
 
@@ -1071,13 +1072,18 @@ mod tests {
         client.delegate(&delegator, &delegatee);
 
         let events = env.events().all();
-        // Index 0: Mint
-        // Index 1: Update total supply (v_active event might be used if I changed it, wait)
-        // Actually, my current update_account_votes emits "v_active"
-        // and delegate emits "del_chsh"
+        let sub_events: soroban_sdk::Vec<_> =
+            events.iter().filter(|e| e.0 == contract_id).collect();
+        assert!(sub_events.len() >= 2);
 
-        let sub_events = events.iter().filter(|e| e.0 == contract_id);
-        assert!(sub_events.count() >= 2);
+        // The last contract event must be the canonical DelegateChanged event
+        // with the delegator as the second topic element (issue #460).
+        let delegate_changed = sub_events.last().unwrap();
+        let topic_0: Result<Symbol, _> = delegate_changed.1.get(0).unwrap().try_into_val(&env);
+        assert!(topic_0.is_ok());
+        assert_eq!(topic_0.unwrap(), Symbol::new(&env, "DelegateChanged"));
+        let topic_1: Result<Address, _> = delegate_changed.1.get(1).unwrap().try_into_val(&env);
+        assert_eq!(topic_1.unwrap(), delegator);
     }
 
     #[test]

--- a/packages/indexer/src/events.ts
+++ b/packages/indexer/src/events.ts
@@ -15,6 +15,7 @@ const TOPIC_MAP: Record<string, string> = {
   queued: "ProposalQueued",
   executed: "ProposalExecuted",
   delegate: "DelegateChanged",
+  del_chsh: "DelegateChanged",
   config_updated: "ConfigUpdated",
   upgraded: "GovernorUpgraded",
   // New-form (already canonical — identity mappings keep the map exhaustive)

--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -15,6 +15,32 @@ const PORT = Number(process.env.PORT ?? 3001);
 // Track indexer startup time for uptime calculation
 export const startTime = Date.now();
 
+let pollingInterval: ReturnType<typeof setInterval> | null = null;
+let currentBatchPromise: Promise<void> = Promise.resolve();
+let isShuttingDown = false;
+
+async function shutdown(): Promise<void> {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+
+  console.log("Shutting down gracefully...");
+
+  if (pollingInterval !== null) {
+    clearInterval(pollingInterval);
+    pollingInterval = null;
+  }
+
+  // Wait for the in-flight batch to complete before closing the DB connection
+  await currentBatchPromise;
+
+  await pool.end();
+  console.log("Database connections closed.");
+  process.exit(0);
+}
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);
+
 async function runIndexer(): Promise<void> {
   const server = new SorobanRpc.Server(RPC_URL, { allowHttp: false });
 
@@ -29,15 +55,30 @@ async function runIndexer(): Promise<void> {
 
   console.log(`Starting indexer from ledger ${lastLedger}`);
 
-  while (true) {
-    const latestLedger = await processEvents(server, config, lastLedger + 1);
-    if (latestLedger > lastLedger) {
-      await updateLastIndexedLedger(latestLedger);
-      lastLedger = latestLedger;
-      console.log(`Indexed up to ledger ${lastLedger}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  async function pollOnce(): Promise<void> {
+    if (isShuttingDown) return;
+    const batchPromise = (async () => {
+      const latestLedger = await processEvents(server, config, lastLedger + 1);
+      if (latestLedger > lastLedger) {
+        await updateLastIndexedLedger(latestLedger);
+        lastLedger = latestLedger;
+        console.log(`Indexed up to ledger ${lastLedger}`);
+      }
+    })();
+    currentBatchPromise = batchPromise.catch((err) => {
+      console.error("Batch processing error:", err);
+    });
+    await currentBatchPromise;
   }
+
+  // Run the first poll immediately, then schedule subsequent ones.
+  await pollOnce();
+
+  pollingInterval = setInterval(() => {
+    currentBatchPromise = pollOnce().catch((err) => {
+      console.error("Poll error:", err);
+    });
+  }, POLL_INTERVAL_MS);
 }
 
 async function main(): Promise<void> {


### PR DESCRIPTION
## Summary

This PR addresses four security and correctness issues across the governance contracts and indexer:

- **[governor] `queue()` independent quorum re-verification** (#461): The `queue()` function now independently re-checks the final vote tally against quorum and the for-wins condition directly on the stored proposal data, before scheduling via the timelock. Previously, a proposal that narrowly failed quorum could theoretically bypass the governance outcome if `state()` relied on stale cached values.

- **[token-votes] Emit canonical `DelegateChanged` event** (#460): `apply_delegation()` now emits the event using `Symbol::new(&env, "DelegateChanged")` instead of the short `symbol_short!("del_chsh")`. This makes delegation history observable by the indexer and any off-chain analytics. The indexer `TOPIC_MAP` also gains a `del_chsh` → `DelegateChanged` backward-compat mapping so existing deployed contract versions continue to be indexed.

- **[indexer] Graceful SIGTERM/SIGINT shutdown** (#469): `packages/indexer/src/index.ts` now registers `SIGTERM` and `SIGINT` handlers that stop the polling interval, await the current in-flight batch to completion, then cleanly call `pool.end()` before exiting. This prevents partial-batch database state on Kubernetes pod restarts or deployments and ensures all PostgreSQL connections are properly closed.

- **[governor-factory] `deploy()` settings validation** (#477): The factory's `deploy()` function now validates `voting_period`, `quorum_numerator`, `timelock_delay`, and `vote_type` before deploying any contracts, using a typed `FactoryError` enum. Misconfigured governors are rejected at the factory boundary before any on-chain deployment occurs.

## Files Changed

| File | Change |
|------|--------|
| `contracts/governor/src/lib.rs` | Added independent quorum+for-wins re-check inside `queue()` |
| `contracts/governor/src/tests/transitions.rs` | Test: `queue()` rejects proposal failing quorum (#461) |
| `contracts/governor-factory/src/lib.rs` | Added `FactoryError` enum and parameter validation in `deploy()` |
| `contracts/governor-factory/src/tests.rs` | Tests: four validation rejection cases (#477) |
| `contracts/token-votes/src/lib.rs` | Changed delegation event to canonical `DelegateChanged` symbol; updated delegation event test |
| `packages/indexer/src/events.ts` | Added `del_chsh` → `DelegateChanged` to `TOPIC_MAP` |
| `packages/indexer/src/index.ts` | SIGTERM/SIGINT graceful shutdown with in-flight batch drain |

## Test Plan

- [ ] `cargo test --package sorogov-governor` — includes `test_queue_rejects_proposal_failing_quorum`
- [ ] `cargo test --package sorogov-governor-factory` — includes four new `test_deploy_rejects_*` tests
- [ ] `cargo test --package sorogov-token-votes` — `test_delegation_emits_events` now asserts canonical `DelegateChanged` topic
- [ ] `cargo test --workspace` — full contract suite
- [ ] `pnpm test:sdk` — SDK unit tests unaffected
- [ ] Manual: kill the indexer process with SIGTERM during active polling and confirm no partial writes and clean DB connection teardown

Closes #461
Closes #460
Closes #469
Closes #477