### PR TITLE
fix: address issues #437 #439 #429 #447

### DIFF
--- a/contracts/governor/src/lib.rs
+++ b/contracts/governor/src/lib.rs
@@ -1,5 +1,8 @@
 #![no_std]
 #![allow(clippy::too_many_arguments)]
+// Prevent future introduction of dead match patterns in this security-critical
+// state machine (issue #439).
+#![deny(unreachable_patterns)]
 
 mod events;
 
@@ -41,6 +44,13 @@ pub enum GovernorError {
     VotesTokenNotSet = 25,
     PauserNotSet = 26,
     ArithmeticOverflow = 27,
+    /// Proposal contains more calldata entries than the on-chain maximum.
+    ///
+    /// Even when every individual calldata entry is within `MaxCalldataSize`,
+    /// a proposal with thousands of tiny entries can exhaust the Soroban
+    /// compute budget during `execute()`.  This error is returned by
+    /// `propose()` when `calldata.len() > MAX_CALLDATA_COUNT`.
+    TooManyCalldataEntries = 28,
 }
 
 /// Cross-contract interface for the Timelock contract.
@@ -529,6 +539,20 @@ impl GovernorContract {
             if calldata.len() > max_calldata_size {
                 env.panic_with_error(GovernorError::CalldataTooLarge);
             }
+        }
+
+        // Validate calldata count (Issue #447)
+        //
+        // MaxCalldataSize limits the byte size of each individual calldata entry,
+        // but does not bound the *number* of entries.  A proposal with thousands
+        // of tiny entries would pass the size check yet exhaust the Soroban
+        // compute budget when execute() iterates and dispatches every entry.
+        //
+        // 10 is a conservative upper bound that covers all realistic batch
+        // governance proposals while preventing compute-exhaustion attacks.
+        const MAX_CALLDATA_COUNT: u32 = 10;
+        if calldatas.len() > MAX_CALLDATA_COUNT {
+            env.panic_with_error(GovernorError::TooManyCalldataEntries);
         }
 
         // Rate limiting checks (Issue #188)
@@ -1312,9 +1336,13 @@ impl GovernorContract {
         } else if !quorum_met || against_wins_or_ties {
             ProposalState::Defeated
         } else {
-            // Defensive fallback: with quorum_met=false or against_wins_or_ties=true,
-            // we must have already returned Defeated above.
-            ProposalState::Defeated
+            // This branch is structurally unreachable: the outer condition
+            // `!(quorum_met && for_wins)` means at least one of `!quorum_met`
+            // or `against_wins_or_ties` is true, so the `else if` above always
+            // matches first.  The `unreachable!()` here documents that intent
+            // and will panic loudly if a future refactor accidentally makes
+            // this path reachable (issue #439).
+            unreachable!("state machine invariant violated: defeated branch must have been taken")
         }
     }
 

--- a/packages/indexer/src/__tests__/api.test.ts
+++ b/packages/indexer/src/__tests__/api.test.ts
@@ -272,3 +272,124 @@ describe("GET /proposals with cursor pagination", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Rate limiting tests (issue #437)
+// ---------------------------------------------------------------------------
+describe("Rate limiting", () => {
+  /**
+   * Each test creates a fresh app instance so the in-process rate-limit
+   * store is reset between test cases.
+   *
+   * NOTE: The general limiter allows 100 req / 15 min and the strict limiter
+   * allows 30 req / 15 min.  We exhaust each by sending one extra request
+   * beyond the limit and asserting the final response is HTTP 429.
+   */
+  let rateLimitApp: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const freshServer = {
+      getLatestLedger: jest.fn().mockResolvedValue({ sequence: 1050 }),
+    } as any;
+    rateLimitApp = createApp(freshServer);
+
+    // Default mock so route handlers don't throw on DB calls.
+    (pool.query as jest.Mock).mockResolvedValue({ rows: [], rowCount: 0 });
+  });
+
+  it("should include X-RateLimit-* headers on normal requests", async () => {
+    const response = await request(rateLimitApp)
+      .get("/proposals/1")
+      .set("X-Forwarded-For", "192.0.2.1");
+
+    expect(response.headers["x-ratelimit-limit"]).toBeDefined();
+    expect(response.headers["x-ratelimit-remaining"]).toBeDefined();
+    expect(response.headers["x-ratelimit-reset"]).toBeDefined();
+  });
+
+  it("should return 429 after exceeding the general rate limit (100 req/15 min)", async () => {
+    const responses: number[] = [];
+    for (let i = 0; i <= 100; i++) {
+      (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      const r = await request(rateLimitApp)
+        .get("/proposals/1")
+        .set("X-Forwarded-For", "192.0.2.10");
+      responses.push(r.status);
+    }
+
+    // The 101st request (index 100) must be rate-limited.
+    expect(responses[100]).toBe(429);
+    // All earlier requests must not be 429.
+    expect(responses.slice(0, 100).every((s) => s !== 429)).toBe(true);
+  });
+
+  it("should return 429 with Retry-After header when rate limited", async () => {
+    for (let i = 0; i <= 100; i++) {
+      (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      await request(rateLimitApp)
+        .get("/proposals/1")
+        .set("X-Forwarded-For", "192.0.2.11");
+    }
+
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const limited = await request(rateLimitApp)
+      .get("/proposals/1")
+      .set("X-Forwarded-For", "192.0.2.11");
+
+    expect(limited.status).toBe(429);
+    expect(limited.headers["retry-after"]).toBeDefined();
+    expect(limited.body.error).toMatch(/too many requests/i);
+  });
+
+  it("should apply stricter limit (30 req/15 min) to /delegates", async () => {
+    const responses: number[] = [];
+    for (let i = 0; i <= 30; i++) {
+      (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      const r = await request(rateLimitApp)
+        .get("/delegates")
+        .set("X-Forwarded-For", "192.0.2.20");
+      responses.push(r.status);
+    }
+
+    expect(responses[30]).toBe(429);
+    expect(responses.slice(0, 30).every((s) => s !== 429)).toBe(true);
+  });
+
+  it("should apply stricter limit (30 req/15 min) to /profile/:address", async () => {
+    const responses: number[] = [];
+    for (let i = 0; i <= 30; i++) {
+      (pool.query as jest.Mock)
+        .mockResolvedValueOnce({ rows: [{ count: "0" }] })
+        .mockResolvedValueOnce({ rows: [{ count: "0", sum: null }] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ sum: "0" }] })
+        .mockResolvedValueOnce({ rows: [{ sum: "0" }] });
+      const r = await request(rateLimitApp)
+        .get("/profile/GABC123")
+        .set("X-Forwarded-For", "192.0.2.21");
+      responses.push(r.status);
+    }
+
+    expect(responses[30]).toBe(429);
+    expect(responses.slice(0, 30).every((s) => s !== 429)).toBe(true);
+  });
+
+  it("should track rate limits independently per IP address", async () => {
+    // Exhaust the limit for IP A.
+    for (let i = 0; i <= 100; i++) {
+      (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      await request(rateLimitApp)
+        .get("/proposals/1")
+        .set("X-Forwarded-For", "192.0.2.30");
+    }
+
+    // IP B should still be within its own limit.
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const ipBResponse = await request(rateLimitApp)
+      .get("/proposals/1")
+      .set("X-Forwarded-For", "192.0.2.31");
+
+    expect(ipBResponse.status).not.toBe(429);
+  });
+});

--- a/packages/indexer/src/api.ts
+++ b/packages/indexer/src/api.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response } from "express";
+import express, { Request, Response, NextFunction } from "express";
 import { SorobanRpc } from "@stellar/stellar-sdk";
 import { pool } from "./db";
 import { cached, getMetrics } from "./cache";
@@ -6,6 +6,107 @@ import { getLastIndexedLedger } from "./events";
 import { startTime } from "./index";
 import swaggerUi from "swagger-ui-express";
 import { generateOpenApiDocument } from "./openapi";
+
+// ---------------------------------------------------------------------------
+// In-process rate limiter (issue #437)
+//
+// Tracks request counts per IP in a sliding window. No external dependency
+// required — the store is a plain Map that is pruned on every request so
+// memory usage stays bounded.
+// ---------------------------------------------------------------------------
+
+interface RateLimitEntry {
+  count: number;
+  windowStart: number;
+}
+
+const rateLimitStore = new Map<string, RateLimitEntry>();
+
+/**
+ * Build an Express middleware that limits each IP to `max` requests within
+ * a rolling `windowMs` millisecond window.
+ *
+ * When the limit is exceeded the middleware responds with HTTP 429 and a
+ * JSON body that includes a `Retry-After` header (seconds until the window
+ * resets) so well-behaved clients can back off automatically.
+ */
+function createRateLimiter(options: {
+  windowMs: number;
+  max: number;
+  message?: string;
+}) {
+  const { windowMs, max, message = "Too many requests, please try again later." } = options;
+
+  return function rateLimitMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): void {
+    const ip =
+      (req.headers["x-forwarded-for"] as string | undefined)?.split(",")[0].trim() ??
+      req.socket.remoteAddress ??
+      "unknown";
+
+    const now = Date.now();
+
+    // Prune stale entries to keep the store from growing unboundedly.
+    for (const [key, entry] of rateLimitStore.entries()) {
+      if (now - entry.windowStart > windowMs) {
+        rateLimitStore.delete(key);
+      }
+    }
+
+    const entry = rateLimitStore.get(ip);
+
+    if (!entry || now - entry.windowStart > windowMs) {
+      // First request in this window (or window has expired).
+      rateLimitStore.set(ip, { count: 1, windowStart: now });
+      res.setHeader("X-RateLimit-Limit", max);
+      res.setHeader("X-RateLimit-Remaining", max - 1);
+      res.setHeader("X-RateLimit-Reset", Math.ceil((now + windowMs) / 1000));
+      next();
+      return;
+    }
+
+    entry.count += 1;
+    const remaining = Math.max(0, max - entry.count);
+    const resetAt = Math.ceil((entry.windowStart + windowMs) / 1000);
+
+    res.setHeader("X-RateLimit-Limit", max);
+    res.setHeader("X-RateLimit-Remaining", remaining);
+    res.setHeader("X-RateLimit-Reset", resetAt);
+
+    if (entry.count > max) {
+      const retryAfter = Math.ceil((entry.windowStart + windowMs - now) / 1000);
+      res.setHeader("Retry-After", retryAfter);
+      res.status(429).json({ error: message });
+      return;
+    }
+
+    next();
+  };
+}
+
+/** General-purpose limiter: 100 requests per 15-minute window per IP. */
+const generalLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100,
+});
+
+/**
+ * Stricter limiter for expensive / enumeration-prone endpoints.
+ *
+ * Applied to:
+ *   - GET /delegates  (N+1 query risk)
+ *   - GET /profile/:address  (enumeration attack surface)
+ *
+ * Allows 30 requests per 15-minute window per IP.
+ */
+const strictLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000,
+  max: 30,
+  message: "Too many requests to this endpoint, please slow down.",
+});
 
 const TTL = {
   proposals: 30_000, // 30 seconds
@@ -140,6 +241,11 @@ async function getStatsStatus(server: SorobanRpc.Server): Promise<StatsResponse>
 export function createApp(server: SorobanRpc.Server): express.Application {
   const app = express();
   app.use(express.json());
+
+  // Apply general rate limiting to all routes (issue #437).
+  // Health and docs endpoints are intentionally included so that monitoring
+  // probes cannot be weaponised to exhaust the database connection pool.
+  app.use(generalLimiter);
 
   // Swagger documentation
   app.get("/openapi.json", (_req, res) => {
@@ -360,7 +466,7 @@ export function createApp(server: SorobanRpc.Server): express.Application {
   );
 
   // GET /delegates?top=20
-  app.get("/delegates", async (req: Request, res: Response): Promise<void> => {
+  app.get("/delegates", strictLimiter, async (req: Request, res: Response): Promise<void> => {
     const top = Math.min(Number(req.query.top ?? 20), 100);
     const key = `delegates:${top}`;
     try {
@@ -387,6 +493,7 @@ export function createApp(server: SorobanRpc.Server): express.Application {
   // GET /profile/:address
   app.get(
     "/profile/:address",
+    strictLimiter,
     async (req: Request, res: Response): Promise<void> => {
       const { address } = req.params;
       const key = `profile:${address}`;

--- a/sdk/src/__tests__/governor.test.ts
+++ b/sdk/src/__tests__/governor.test.ts
@@ -786,3 +786,118 @@ describe("GovernorClient", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// uploadProposalMetadata tests (issue #429)
+// ---------------------------------------------------------------------------
+import { uploadProposalMetadata, MetadataUploadOptions } from "../governor";
+
+describe("uploadProposalMetadata()", () => {
+  const description = "Fund the security audit for the NebGov contracts.";
+
+  beforeEach(() => {
+    // Reset fetch mock between tests.
+    jest.restoreAllMocks();
+  });
+
+  it("uses customUploader when provided and returns uri + hash", async () => {
+    const customUploader = jest.fn().mockResolvedValue("ipfs://QmCustomHash");
+    const options: MetadataUploadOptions = { customUploader };
+
+    const result = await uploadProposalMetadata(description, options);
+
+    expect(customUploader).toHaveBeenCalledWith(description);
+    expect(result.uri).toBe("ipfs://QmCustomHash");
+    expect(result.hash).toMatch(/^[0-9a-f]{64}$/); // 64-char hex SHA-256
+  });
+
+  it("uploads via Pinata JWT and returns ipfs:// URI", async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ IpfsHash: "QmPinataHash123" }),
+    });
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const options: MetadataUploadOptions = { pinataApiKey: "test-jwt-token" };
+    const result = await uploadProposalMetadata(description, options);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.pinata.cloud/pinning/pinJSONToIPFS",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-jwt-token",
+        }),
+      }),
+    );
+    expect(result.uri).toBe("ipfs://QmPinataHash123");
+    expect(result.hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("uploads via Pinata legacy API key + secret pair", async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ IpfsHash: "QmLegacyHash456" }),
+    });
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const options: MetadataUploadOptions = {
+      pinataApiKey: "my-api-key",
+      pinataSecretKey: "my-secret-key",
+    };
+    const result = await uploadProposalMetadata(description, options);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.pinata.cloud/pinning/pinJSONToIPFS",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          pinata_api_key: "my-api-key",
+          pinata_secret_api_key: "my-secret-key",
+        }),
+      }),
+    );
+    expect(result.uri).toBe("ipfs://QmLegacyHash456");
+  });
+
+  it("throws when Pinata returns a non-OK response", async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => "Unauthorized",
+    });
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const options: MetadataUploadOptions = { pinataApiKey: "bad-key" };
+
+    await expect(uploadProposalMetadata(description, options)).rejects.toThrow(
+      "Pinata upload failed: 401 Unauthorized",
+    );
+  });
+
+  it("throws a clear error when no provider is configured", async () => {
+    const options: MetadataUploadOptions = {};
+
+    await expect(uploadProposalMetadata(description, options)).rejects.toThrow(
+      "No IPFS upload provider configured in options",
+    );
+  });
+
+  it("does NOT have a web3StorageToken field on MetadataUploadOptions (compile-time removal)", () => {
+    // This test documents that web3StorageToken has been removed from the
+    // public interface (issue #429).  TypeScript would catch this at compile
+    // time; here we verify it at runtime via the object shape.
+    const options: MetadataUploadOptions = {
+      customUploader: async () => "ipfs://test",
+    };
+    expect("web3StorageToken" in options).toBe(false);
+  });
+
+  it("customUploader errors propagate to the caller", async () => {
+    const customUploader = jest.fn().mockRejectedValue(new Error("IPFS node unreachable"));
+    const options: MetadataUploadOptions = { customUploader };
+
+    await expect(uploadProposalMetadata(description, options)).rejects.toThrow(
+      "IPFS node unreachable",
+    );
+  });
+});

--- a/sdk/src/governor.ts
+++ b/sdk/src/governor.ts
@@ -37,9 +37,23 @@ export interface MetadataUploadOptions {
   pinataApiKey?: string;
   /** Pinata Secret Key (if using API Key/Secret pair) */
   pinataSecretKey?: string;
-  /** web3.storage API token */
-  web3StorageToken?: string;
-  /** Custom uploader function for other IPFS gateways */
+  /**
+   * Custom uploader function for other IPFS gateways.
+   *
+   * Use this to integrate any storage provider not natively supported by the
+   * SDK (e.g. web3.storage, nft.storage, Filebase, etc.).  The function
+   * receives the raw description string and must return a fully-qualified
+   * IPFS URI (`ipfs://…`).
+   *
+   * @example
+   * // web3.storage integration (tracked in issue #429)
+   * const options: MetadataUploadOptions = {
+   *   customUploader: async (content) => {
+   *     // Use @web3-storage/w3up-client or any compatible library here.
+   *     throw new Error("web3.storage uploader not yet configured");
+   *   },
+   * };
+   */
   customUploader?: (content: string) => Promise<string>;
 }
 
@@ -2314,8 +2328,6 @@ export async function uploadProposalMetadata(
 
     const data = (await response.json()) as { IpfsHash: string };
     uri = `ipfs://${data.IpfsHash}`;
-  } else if (options.web3StorageToken) {
-    throw new Error("web3.storage support not yet implemented");
   } else {
     throw new Error("No IPFS upload provider configured in options");
   }


### PR DESCRIPTION
#437 [indexer] Add in-process rate limiting to all API endpoints
- Implement lightweight sliding-window rate limiter with no external deps
- General limiter: 100 req / 15 min per IP on all routes
- Strict limiter: 30 req / 15 min per IP on /delegates and /profile/:address
- Returns HTTP 429 with Retry-After header and X-RateLimit-* headers
- Rate limit store is pruned on every request to bound memory usage
- Add comprehensive tests covering per-IP tracking, 429 responses, headers

#429 [sdk] Remove false web3Storage branch from uploadProposalMetadata
- Remove web3StorageToken from MetadataUploadOptions interface
- Remove runtime throw that gave false impression of web3.storage support
- Document web3.storage as a customUploader use-case in JSDoc
- Add tests for Pinata JWT, legacy key/secret, customUploader, error paths

#447 [governor] Enforce MAX_CALLDATA_COUNT=10 in propose()
- Add TooManyCalldataEntries = 28 to GovernorError enum
- Add MAX_CALLDATA_COUNT constant (10 entries) and count check in propose()
- Prevents compute-exhaustion attack via thousands of tiny calldata entries

#439 [governor] Mark dead state machine branch as unreachable
- Add #![deny(unreachable_patterns)] to prevent future dead patterns
- Replace silent dead else-branch in state() with unreachable!() macro
- Documents the invariant: !(quorum_met && for_wins) always matches else-if

Closes #437
Closes #429
Closes #447
Closes #439