### PR TITLE
feat: add WebSocket endpoint to indexer for real-time proposal updates

### DIFF
--- a/app/src/components/GovernorNotificationsProvider.tsx
+++ b/app/src/components/GovernorNotificationsProvider.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 /**
- * Subscribes to governor `prop_crtd` events and polls proposal state while a
- * wallet is connected. Shows browser Notification + appends local history when
- * toggles allow.
+ * Subscribes to governor events via the indexer WebSocket (with polling
+ * fallback) and polls proposal state while a wallet is connected.
+ * Shows browser Notification + appends local history when toggles allow.
  */
 
 import { useEffect, useRef } from "react";
@@ -13,6 +13,7 @@ import {
   subscribeToProposals,
   getProposalEvents,
   parseProposalCreatedEvent,
+  streamEvents,
 } from "@nebgov/sdk";
 import { useWallet } from "../lib/wallet-context";
 import {
@@ -25,6 +26,7 @@ import {
 } from "../lib/governance-notifications";
 import {
   readGovernorConfig,
+  readIndexerUrl,
   subscriptionOptsFromConfig,
 } from "../lib/nebgov-env";
 
@@ -325,9 +327,43 @@ export function GovernorNotificationsProvider({
     void tick();
     const pollTimer = window.setInterval(() => void tick(), POLL_MS);
 
+    const indexerUrl = readIndexerUrl();
+    const unsubStream = indexerUrl
+      ? streamEvents(
+          indexerUrl,
+          (event) => {
+            if (event.type === "proposal_created") {
+              const d = event.data;
+              const id = BigInt(String(d.id ?? 0));
+              mergeProposalMetaEntry(id, {
+                endLedger: Number(d.end_ledger ?? 0),
+                startLedger: Number(d.start_ledger ?? 0),
+                proposer: String(d.proposer ?? ""),
+              });
+              const toggles = loadNotificationToggles();
+              if (toggles.created_self && sameStrKey(String(d.proposer ?? ""), publicKey)) {
+                appendNotificationHistory({
+                  kind: "created_self",
+                  proposalId: id.toString(),
+                  title: `Your proposal #${id} was created`,
+                  body: "It was submitted on-chain from your wallet.",
+                });
+                showSystemNotification(
+                  `Proposal #${id} created`,
+                  "Your wallet submitted this proposal.",
+                  `nebgov-created-${id}`
+                );
+              }
+            }
+          },
+          { types: ["proposal_created", "vote_cast", "proposal_queued", "proposal_executed"] }
+        )
+      : undefined;
+
     return () => {
       stopped = true;
       unsubProposals();
+      unsubStream?.();
       window.clearInterval(pollTimer);
     };
   }, [isConnected, publicKey]);

--- a/app/src/lib/nebgov-env.ts
+++ b/app/src/lib/nebgov-env.ts
@@ -25,3 +25,8 @@ export function subscriptionOptsFromConfig(config: GovernorConfig): {
 } {
   return { network: config.network, ...(config.rpcUrl ? { rpcUrl: config.rpcUrl } : {}) };
 }
+
+/** Returns the indexer base URL or null if not configured. */
+export function readIndexerUrl(): string | null {
+  return process.env.NEXT_PUBLIC_INDEXER_URL ?? null;
+}

--- a/packages/indexer/package-lock.json
+++ b/packages/indexer/package-lock.json
@@ -15,6 +15,7 @@
         "node-pg-migrate": "^8.0.4",
         "pg": "^8.11.0",
         "swagger-ui-express": "^5.0.1",
+        "ws": "^8.21.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -24,6 +25,7 @@
         "@types/pg": "^8.10.0",
         "@types/supertest": "^2.0.12",
         "@types/swagger-ui-express": "^4.1.8",
+        "@types/ws": "^8.18.1",
         "jest": "^29.0.0",
         "supertest": "^6.3.3",
         "ts-jest": "^29.0.0",
@@ -1833,6 +1835,16 @@
       "dependencies": {
         "@types/express": "*",
         "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/yargs": {
@@ -6563,6 +6575,27 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -20,6 +20,7 @@
     "node-pg-migrate": "^8.0.4",
     "pg": "^8.11.0",
     "swagger-ui-express": "^5.0.1",
+    "ws": "^8.21.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -29,6 +30,7 @@
     "@types/pg": "^8.10.0",
     "@types/supertest": "^2.0.12",
     "@types/swagger-ui-express": "^4.1.8",
+    "@types/ws": "^8.18.1",
     "jest": "^29.0.0",
     "supertest": "^6.3.3",
     "ts-jest": "^29.0.0",

--- a/packages/indexer/src/__tests__/ws.test.ts
+++ b/packages/indexer/src/__tests__/ws.test.ts
@@ -1,0 +1,140 @@
+import { WebSocket } from "ws";
+import { broadcast, clearClients, createWsServer, getConnectedClientCount } from "../ws";
+import { createServer } from "http";
+
+function openClient(url: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    ws.once("open", () => resolve(ws));
+    ws.once("error", reject);
+  });
+}
+
+function nextMessage(ws: WebSocket): Promise<string> {
+  return new Promise((resolve) => {
+    ws.once("message", (data) => resolve(data.toString()));
+  });
+}
+
+function waitMs(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+describe("WebSocket broadcast server", () => {
+  let httpServer: ReturnType<typeof createServer>;
+  let serverUrl: string;
+
+  beforeEach((done) => {
+    clearClients();
+    httpServer = createServer();
+    createWsServer(httpServer);
+    httpServer.listen(0, () => {
+      const addr = httpServer.address() as { port: number };
+      serverUrl = `ws://localhost:${addr.port}/events`;
+      done();
+    });
+  });
+
+  afterEach((done) => {
+    clearClients();
+    httpServer.close(done);
+  });
+
+  it("broadcasts an event to a connected client", async () => {
+    const ws = await openClient(serverUrl);
+    const messagePromise = nextMessage(ws);
+
+    broadcast({ type: "proposal_created", data: { id: "1", proposer: "GABC" } });
+
+    const raw = await messagePromise;
+    const msg = JSON.parse(raw);
+    expect(msg.type).toBe("proposal_created");
+    expect(msg.data.id).toBe("1");
+    ws.close();
+  });
+
+  it("broadcasts to multiple connected clients", async () => {
+    const ws1 = await openClient(serverUrl);
+    const ws2 = await openClient(serverUrl);
+    const p1 = nextMessage(ws1);
+    const p2 = nextMessage(ws2);
+
+    broadcast({ type: "vote_cast", data: { proposal_id: "2", voter: "GXYZ" } });
+
+    const [m1, m2] = await Promise.all([p1, p2]);
+    expect(JSON.parse(m1).type).toBe("vote_cast");
+    expect(JSON.parse(m2).type).toBe("vote_cast");
+    ws1.close();
+    ws2.close();
+  });
+
+  it("filters by event type when client sends a filter message", async () => {
+    const ws = await openClient(serverUrl);
+
+    ws.send(JSON.stringify({ types: ["proposal_queued"] }));
+    await waitMs(50);
+
+    broadcast({ type: "vote_cast", data: { proposal_id: "3" } });
+
+    let received = false;
+    ws.once("message", () => { received = true; });
+    await waitMs(100);
+    expect(received).toBe(false);
+
+    const messagePromise = nextMessage(ws);
+    broadcast({ type: "proposal_queued", data: { proposal_id: "3" } });
+    const raw = await messagePromise;
+    expect(JSON.parse(raw).type).toBe("proposal_queued");
+    ws.close();
+  });
+
+  it("filters by proposalId when client sends a filter message", async () => {
+    const ws = await openClient(serverUrl);
+
+    ws.send(JSON.stringify({ proposalId: "5" }));
+    await waitMs(50);
+
+    broadcast({ type: "vote_cast", data: { proposal_id: "6", voter: "G1" } });
+
+    let received = false;
+    ws.once("message", () => { received = true; });
+    await waitMs(100);
+    expect(received).toBe(false);
+
+    const messagePromise = nextMessage(ws);
+    broadcast({ type: "vote_cast", data: { proposal_id: "5", voter: "G2" } });
+    const raw = await messagePromise;
+    expect(JSON.parse(raw).data.proposal_id).toBe("5");
+    ws.close();
+  });
+
+  it("removes client from set on disconnect", async () => {
+    const ws = await openClient(serverUrl);
+    expect(getConnectedClientCount()).toBe(1);
+
+    await new Promise<void>((resolve) => {
+      ws.once("close", resolve);
+      ws.close();
+    });
+    await waitMs(50);
+    expect(getConnectedClientCount()).toBe(0);
+  });
+
+  it("does not throw when no clients are connected", () => {
+    expect(() => {
+      broadcast({ type: "proposal_executed", data: { proposal_id: "1" } });
+    }).not.toThrow();
+  });
+
+  it("ignores malformed filter messages without disconnecting client", async () => {
+    const ws = await openClient(serverUrl);
+    ws.send("not-valid-json");
+    await waitMs(50);
+
+    const messagePromise = nextMessage(ws);
+    broadcast({ type: "proposal_created", data: { id: "10" } });
+    const raw = await messagePromise;
+    expect(JSON.parse(raw).type).toBe("proposal_created");
+    ws.close();
+  });
+});

--- a/packages/indexer/src/events.ts
+++ b/packages/indexer/src/events.ts
@@ -1,6 +1,7 @@
 import { SorobanRpc, scValToNative } from "@stellar/stellar-sdk";
 import { pool } from "./db";
 import { invalidate, invalidatePattern } from "./cache";
+import { broadcast } from "./ws";
 
 /**
  * Normalises both legacy short-symbol topics (e.g. "prop_crtd") and the newer
@@ -183,6 +184,10 @@ async function handleProposalCreated(
     [String(id), proposer, description, startLedger, endLedger],
   );
   invalidate(`profile:${proposer}`);
+  broadcast({
+    type: "proposal_created",
+    data: { id: String(id), proposer, description, start_ledger: startLedger, end_ledger: endLedger },
+  });
 }
 
 async function handleVoteCast(
@@ -221,6 +226,10 @@ async function handleVoteCast(
   ]);
   invalidate(`proposal_votes:${proposalId}`, `profile:${voter}`);
   invalidatePattern("proposals:");
+  broadcast({
+    type: "vote_cast",
+    data: { proposal_id: proposalId, voter, support, weight, reason: reason ?? undefined },
+  });
 }
 
 async function handleProposalQueued(topics: unknown[]): Promise<void> {
@@ -230,6 +239,7 @@ async function handleProposalQueued(topics: unknown[]): Promise<void> {
   ]);
   invalidate(`proposal_votes:${proposalId}`);
   invalidatePattern("proposals:");
+  broadcast({ type: "proposal_queued", data: { proposal_id: proposalId } });
 }
 
 async function handleProposalExecuted(topics: unknown[]): Promise<void> {
@@ -239,6 +249,7 @@ async function handleProposalExecuted(topics: unknown[]): Promise<void> {
   ]);
   invalidate(`proposal_votes:${proposalId}`);
   invalidatePattern("proposals:");
+  broadcast({ type: "proposal_executed", data: { proposal_id: proposalId } });
 }
 
 async function handleDelegateChanged(
@@ -256,6 +267,10 @@ async function handleDelegateChanged(
   );
   invalidatePattern("delegates:");
   invalidate(`profile:${delegator}`);
+  broadcast({
+    type: "delegate_changed",
+    data: { delegator, old_delegatee: oldDelegatee, new_delegatee: newDelegatee, ledger: event.ledger },
+  });
 }
 
 async function handleWrapperDeposit(
@@ -272,6 +287,7 @@ async function handleWrapperDeposit(
     [account, amount, event.ledger],
   );
   invalidate(`profile:${account}`);
+  broadcast({ type: "wrapper_deposit", data: { account, amount, ledger: event.ledger } });
 }
 
 async function handleWrapperWithdraw(
@@ -288,6 +304,7 @@ async function handleWrapperWithdraw(
     [account, amount, event.ledger],
   );
   invalidate(`profile:${account}`);
+  broadcast({ type: "wrapper_withdrawal", data: { account, amount, ledger: event.ledger } });
 }
 
 async function handleTreasuryBatchTransfer(

--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -1,8 +1,10 @@
+import { createServer } from "http";
 import { SorobanRpc } from "@stellar/stellar-sdk";
 import dotenv from "dotenv";
 import { initDb, pool } from "./db";
 import { processEvents, getLastIndexedLedger, updateLastIndexedLedger } from "./events";
 import { createApp } from "./api";
+import { createWsServer } from "./ws";
 
 dotenv.config();
 
@@ -85,11 +87,14 @@ async function main(): Promise<void> {
   await initDb();
   console.log("Database initialized");
 
-  // Start REST API server
-  const server = new SorobanRpc.Server(RPC_URL, { allowHttp: false });
-  const app = createApp(server);
-  app.listen(PORT, () => {
+  // Start REST API + WebSocket server
+  const rpcServer = new SorobanRpc.Server(RPC_URL, { allowHttp: false });
+  const app = createApp(rpcServer);
+  const httpServer = createServer(app);
+  createWsServer(httpServer);
+  httpServer.listen(PORT, () => {
     console.log(`NebGov indexer API running on port ${PORT}`);
+    console.log(`WebSocket endpoint: ws://localhost:${PORT}/events`);
   });
 
   // Start indexer loop

--- a/packages/indexer/src/ws.ts
+++ b/packages/indexer/src/ws.ts
@@ -1,0 +1,94 @@
+import { IncomingMessage, Server as HttpServer } from "http";
+import { WebSocket, WebSocketServer } from "ws";
+
+export type WsEventType =
+  | "proposal_created"
+  | "vote_cast"
+  | "proposal_queued"
+  | "proposal_executed"
+  | "delegate_changed"
+  | "config_updated"
+  | "governor_upgraded"
+  | "wrapper_deposit"
+  | "wrapper_withdrawal";
+
+export interface WsEvent {
+  type: WsEventType;
+  data: Record<string, unknown>;
+}
+
+interface SubscriptionFilter {
+  types?: WsEventType[];
+  proposalId?: string;
+}
+
+interface SubscribedClient {
+  socket: WebSocket;
+  filter: SubscriptionFilter;
+}
+
+const clients = new Set<SubscribedClient>();
+
+function matchesFilter(event: WsEvent, filter: SubscriptionFilter): boolean {
+  if (filter.types && filter.types.length > 0) {
+    if (!filter.types.includes(event.type)) return false;
+  }
+  if (filter.proposalId !== undefined) {
+    const pid = (event.data as any).proposal_id ?? (event.data as any).id;
+    if (String(pid) !== filter.proposalId) return false;
+  }
+  return true;
+}
+
+export function broadcast(event: WsEvent): void {
+  const payload = JSON.stringify(event);
+  for (const client of clients) {
+    if (
+      client.socket.readyState === WebSocket.OPEN &&
+      matchesFilter(event, client.filter)
+    ) {
+      client.socket.send(payload);
+    }
+  }
+}
+
+export function createWsServer(httpServer: HttpServer): WebSocketServer {
+  const wss = new WebSocketServer({ server: httpServer, path: "/events" });
+
+  wss.on("connection", (socket: WebSocket, _req: IncomingMessage) => {
+    const entry: SubscribedClient = { socket, filter: {} };
+    clients.add(entry);
+
+    socket.on("message", (raw) => {
+      try {
+        const msg = JSON.parse(raw.toString()) as {
+          types?: WsEventType[];
+          proposalId?: string;
+        };
+        if (Array.isArray(msg.types)) entry.filter.types = msg.types;
+        if (typeof msg.proposalId === "string")
+          entry.filter.proposalId = msg.proposalId;
+      } catch {
+        /* ignore malformed filter messages */
+      }
+    });
+
+    socket.on("close", () => {
+      clients.delete(entry);
+    });
+
+    socket.on("error", () => {
+      clients.delete(entry);
+    });
+  });
+
+  return wss;
+}
+
+export function getConnectedClientCount(): number {
+  return clients.size;
+}
+
+export function clearClients(): void {
+  clients.clear();
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -80,3 +80,5 @@ export {
 } from "./events";
 export * from "./types";
 export { computeQuadraticWeight, hexToBytes32 } from "./utils";
+export { streamEvents } from "./streamEvents";
+export type { IndexerEvent, WsEventType, StreamEventsOptions, UnsubscribeFn } from "./streamEvents";

--- a/sdk/src/streamEvents.ts
+++ b/sdk/src/streamEvents.ts
@@ -1,0 +1,177 @@
+export type WsEventType =
+  | "proposal_created"
+  | "vote_cast"
+  | "proposal_queued"
+  | "proposal_executed"
+  | "delegate_changed"
+  | "config_updated"
+  | "governor_upgraded"
+  | "wrapper_deposit"
+  | "wrapper_withdrawal";
+
+export interface IndexerEvent {
+  type: WsEventType;
+  data: Record<string, unknown>;
+}
+
+export interface StreamEventsOptions {
+  /** Filter to specific event types. If omitted, all types are received. */
+  types?: WsEventType[];
+  /** Filter to a specific proposal ID. */
+  proposalId?: string;
+  /** Reconnect delay in ms (default 3000). */
+  reconnectDelayMs?: number;
+  /** Polling interval in ms used as fallback when WebSocket is unavailable (default 10000). */
+  pollIntervalMs?: number;
+  /** Custom fetch function for polling fallback (default: global fetch). */
+  fetchFn?: typeof fetch;
+}
+
+export type UnsubscribeFn = () => void;
+
+function buildWsUrl(indexerUrl: string): string {
+  return indexerUrl.replace(/^http/, "ws").replace(/\/$/, "") + "/events";
+}
+
+function buildPollUrl(indexerUrl: string): string {
+  return indexerUrl.replace(/\/$/, "") + "/proposals?limit=20";
+}
+
+/**
+ * Connects to the indexer WebSocket and calls `handler` on each matching event.
+ * Falls back to polling `GET /proposals` if WebSocket is unavailable.
+ * Returns an unsubscribe function that stops the stream and closes connections.
+ */
+export function streamEvents(
+  indexerUrl: string,
+  handler: (event: IndexerEvent) => void,
+  opts: StreamEventsOptions = {}
+): UnsubscribeFn {
+  const {
+    types,
+    proposalId,
+    reconnectDelayMs = 3000,
+    pollIntervalMs = 10_000,
+    fetchFn = typeof fetch !== "undefined" ? fetch : undefined,
+  } = opts;
+
+  let stopped = false;
+  let ws: WebSocket | null = null;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let usingPolling = false;
+
+  function stopPolling() {
+    if (pollTimer !== null) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+  }
+
+  function startPolling() {
+    if (!fetchFn || usingPolling) return;
+    usingPolling = true;
+    const url = buildPollUrl(indexerUrl);
+    let lastSeenId: string | null = null;
+
+    async function poll() {
+      if (stopped) return;
+      try {
+        const res = await fetchFn!(url);
+        if (!res.ok) return;
+        const body = (await res.json()) as { proposals?: Array<{ id: string | number; [k: string]: unknown }> };
+        const proposals = body.proposals ?? [];
+        for (const p of proposals) {
+          const id = String(p.id);
+          if (lastSeenId !== null && id <= lastSeenId) continue;
+          const event: IndexerEvent = { type: "proposal_created", data: p as Record<string, unknown> };
+          if (matchesFilter(event)) handler(event);
+        }
+        if (proposals.length > 0) {
+          lastSeenId = String(proposals[0].id);
+        }
+      } catch {
+        /* polling best-effort */
+      }
+    }
+
+    void poll();
+    pollTimer = setInterval(() => void poll(), pollIntervalMs);
+  }
+
+  function matchesFilter(event: IndexerEvent): boolean {
+    if (types && types.length > 0 && !types.includes(event.type)) return false;
+    if (proposalId !== undefined) {
+      const pid = (event.data as any).proposal_id ?? (event.data as any).id;
+      if (String(pid) !== proposalId) return false;
+    }
+    return true;
+  }
+
+  function connect() {
+    if (stopped) return;
+
+    const WS = typeof WebSocket !== "undefined"
+      ? WebSocket
+      : (() => { startPolling(); return null; })();
+
+    if (!WS) return;
+
+    const wsUrl = buildWsUrl(indexerUrl);
+    try {
+      ws = new WS(wsUrl) as WebSocket;
+    } catch {
+      startPolling();
+      return;
+    }
+
+    ws.onopen = () => {
+      stopPolling();
+      usingPolling = false;
+      if (types || proposalId) {
+        ws!.send(JSON.stringify({ types, proposalId }));
+      }
+    };
+
+    ws.onmessage = (ev) => {
+      try {
+        const event = JSON.parse(
+          typeof ev.data === "string" ? ev.data : ev.data.toString()
+        ) as IndexerEvent;
+        if (matchesFilter(event)) handler(event);
+      } catch {
+        /* ignore malformed messages */
+      }
+    };
+
+    ws.onerror = () => {
+      /* handled by onclose */
+    };
+
+    ws.onclose = () => {
+      ws = null;
+      if (stopped) return;
+      startPolling();
+      reconnectTimer = setTimeout(() => {
+        if (!stopped) {
+          stopPolling();
+          usingPolling = false;
+          connect();
+        }
+      }, reconnectDelayMs);
+    };
+  }
+
+  connect();
+
+  return function unsubscribe() {
+    stopped = true;
+    if (reconnectTimer !== null) clearTimeout(reconnectTimer);
+    stopPolling();
+    if (ws !== null) {
+      ws.onclose = null;
+      ws.close();
+      ws = null;
+    }
+  };
+}


### PR DESCRIPTION
Closes #226

## What changed
- Added `packages/indexer/src/ws.ts`: WebSocket server on `ws://indexer/events` using the `ws` package. Clients can send a filter message `{ types, proposalId }` after connecting to receive only relevant events. Disconnected clients are cleaned up automatically.
- Updated `packages/indexer/src/events.ts`: each event handler (`proposal_created`, `vote_cast`, `proposal_queued`, `proposal_executed`, `delegate_changed`, `wrapper_deposit`, `wrapper_withdrawal`) now broadcasts to connected WebSocket clients immediately after writing to the DB.
- Updated `packages/indexer/src/index.ts`: switched from `app.listen()` to `http.createServer(app)` so the WebSocket server shares the same port as the REST API.
- Added `sdk/src/streamEvents.ts`: `streamEvents(indexerUrl, handler, opts)` that connects to the WebSocket, applies optional type/proposalId filtering, auto-reconnects on disconnect (default 3 s delay), and falls back to polling `GET /proposals` when WebSocket is unavailable.
- Exported `streamEvents` and related types from `sdk/src/index.ts`.
- Updated `app/src/components/GovernorNotificationsProvider.tsx`: subscribes to `streamEvents()` for push notifications; polling loop is kept as a fallback when the indexer URL is not configured.
- Added `app/src/lib/nebgov-env.ts`: `readIndexerUrl()` reads `NEXT_PUBLIC_INDEXER_URL`.

## Why
- Polling every client every 10 s creates unnecessary load as the number of connected frontends grows.
- WebSocket push reduces latency from ~10 s average to near-zero for new proposals and votes.
- Fallback to polling ensures the frontend remains functional when the WebSocket is unavailable.

## How to test
- Set `NEXT_PUBLIC_INDEXER_URL=http://localhost:3001` in the app env.
- Start the indexer (`npm run dev` in `packages/indexer`).
- Open a WebSocket client to `ws://localhost:3001/events` and observe events as proposals/votes are processed.
- Optionally send `{ "types": ["vote_cast"] }` to subscribe to vote events only.
- Run indexer unit tests: `cd packages/indexer && npm test -- --testPathPattern=ws`