### PR TITLE
fix: voting power inflation, proposal ID precision, treasury calldata labels, delegates bar

### DIFF
--- a/app/src/app/delegates/page.tsx
+++ b/app/src/app/delegates/page.tsx
@@ -51,52 +51,55 @@ export default function DelegatesPage() {
   const [currentDelegatee, setCurrentDelegatee] = useState<string | null>(null);
   const { publicKey } = useWallet();
 
-  useEffect(() => {
-    async function fetchDelegates() {
-      try {
-        const governorAddress = process.env.NEXT_PUBLIC_GOVERNOR_ADDRESS;
-        const timelockAddress = process.env.NEXT_PUBLIC_TIMELOCK_ADDRESS;
-        const votesAddress = process.env.NEXT_PUBLIC_VOTES_ADDRESS;
-        const network = (process.env.NEXT_PUBLIC_NETWORK ||
-          "testnet") as Network;
-        const rpcUrl = process.env.NEXT_PUBLIC_RPC_URL;
+  async function fetchDelegates() {
+    setLoading(true);
+    setError(null);
+    try {
+      const governorAddress = process.env.NEXT_PUBLIC_GOVERNOR_ADDRESS;
+      const timelockAddress = process.env.NEXT_PUBLIC_TIMELOCK_ADDRESS;
+      const votesAddress = process.env.NEXT_PUBLIC_VOTES_ADDRESS;
+      const network = (process.env.NEXT_PUBLIC_NETWORK ||
+        "testnet") as Network;
+      const rpcUrl = process.env.NEXT_PUBLIC_RPC_URL;
 
-        if (!governorAddress || !timelockAddress || !votesAddress) {
-          throw new Error("Missing required environment variables.");
-        }
-
-        const client = new VotesClient({
-          governorAddress,
-          timelockAddress,
-          votesAddress,
-          network,
-          ...(rpcUrl && { rpcUrl }),
-        });
-
-        const supply = await client.getTotalSupply();
-        setTotalSupply(supply);
-
-        const topDelegates = await client.getTopDelegates(20);
-        setDelegates(topDelegates);
-        const total = topDelegates.reduce((sum, d) => sum + d.votingPower, 0n);
-        setTotalDelegated(total);
-
-        if (publicKey) {
-          setCurrentDelegatee(await client.getDelegatee(publicKey));
-        } else {
-          setCurrentDelegatee(null);
-        }
-      } catch (err) {
-        console.error("Error fetching delegates:", err);
-        setError(
-          err instanceof Error ? err.message : "Failed to load delegates",
-        );
-      } finally {
-        setLoading(false);
+      if (!governorAddress || !timelockAddress || !votesAddress) {
+        throw new Error("Missing required environment variables.");
       }
-    }
 
+      const client = new VotesClient({
+        governorAddress,
+        timelockAddress,
+        votesAddress,
+        network,
+        ...(rpcUrl && { rpcUrl }),
+      });
+
+      const supply = await client.getTotalSupply();
+      setTotalSupply(supply);
+
+      const topDelegates = await client.getTopDelegates(20);
+      setDelegates(topDelegates);
+      const total = topDelegates.reduce((sum, d) => sum + d.votingPower, 0n);
+      setTotalDelegated(total);
+
+      if (publicKey) {
+        setCurrentDelegatee(await client.getDelegatee(publicKey));
+      } else {
+        setCurrentDelegatee(null);
+      }
+    } catch (err) {
+      console.error("Error fetching delegates:", err);
+      setError(
+        err instanceof Error ? err.message : "Failed to load delegates",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
     fetchDelegates();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [publicKey]);
 
   function handleDelegateClick(address: string) {
@@ -233,7 +236,7 @@ export default function DelegatesPage() {
                           <div
                             className="bg-indigo-600 h-2 rounded-full"
                             style={{
-                              width: `${Math.min(percentOfSupply * 2, 100)}%`,
+                              width: `${Math.max(2, Math.min(percentOfSupply, 100))}%`,
                             }}
                           />
                         </div>
@@ -264,7 +267,7 @@ export default function DelegatesPage() {
       <DelegateModal
         open={modalOpen}
         onClose={() => setModalOpen(false)}
-        onDelegated={() => window.location.reload()}
+        onDelegated={fetchDelegates}
         currentDelegatee={currentDelegatee}
       />
     </div>

--- a/app/src/lib/treasury-calldata.ts
+++ b/app/src/lib/treasury-calldata.ts
@@ -117,9 +117,11 @@ export function labelPendingTx(target: string, dataHex: string, fnName?: string)
   }
 
   if (fn) {
+    // SEP-41 transfer signature is transfer(from, to, amount) — three args.
+    // args[0] = from, args[1] = to, args[2] = amount.
     const human =
-      fn === "transfer" && args.length >= 2
-        ? `Transfer ${args[1]} to ${shortAddr(args[0])}`
+      fn === "transfer" && args.length >= 3
+        ? `Transfer ${args[2]} to ${shortAddr(args[1])}`
         : `${fn}(${args.join(", ")})`;
     return `${human} · ${shortAddr(target)}`;
   }

--- a/contracts/token-votes-wrapper/src/lib.rs
+++ b/contracts/token-votes-wrapper/src/lib.rs
@@ -468,6 +468,48 @@ mod tests {
         assert_eq!(wrapper.get_depositor_balance(&user2), 900);
     }
 
+    /// Regression test for issue #392: delegate() must move only the caller's
+    /// deposited balance, never the delegatee's aggregate voting power.
+    #[test]
+    fn test_redelegate_does_not_inflate_voting_power() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        let carol = Address::generate(&env);
+        let dave = Address::generate(&env);
+
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_addr = sac.address();
+        let token_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
+        token_client.mint(&alice, &100_i128);
+        token_client.mint(&bob, &900_i128);
+
+        let wrapper_id = env.register(TokenVotesWrapperContract, ());
+        let wrapper = TokenVotesWrapperContractClient::new(&env, &wrapper_id);
+        wrapper.initialize(&admin, &token_addr);
+
+        // Alice deposits 100, Bob deposits 900, both delegate to Carol.
+        // Carol now has 1000 total power.
+        wrapper.deposit(&alice, &100_i128);
+        wrapper.deposit(&bob, &900_i128);
+        wrapper.delegate(&alice, &carol);
+        wrapper.delegate(&bob, &carol);
+        assert_eq!(wrapper.get_votes(&carol), 1000);
+
+        // Alice redelegates to Dave.  Only Alice's 100 should move.
+        wrapper.delegate(&alice, &dave);
+
+        // Dave must have exactly 100 (Alice's deposit), not 1000.
+        assert_eq!(wrapper.get_votes(&dave), 100, "voting power inflation detected");
+        assert_eq!(wrapper.get_votes(&carol), 900, "carol's power should be exactly bob's deposit");
+
+        // Total voting power must be conserved.
+        assert_eq!(wrapper.get_votes(&dave) + wrapper.get_votes(&carol), 1000);
+    }
+
     #[test]
     #[should_panic(expected = "InsufficientBalance")]
     fn test_withdraw_rejects_overdraw_from_shared_delegatee() {

--- a/packages/indexer/src/api.ts
+++ b/packages/indexer/src/api.ts
@@ -345,8 +345,9 @@ export function createApp(server: SorobanRpc.Server): express.Application {
   // GET /proposals?offset=0&limit=20 or ?before=47&limit=20 or ?after=10&limit=20
   app.get("/proposals", async (req: Request, res: Response): Promise<void> => {
     const limit = Math.min(Number(req.query.limit ?? 20), 100);
-    const before = req.query.before ? Number(req.query.before) : undefined;
-    const after = req.query.after ? Number(req.query.after) : undefined;
+    // Parse cursor IDs as BigInt to preserve u64 precision.
+    const before = req.query.before ? BigInt(req.query.before as string) : undefined;
+    const after = req.query.after ? BigInt(req.query.after as string) : undefined;
     const offset = Number(req.query.offset ?? 0);
 
     try {
@@ -378,19 +379,23 @@ export function createApp(server: SorobanRpc.Server): express.Application {
         const result = await pool.query(query, params);
         const proposals = result.rows;
 
-        // For cursor pagination, calculate next/prev cursors and hasMore
+        // For cursor pagination, calculate next/prev cursors and hasMore.
+        // Use BigInt to preserve u64 precision when comparing/passing IDs.
         if (before !== undefined || after !== undefined) {
-          let nextCursor: number | undefined;
-          let prevCursor: number | undefined;
+          let nextCursor: string | undefined;
+          let prevCursor: string | undefined;
           let hasMore = false;
 
           if (proposals.length > 0) {
+            const ids = proposals.map((p: { id: string | number }) => BigInt(p.id));
+            const minId = ids.reduce((a: bigint, b: bigint) => (a < b ? a : b));
+            const maxId = ids.reduce((a: bigint, b: bigint) => (a > b ? a : b));
+
             if (before !== undefined) {
               // For "before" queries, next cursor is the smallest ID in results
-              nextCursor = Math.min(...proposals.map(p => p.id));
-              prevCursor = Math.max(...proposals.map(p => p.id));
-              
-              // Check if there are more proposals with smaller IDs
+              nextCursor = minId.toString();
+              prevCursor = maxId.toString();
+
               const hasMoreResult = await pool.query(
                 "SELECT 1 FROM proposals WHERE id < $1 LIMIT 1",
                 [nextCursor]
@@ -399,10 +404,9 @@ export function createApp(server: SorobanRpc.Server): express.Application {
             } else {
               // For "after" queries, reverse the order to match DESC ordering
               proposals.reverse();
-              nextCursor = Math.min(...proposals.map(p => p.id));
-              prevCursor = Math.max(...proposals.map(p => p.id));
-              
-              // Check if there are more proposals with larger IDs
+              nextCursor = minId.toString();
+              prevCursor = maxId.toString();
+
               const hasMoreResult = await pool.query(
                 "SELECT 1 FROM proposals WHERE id > $1 LIMIT 1",
                 [prevCursor]
@@ -411,11 +415,11 @@ export function createApp(server: SorobanRpc.Server): express.Application {
             }
           }
 
-          return { 
-            proposals, 
-            nextCursor, 
-            prevCursor, 
-            hasMore 
+          return {
+            proposals,
+            nextCursor,
+            prevCursor,
+            hasMore
           };
         } else {
           // For offset pagination, return legacy format
@@ -431,16 +435,19 @@ export function createApp(server: SorobanRpc.Server): express.Application {
 
   // GET /proposals/:id
   app.get("/proposals/:id", async (req: Request, res: Response): Promise<void> => {
-    const id = parseInt(req.params.id);
-    
-    // Validate ID is a valid integer
-    if (isNaN(id) || id < 1) {
+    // Use BigInt to preserve full u64 precision — parseInt() silently truncates
+    // values beyond Number.MAX_SAFE_INTEGER (2^53-1), causing wrong lookups.
+    let id: bigint;
+    try {
+      id = BigInt(req.params.id);
+      if (id < 1n) throw new RangeError("non-positive");
+    } catch {
       res.status(400).json({ error: "Invalid proposal ID" });
       return;
     }
 
     try {
-      const result = await pool.query('SELECT * FROM proposals WHERE id = $1', [id]);
+      const result = await pool.query('SELECT * FROM proposals WHERE id = $1', [id.toString()]);
       if (!result.rows[0]) {
         res.status(404).json({ error: 'Proposal not found' });
         return;


### PR DESCRIPTION
## Summary

- **#392 (security)** — `token-votes-wrapper` `delegate()` already reads the depositor's own balance correctly via `get_depositor_balance_internal`. Added an explicit regression test (`test_redelegate_does_not_inflate_voting_power`) that reproduces the exact attack scenario from the issue and asserts that total voting power is conserved after redelegation.

- **#393 (bug)** — `packages/indexer/src/api.ts`: replaced `parseInt()` with `BigInt()` for parsing proposal IDs in `GET /proposals/:id` and the cursor-based pagination parameters (`before`/`after`). `parseInt()` silently truncates values beyond `Number.MAX_SAFE_INTEGER` (2^53−1); Soroban proposal IDs are `u64` and can exceed this boundary.

- **#396 (bug)** — `app/src/lib/treasury-calldata.ts`: fixed `labelPendingTx()` to use the correct SEP-41 `transfer(from, to, amount)` argument indexes. Previously read `args[0]` as recipient and `args[1]` as amount; corrected to `args[1]` = `to` and `args[2]` = `amount`. Also updated the guard from `args.length >= 2` to `args.length >= 3`.

- **#397 (bug)** — `app/src/app/delegates/page.tsx`: removed the `* 2` multiplier from the progress bar width calculation, which caused any delegate holding ≥50% of supply to show a full bar (100%), masking dangerous voting power concentration. Bar now uses `Math.max(2, Math.min(percentOfSupply, 100))` for a minimum 2% visible width. Also replaced `window.location.reload()` in `onDelegated` with a targeted re-fetch via the extracted `fetchDelegates` function.

## Test plan

- [ ] Run `cargo test -p token-votes-wrapper` — all tests including the new `test_redelegate_does_not_inflate_voting_power` should pass
- [ ] Start the indexer and request `GET /proposals/<id>` with a large u64 ID (> 2^53); confirm it returns the correct row rather than a truncated match
- [ ] In the treasury UI, create a pending `transfer` calldata and verify the label shows the correct `to` address and `amount`
- [ ] Open the delegates page; confirm a delegate with >50% supply shows a proportional bar, not a full bar
- [ ] Delegate via the modal and confirm the delegate list refreshes in-place without a full page reload



closes #392 closes #393 closes #396 closes #397