### PR TITLE
fix: resolve issues #409, #410, #411, #419

### DIFF
--- a/app/src/app/propose/page.tsx
+++ b/app/src/app/propose/page.tsx
@@ -116,7 +116,11 @@ function getClients() {
 function buildDescription(title: string, desc: string, ipfs: string): string {
   // We store the title + description content on-chain as a single string
   // and we also store the IPFS link for rich metadata access.
-  return `${title}\n\n${desc}`;
+  const base = `${title}\n\n${desc}`;
+  if (ipfs) {
+    return `${base}\n\n<!-- ipfs:${ipfs} -->`;
+  }
+  return base;
 }
 
 function buildPayload(actions: WizardAction[], governorAddress: string) {

--- a/contracts/governor-factory/src/lib.rs
+++ b/contracts/governor-factory/src/lib.rs
@@ -77,6 +77,13 @@ pub trait GovernorTrait {
         vote_type: VoteType,
         proposal_grace_period: u32,
     );
+    fn set_initial_config(
+        env: Env,
+        admin: Address,
+        max_calldata_size: u32,
+        proposal_cooldown: u32,
+        max_proposals_per_period: u32,
+    );
 }
 
 #[contract]

--- a/contracts/governor/src/lib.rs
+++ b/contracts/governor/src/lib.rs
@@ -46,6 +46,7 @@ pub enum GovernorError {
     ArithmeticOverflow = 27,
     VotePeriodTooShort = 28,
     ExecutionWindowZero = 29,
+    TooManyCalldataEntries = 30,
 }
 
 /// Cross-contract interface for the Timelock contract.
@@ -496,6 +497,50 @@ impl GovernorContract {
         env.storage().instance().set(&DataKey::IsPaused, &false);
         // Set admin as initial pauser
         env.storage().instance().set(&DataKey::Pauser, &admin);
+    }
+
+    /// Override security settings after initialization (admin-only, before any proposals).
+    ///
+    /// The governor's `initialize()` hardcodes three security values:
+    /// `MaxCalldataSize = 10000`, `ProposalCooldown = 100`, and
+    /// `MaxProposalsPerPeriod = 5`.  This function lets the admin change
+    /// those values before the first proposal is created.
+    ///
+    /// After the first proposal is submitted, this function can no longer
+    /// be called and operators must use the governance `update_config` path instead.
+    pub fn set_initial_config(
+        env: Env,
+        admin: Address,
+        max_calldata_size: u32,
+        proposal_cooldown: u32,
+        max_proposals_per_period: u32,
+    ) {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| env.panic_with_error(GovernorError::UnauthorizedPause));
+        if admin != stored_admin {
+            env.panic_with_error(GovernorError::UnauthorizedPause);
+        }
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProposalCount)
+            .unwrap_or(0);
+        if count > 0 {
+            env.panic_with_error(GovernorError::ProposalRateLimited);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxCalldataSize, &max_calldata_size);
+        env.storage()
+            .instance()
+            .set(&DataKey::ProposalCooldown, &proposal_cooldown);
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxProposalsPerPeriod, &max_proposals_per_period);
     }
 
     /// Create a new governance proposal.

--- a/contracts/token-votes-wrapper/src/lib.rs
+++ b/contracts/token-votes-wrapper/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env, Vec};
 
 /// A voting power checkpoint at a specific ledger sequence.
 #[contracttype]
@@ -141,6 +141,19 @@ impl TokenVotesWrapperContract {
         env.storage()
             .instance()
             .set(&DataKey::UnderlyingToken, &underlying_token);
+    }
+
+    /// Upgrade the contract WASM.
+    /// Only the admin (governor) can call this.
+    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+        env.deployer().update_current_contract_wasm(new_wasm_hash.clone());
+        env.events().publish((symbol_short!("upgrade"),), (new_wasm_hash,));
     }
 
     /// Deposit `amount` of the underlying SEP-41 token and receive 1:1 wrapped voting tokens.

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -92,6 +92,7 @@ pub enum DataKey {
     SpentThisPeriod(Address, u32),
     IsSlashed(Address),
     SlashingHistory(Address),
+    PendingOwner,
 }
 
 #[contractclient(name = "TreasuryClient")]
@@ -142,6 +143,49 @@ impl TreasuryContract {
         env.storage()
             .instance()
             .set(&DataKey::DayWindowStart, &env.ledger().timestamp());
+    }
+
+    /// Propose a new owner (governor) for the treasury.
+    /// Current governor must call this.
+    pub fn propose_owner(env: Env, new_owner: Address) {
+        let governor: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Governor)
+            .expect("not initialized");
+        governor.require_auth();
+        env.storage()
+            .instance()
+            .set(&DataKey::PendingOwner, &new_owner);
+        env.events()
+            .publish((Symbol::new(&env, "OwnershipProposed"),), (new_owner,));
+    }
+
+    /// Accept ownership of the treasury.
+    /// New owner must call this to finalize the transfer.
+    pub fn accept_ownership(env: Env) {
+        let pending: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingOwner)
+            .expect("no pending owner");
+        pending.require_auth();
+        env.storage()
+            .instance()
+            .set(&DataKey::Governor, &pending);
+        env.storage()
+            .instance()
+            .remove(&DataKey::PendingOwner);
+        env.events()
+            .publish((Symbol::new(&env, "OwnershipTransferred"),), (pending,));
+    }
+
+    /// Get the current owner (governor) address.
+    pub fn get_owner(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::Governor)
+            .expect("not initialized")
     }
 
     /// Configure a per-token spending cap for batch transfers.


### PR DESCRIPTION
### Summary

### Changes

**#419 — buildDescription ignores ipfs parameter** (`app/src/app/propose/page.tsx`)
- `buildDescription` now appends an HTML comment `<!-- ipfs:<hash> -->` when the `ipfs` string is non-empty, so the hash is stored on-chain.

**#411 — governor initialize() hardcodes settings** (`contracts/governor/src/lib.rs`, `contracts/governor-factory/src/lib.rs`)
- Added `set_initial_config(admin, max_calldata_size, proposal_cooldown, max_proposals_per_period)` as an admin-only function callable before the first proposal.
- Uses a separate function instead of bloating `initialize()` past Soroban's 10-parameter limit (both `initialize` and factory `deploy` already hit the ceiling).
- Also added the missing `GovernorError::TooManyCalldataEntries = 30` variant (referenced at line 555 but absent from the enum).

**#410 — treasury ownership transfer mechanism** (`contracts/treasury/src/lib.rs`)
- Two-step ownership transfer: `propose_owner()` (current governor nominates), `accept_ownership()` (new owner accepts).
- Added `PendingOwner` to `DataKey` enum.
- Added `get_owner()` read function.
- Events emitted for `OwnershipProposed` and `OwnershipTransferred`.

**#409 — token-votes-wrapper upgrade** (`contracts/token-votes-wrapper/src/lib.rs`)
- Added `upgrade(env, new_wasm_hash: BytesN<32>)` with admin authentication and event emission.

### Testing

- Treasury: 19/19 tests pass
- Token-votes-wrapper: 5/5 tests pass
- Governance tests: pre-existing failures (19 tests fail due to mock timelock using `Address::generate` instead of `env.register`, unrelated to these changes)

Closes #419
Closes #411 
Closes #410 
Closes #409