### PR TITLE
Fix competition auth context and profile address validation

### DIFF
--- a/backend/src/routes/competitions.ts
+++ b/backend/src/routes/competitions.ts
@@ -158,7 +158,7 @@ router.get(
   authenticate,
   validate({ params: getCompetitionSchema }),
   async (req: AuthRequest, res: Response) => {
-    const competitionId = (req.params as any).id;
+    const competitionId = Number((req.params as Record<string, string>).id);
 
     try {
       const result = await pool.query(

--- a/backend/src/routes/competitions.ts
+++ b/backend/src/routes/competitions.ts
@@ -155,6 +155,7 @@ router.get(
 // GET /competitions/:id - Get single competition
 router.get(
   "/:id",
+  authenticate,
   validate({ params: getCompetitionSchema }),
   async (req: AuthRequest, res: Response) => {
     const competitionId = (req.params as any).id;

--- a/backend/src/routes/competitions.ts
+++ b/backend/src/routes/competitions.ts
@@ -152,7 +152,7 @@ router.get(
   },
 );
 
-// GET /competitions/:id - Get single competition
+// GET /competitions/:id - Get single competition with user participation state
 router.get(
   "/:id",
   authenticate,

--- a/backend/src/routes/competitions.ts
+++ b/backend/src/routes/competitions.ts
@@ -159,6 +159,7 @@ router.get(
   validate({ params: getCompetitionSchema }),
   async (req: AuthRequest, res: Response) => {
     const competitionId = Number((req.params as Record<string, string>).id);
+    const userId = req.userId;
 
     try {
       const result = await pool.query(
@@ -177,10 +178,10 @@ router.get(
       const competition = result.rows[0];
       const response: Record<string, unknown> = { competition };
 
-      if (req.userId) {
+      if (userId) {
         const participantResult = await pool.query(
           "SELECT id FROM competition_participants WHERE competition_id = $1 AND user_id = $2",
-          [competitionId, req.userId],
+          [competitionId, userId],
         );
         response.is_joined = participantResult.rows.length > 0;
       }

--- a/backend/src/routes/competitions.ts
+++ b/backend/src/routes/competitions.ts
@@ -161,6 +161,10 @@ router.get(
     const competitionId = Number((req.params as Record<string, string>).id);
     const userId = req.userId;
 
+    if (!userId) {
+      return res.status(401).json({ error: "Authentication required" });
+    }
+
     try {
       const result = await pool.query(
         `SELECT c.*, COUNT(cp.id) AS participant_count
@@ -178,13 +182,11 @@ router.get(
       const competition = result.rows[0];
       const response: Record<string, unknown> = { competition };
 
-      if (userId) {
-        const participantResult = await pool.query(
-          "SELECT id FROM competition_participants WHERE competition_id = $1 AND user_id = $2",
-          [competitionId, userId],
-        );
-        response.is_joined = participantResult.rows.length > 0;
-      }
+      const participantResult = await pool.query(
+        "SELECT id FROM competition_participants WHERE competition_id = $1 AND user_id = $2",
+        [competitionId, userId],
+      );
+      response.is_joined = participantResult.rows.length > 0;
 
       res.json(response);
     } catch (error) {

--- a/packages/indexer/src/api.ts
+++ b/packages/indexer/src/api.ts
@@ -121,6 +121,10 @@ const STELLAR_LEDGER_CLOSE_TIME_SECONDS = 5; // Stellar ledgers close approximat
 const STELLAR_PUBLIC_KEY_REGEX = /^G[A-Z2-7]{55}$/;
 const INVALID_ADDRESS_ERROR = "Invalid Stellar address";
 
+function isValidStellarPublicKey(address: string): boolean {
+  return STELLAR_PUBLIC_KEY_REGEX.test(address);
+}
+
 interface HealthResponse {
   status: "ok" | "degraded";
   last_indexed_ledger: number;

--- a/packages/indexer/src/api.ts
+++ b/packages/indexer/src/api.ts
@@ -335,7 +335,8 @@ export function createApp(server: SorobanRpc.Server): express.Application {
           };
         });
         res.json(data);
-      } catch {
+      } catch (error) {
+        console.error("Profile lookup error:", error);
         res.status(500).json({ error: "Internal server error" });
       }
     },

--- a/packages/indexer/src/api.ts
+++ b/packages/indexer/src/api.ts
@@ -118,6 +118,8 @@ const TTL = {
 
 const HEALTH_LAG_THRESHOLD = Number(process.env.HEALTH_LAG_THRESHOLD ?? 100);
 const STELLAR_LEDGER_CLOSE_TIME_SECONDS = 5; // Stellar ledgers close approximately every 5 seconds
+const STELLAR_PUBLIC_KEY_REGEX = /^G[A-Z2-7]{55}$/;
+const INVALID_ADDRESS_ERROR = "Invalid Stellar address";
 
 interface HealthResponse {
   status: "ok" | "degraded";

--- a/packages/indexer/src/api.ts
+++ b/packages/indexer/src/api.ts
@@ -522,6 +522,7 @@ export function createApp(server: SorobanRpc.Server): express.Application {
     "/profile/:address",
     strictLimiter,
     async (req: Request, res: Response): Promise<void> => {
+      // Validate before querying to avoid malformed input reaching the database.
       const normalizedAddress = req.params.address.trim().toUpperCase();
       if (!isValidStellarPublicKey(normalizedAddress)) {
         res.status(400).json({ error: INVALID_ADDRESS_ERROR });

--- a/packages/indexer/src/api.ts
+++ b/packages/indexer/src/api.ts
@@ -521,7 +521,13 @@ export function createApp(server: SorobanRpc.Server): express.Application {
     "/profile/:address",
     strictLimiter,
     async (req: Request, res: Response): Promise<void> => {
-      const { address } = req.params;
+      const normalizedAddress = req.params.address.trim().toUpperCase();
+      if (!isValidStellarPublicKey(normalizedAddress)) {
+        res.status(400).json({ error: INVALID_ADDRESS_ERROR });
+        return;
+      }
+
+      const address = normalizedAddress;
       const key = `profile:${address}`;
       try {
         const data = await cached(key, TTL.profile, async () => {


### PR DESCRIPTION
## Summary
- require authentication on `GET /competitions/:id` so `req.userId` is available and `is_joined` reflects the authenticated user
- validate and normalize `GET /profile/:address` input before any database query to reject malformed addresses with HTTP 400
- keep profile endpoint failures generic for clients while logging server-side errors for operators

## Verification
- reviewed route wiring and handler flow for `backend/src/routes/competitions.ts` to ensure authenticated user context is enforced
- confirmed `packages/indexer/src/api.ts` now validates Stellar public keys before cache/database access
- `git log --format='%h %an <%ae> | %cn <%ce>' -n 10` shows author and committer as `gotethry <gotethry@gmail.com>` on all commits in this branch

Closes #404
Closes #406

Made with [Cursor](https://cursor.com)