### PR TITLE
ci: add treasury to cargo test/clippy and add cancel and ownership transfer tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,8 @@ jobs:
             -p sorogov-token-votes \
             -p sorogov-governor-factory \
             -p sorogov-liquidity \
-            -p sorogov-token-votes-wrapper
+            -p sorogov-token-votes-wrapper \
+            -p sorogov-treasury
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
@@ -116,6 +117,7 @@ jobs:
             -p sorogov-governor-factory \
             -p sorogov-liquidity \
             -p sorogov-token-votes-wrapper \
+            -p sorogov-treasury \
             --all-targets \
             -- -D warnings
 

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -1542,4 +1542,184 @@ mod tests {
         let non_owner = Address::generate(&env);
         client.slash_signer(&governor, &non_owner, &Symbol::new(&env, "bad"));
     }
+
+    // ── cancel tests ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_cancel_pending_by_owner() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (treasury_id, _token_addr, governor) = setup(&env);
+        let client = TreasuryContractClient::new(&env, &treasury_id);
+
+        let owner = Address::generate(&env);
+        let target = Address::generate(&env);
+        let mut owners = Vec::new(&env);
+        owners.push_back(owner.clone());
+        client.initialize(&owners, &1u32, &governor);
+
+        let data = Bytes::new(&env);
+        let tx_id = client.submit(&owner, &target, &symbol_short!("transfer"), &data);
+
+        let tx_before = client.get_tx(&tx_id);
+        assert!(!tx_before.executed);
+        assert!(!tx_before.cancelled);
+
+        client.cancel(&owner, &tx_id);
+
+        let tx_after = client.get_tx(&tx_id);
+        assert!(!tx_after.executed);
+        assert!(tx_after.cancelled);
+    }
+
+    #[test]
+    fn test_cancel_pending_by_governor() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (treasury_id, _token_addr, governor) = setup(&env);
+        let client = TreasuryContractClient::new(&env, &treasury_id);
+
+        let owner = Address::generate(&env);
+        let target = Address::generate(&env);
+        let mut owners = Vec::new(&env);
+        owners.push_back(owner.clone());
+        client.initialize(&owners, &1u32, &governor);
+
+        let data = Bytes::new(&env);
+        let tx_id = client.submit(&owner, &target, &symbol_short!("transfer"), &data);
+
+        client.cancel(&governor, &tx_id);
+
+        let tx = client.get_tx(&tx_id);
+        assert!(tx.cancelled);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid state")]
+    fn test_cancel_already_cancelled() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (treasury_id, _token_addr, governor) = setup(&env);
+        let client = TreasuryContractClient::new(&env, &treasury_id);
+
+        let owner = Address::generate(&env);
+        let target = Address::generate(&env);
+        let mut owners = Vec::new(&env);
+        owners.push_back(owner.clone());
+        client.initialize(&owners, &1u32, &governor);
+
+        let data = Bytes::new(&env);
+        let tx_id = client.submit(&owner, &target, &symbol_short!("transfer"), &data);
+
+        client.cancel(&owner, &tx_id);
+
+        client.cancel(&owner, &tx_id);
+    }
+
+    #[test]
+    #[should_panic(expected = "tx not found")]
+    fn test_cancel_nonexistent_tx() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (treasury_id, _token_addr, governor) = setup(&env);
+        let client = TreasuryContractClient::new(&env, &treasury_id);
+
+        client.cancel(&governor, &999u64);
+    }
+
+    #[test]
+    #[should_panic(expected = "not authorized")]
+    fn test_cancel_unauthorized() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (treasury_id, _token_addr, governor) = setup(&env);
+        let client = TreasuryContractClient::new(&env, &treasury_id);
+
+        let owner = Address::generate(&env);
+        let target = Address::generate(&env);
+        let mut owners = Vec::new(&env);
+        owners.push_back(owner.clone());
+        client.initialize(&owners, &1u32, &governor);
+
+        let data = Bytes::new(&env);
+        let tx_id = client.submit(&owner, &target, &symbol_short!("transfer"), &data);
+
+        let rando = Address::generate(&env);
+        client.cancel(&rando, &tx_id);
+    }
+
+    // ── ownership transfer tests ─────────────────────────────────────────────
+
+    #[test]
+    fn test_propose_and_accept_ownership() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (treasury_id, _token_addr, governor) = setup(&env);
+        let client = TreasuryContractClient::new(&env, &treasury_id);
+
+        let new_governor = Address::generate(&env);
+
+        assert_eq!(client.get_owner(), governor);
+
+        client.propose_owner(&new_governor);
+
+        assert_eq!(client.get_owner(), governor);
+
+        client.accept_ownership();
+
+        assert_eq!(client.get_owner(), new_governor);
+    }
+
+    #[test]
+    #[should_panic(expected = "HostError: Error(Auth, InvalidAction)")]
+    fn test_propose_ownership_requires_auth() {
+        let env = Env::default();
+
+        let (treasury_id, _token_addr, _governor) = setup(&env);
+        let client = TreasuryContractClient::new(&env, &treasury_id);
+
+        let new_governor = Address::generate(&env);
+
+        client.propose_owner(&new_governor);
+    }
+
+    #[test]
+    fn test_accept_ownership_and_transfer_state() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (treasury_id, _token_addr, governor) = setup(&env);
+        let client = TreasuryContractClient::new(&env, &treasury_id);
+
+        let new_governor = Address::generate(&env);
+
+        client.propose_owner(&new_governor);
+        client.accept_ownership();
+
+        assert_eq!(client.get_owner(), new_governor);
+        assert_ne!(client.get_owner(), governor);
+
+        let newer_governor = Address::generate(&env);
+        client.propose_owner(&newer_governor);
+        client.accept_ownership();
+        assert_eq!(client.get_owner(), newer_governor);
+    }
+
+    #[test]
+    #[should_panic(expected = "no pending owner")]
+    fn test_accept_ownership_with_no_pending() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (treasury_id, _token_addr, _governor) = setup(&env);
+        let client = TreasuryContractClient::new(&env, &treasury_id);
+
+        client.accept_ownership();
+    }
 }


### PR DESCRIPTION
Closes #399

---

## Summary

The treasury contract `sorogov-treasury` was excluded from CI test runs despite being one of the most security-sensitive contracts controlling all protocol fund movements. This PR adds treasury back to CI and fills test coverage gaps.

## Changes

### CI (`.github/workflows/rust.yml`)
- Added `-p sorogov-treasury` to `cargo test` step
- Added `-p sorogov-treasury` to `cargo clippy` step

### Tests (`contracts/treasury/src/lib.rs`)
**Cancel state transitions (5 new tests):**
- `test_cancel_pending_by_owner` — owner cancels their own pending proposal; verifies `cancelled: true`
- `test_cancel_pending_by_governor` — governor cancels an owner's pending proposal
- `test_cancel_already_cancelled` — double-cancel panics with `"invalid state"`
- `test_cancel_nonexistent_tx` — cancelling bad tx id panics with `"tx not found"`
- `test_cancel_unauthorized` — non-owner/non-governor cancel panics with `"not authorized"`

**Ownership transfer (4 new tests):**
- `test_propose_and_accept_ownership` — full propose to accept flow; verifies governor updated
- `test_propose_ownership_requires_auth` — auth gate on propose_owner (no mock_all_auths)
- `test_accept_ownership_and_transfer_state` — chained ownership transfers (2 rounds)
- `test_accept_ownership_with_no_pending` — calling accept with no pending owner panics
