### PR TITLE
Fix competition join race condition and treasury write gating

### DIFF
--- a/app/src/app/treasury/page.tsx
+++ b/app/src/app/treasury/page.tsx
@@ -389,6 +389,12 @@ export default function TreasuryPage() {
         </div>
       )}
 
+      {isConnected && publicKey && !ownerCheckComplete && (
+        <div className="mb-6 bg-blue-50 border border-blue-200 rounded-xl p-4 text-sm text-blue-700">
+          Verifying treasury owner permissions...
+        </div>
+      )}
+
       {isConnected && publicKey && !canWrite && ownerOnChain === false && (
         <div className="mb-6 bg-gray-50 border border-gray-200 rounded-xl p-4 text-sm text-gray-600">
           This wallet is not a treasury owner — you can view balances and

--- a/app/src/app/treasury/page.tsx
+++ b/app/src/app/treasury/page.tsx
@@ -75,6 +75,7 @@ export default function TreasuryPage() {
     Record<string, boolean>
   >({});
   const [ownerOnChain, setOwnerOnChain] = useState<boolean | null>(null);
+  const [ownerCheckComplete, setOwnerCheckComplete] = useState(false);
   const [spendingCap, setSpendingCap] = useState<TreasurySpendingCap | null>(
     null,
   );
@@ -115,12 +116,7 @@ export default function TreasuryPage() {
 
   const readViewer = publicKey ?? treasuryAccountId;
 
-  const canWrite = Boolean(
-    isConnected &&
-    publicKey &&
-    (ownerOnChain === true ||
-      (ownerOnChain === null && isEnvFallbackOwner(publicKey))),
-  );
+  const canWrite = Boolean(isConnected && publicKey && ownerOnChain === true);
 
   async function fetchBalances() {
     if (!treasuryAccountId) return;
@@ -204,18 +200,22 @@ export default function TreasuryPage() {
       setAlreadyApproved(approvedMap);
 
       if (publicKey) {
+        setOwnerCheckComplete(false);
         if (owners && owners.length > 0) {
           setOwnerOnChain(
             owners.some(
               (owner) => owner.toUpperCase() === publicKey.toUpperCase(),
             ),
           );
+          setOwnerCheckComplete(true);
         } else {
           const own = await treasuryClient.isOwner(viewer, publicKey);
           setOwnerOnChain(own);
+          setOwnerCheckComplete(true);
         }
       } else {
         setOwnerOnChain(null);
+        setOwnerCheckComplete(false);
       }
 
       if (treasuryTokenAddress) {

--- a/app/src/app/treasury/page.tsx
+++ b/app/src/app/treasury/page.tsx
@@ -255,10 +255,14 @@ export default function TreasuryPage() {
       const msg =
         e instanceof Error ? e.message : "Failed to load treasury data";
       setError(msg);
+      if (isConnected && publicKey) {
+        setOwnerOnChain(false);
+        setOwnerCheckComplete(true);
+      }
     } finally {
       setLoading(false);
     }
-  }, [fetchPendingTxs, readViewer]);
+  }, [fetchPendingTxs, isConnected, publicKey, readViewer]);
 
   useEffect(() => {
     if (!readViewer) {

--- a/app/src/app/treasury/page.tsx
+++ b/app/src/app/treasury/page.tsx
@@ -270,6 +270,8 @@ export default function TreasuryPage() {
       setLoading(false);
       return;
     }
+    setOwnerOnChain(null);
+    setOwnerCheckComplete(false);
     refreshAll();
   }, [readViewer, refreshAll, treasuryClient]);
 

--- a/app/src/app/treasury/page.tsx
+++ b/app/src/app/treasury/page.tsx
@@ -55,13 +55,6 @@ function hexToBytes(hex: string): Uint8Array {
   return out;
 }
 
-function isEnvFallbackOwner(publicKey: string): boolean {
-  const raw = process.env.NEXT_PUBLIC_TREASURY_OWNER_PUBKEYS;
-  if (!raw?.trim()) return false;
-  const keys = raw.split(",").map((s) => s.trim().toUpperCase());
-  return keys.includes(publicKey.toUpperCase());
-}
-
 export default function TreasuryPage() {
   const { isConnected, publicKey, signTransaction } = useWallet();
 

--- a/backend/migrations/004_enforce_competition_participants_uniqueness.sql
+++ b/backend/migrations/004_enforce_competition_participants_uniqueness.sql
@@ -1,6 +1,9 @@
 -- Ensure one participation row per (competition, user) pair.
-ALTER TABLE competition_participants
-DROP CONSTRAINT IF EXISTS competition_participants_competition_id_user_id_key;
+DELETE FROM competition_participants cp
+USING competition_participants newer
+WHERE cp.id < newer.id
+  AND cp.competition_id = newer.competition_id
+  AND cp.user_id = newer.user_id;
 
 ALTER TABLE competition_participants
 ADD CONSTRAINT competition_participants_competition_id_user_id_key

--- a/backend/migrations/004_enforce_competition_participants_uniqueness.sql
+++ b/backend/migrations/004_enforce_competition_participants_uniqueness.sql
@@ -1,0 +1,7 @@
+-- Ensure one participation row per (competition, user) pair.
+ALTER TABLE competition_participants
+DROP CONSTRAINT IF EXISTS competition_participants_competition_id_user_id_key;
+
+ALTER TABLE competition_participants
+ADD CONSTRAINT competition_participants_competition_id_user_id_key
+UNIQUE (competition_id, user_id);

--- a/backend/src/routes/competitions.ts
+++ b/backend/src/routes/competitions.ts
@@ -294,18 +294,6 @@ router.post(
           .json({ error: "Competition has already started" });
       }
 
-      const existingResult = await client.query(
-        "SELECT * FROM competition_participants WHERE competition_id = $1 AND user_id = $2",
-        [competitionId, userId],
-      );
-
-      if (existingResult.rows.length > 0) {
-        await client.query("ROLLBACK");
-        return res
-          .status(400)
-          .json({ error: "Already joined this competition" });
-      }
-
       const insertResult = await client.query<CompetitionParticipant>(
         `INSERT INTO competition_participants (competition_id, user_id, entry_fee_paid)
          VALUES ($1, $2, $3)
@@ -321,6 +309,9 @@ router.post(
       });
     } catch (error) {
       await client.query("ROLLBACK");
+      if (isUniqueViolation(error)) {
+        return res.status(409).json({ error: "Already joined this competition" });
+      }
       logger.error({ err: error }, "Error joining competition");
       res.status(500).json({ error: "Failed to join competition" });
     } finally {

--- a/backend/src/routes/competitions.ts
+++ b/backend/src/routes/competitions.ts
@@ -310,6 +310,10 @@ router.post(
     } catch (error) {
       await client.query("ROLLBACK");
       if (isUniqueViolation(error)) {
+        logger.warn(
+          { competitionId: (req.params as any).id, userId: req.userId },
+          "Duplicate competition join prevented by unique constraint",
+        );
         return res.status(409).json({ error: "Already joined this competition" });
       }
       logger.error({ err: error }, "Error joining competition");

--- a/backend/src/routes/competitions.ts
+++ b/backend/src/routes/competitions.ts
@@ -10,6 +10,17 @@ import { logger } from "../logger";
 
 const router = Router();
 
+type PostgresError = Error & { code?: string };
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as PostgresError).code === "23505"
+  );
+}
+
 // Zod schemas for validation
 const listCompetitionsSchema = z.object({
   is_active: z.enum(["true", "false"]).transform(v => v === "true").optional(),


### PR DESCRIPTION
## Summary
- prevent duplicate competition joins by relying on DB uniqueness and returning `409` on unique violations
- add a backend migration that deduplicates existing rows and enforces a unique `(competition_id, user_id)` constraint
- make treasury write controls fail-closed until owner verification completes, with explicit loading and error-safe behavior

## Verification
- inspected `git log --format='%h %an <%ae> | %cn <%ce>'` and confirmed all new commits are authored and committed by `gotethry <gotethry@gmail.com>`
- checked lints for modified files with `ReadLints`; no new linter errors reported
- tests not run (skipped by request)

Closes #403
Closes #422
