### PR TITLE
ci: add cargo fmt --check step to Rust CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,20 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
   test:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #401

---

## Summary

The CI pipeline currently has no ustfmt check, allowing formatting violations to silently pass. This PR adds a \Format\ job that runs \cargo fmt --all -- --check\ on every PR targeting main.

## Changes

- Added a new \mt\ job in \.github/workflows/rust.yml\ that runs before build/test steps
- Uses minimal setup: checkout + rust-toolchain with \ustfmt\ component + \cargo fmt --all -- --check\

## Why

- PRs with unformatted Rust code are merged, making future \git blame\ and diff history harder to read
- New contributors don't receive automated feedback on formatting
- Inconsistent indentation and style across contract files makes security audits harder

## How to test

Contributors can run \cargo fmt --all\ locally to auto-fix formatting issues before pushing.