### PR TITLE
fix(governor): use consistent SECONDS_PER_LEDGER in cancel_queued veto window

### DIFF
--- a/contracts/governor/src/lib.rs
+++ b/contracts/governor/src/lib.rs
@@ -323,6 +323,15 @@ pub struct GovernorContract;
 
 #[contractimpl]
 impl GovernorContract {
+    /// Approximate number of seconds per Soroban ledger close.
+    ///
+    /// Used to convert timelock delay/window values (in seconds) to ledger
+    /// counts. Stellar Mainnet closes ledgers roughly every 5 seconds; this
+    /// constant must be kept consistent across all conversion sites in this
+    /// file so that TTL extensions and veto-window calculations use the same
+    /// baseline.
+    const SECONDS_PER_LEDGER: u64 = 5;
+
     fn must_get_proposal(env: &Env, proposal_id: u64) -> Proposal {
         env.storage()
             .persistent()
@@ -359,8 +368,8 @@ impl GovernorContract {
             let timelock = TimelockClient::new(env, &addr);
             let delay_seconds = timelock.min_delay();
             let execution_window_seconds = timelock.execution_window();
-            // Convert seconds to ledgers (assuming ~5 second blocks)
-            ((delay_seconds + execution_window_seconds) / 5) as u32
+            // Convert seconds to ledgers using the shared constant.
+            ((delay_seconds + execution_window_seconds) / Self::SECONDS_PER_LEDGER) as u32
         } else {
             1000 // conservative default
         };
@@ -1248,12 +1257,12 @@ impl GovernorContract {
         let timelock = TimelockClient::new(&env, &timelock_addr);
         let delay = timelock.min_delay();
 
-        // Check if we're still in the veto window
+        // Check if we're still in the veto window.
+        // `delay` is in seconds; convert to ledgers using the shared constant so this
+        // site matches extend_proposal_ttl (previously used /10, which halved the window).
         let current_ledger = env.ledger().sequence();
-        // For simplicity, use delay directly as ledger count (adjusting for typical Soroban block times)
-        // The veto window should close after timelock_delay seconds
-        // Conversion: assume timelock delay is in seconds and we need ledger conversion
-        let veto_window_end_ledger = queue_time + ((delay / 10) as u32); // Roughly 1 ledger per 10 seconds
+        let delay_ledgers = (delay / Self::SECONDS_PER_LEDGER) as u32;
+        let veto_window_end_ledger = queue_time.saturating_add(delay_ledgers);
 
         if current_ledger >= veto_window_end_ledger {
             env.panic_with_error(GovernorError::VetoWindowClosed);

--- a/contracts/governor/src/tests/integration.rs
+++ b/contracts/governor/src/tests/integration.rs
@@ -1661,3 +1661,113 @@ fn test_set_pauser_requires_self_auth() {
 
     governor_client.set_pauser(&new_pauser);
 }
+
+/// Regression test for issue #600: cancel_queued used /10 instead of /5 to
+/// convert the timelock delay (seconds) to ledgers, halving the guardian's
+/// veto window.
+///
+/// With `min_delay = 100` seconds:
+///   - Buggy window end  = queue_ledger + (100 / 10) = queue_ledger + 10
+///   - Correct window end = queue_ledger + (100 /  5) = queue_ledger + 20
+///
+/// This test advances 11 ledgers past the queue point — past the old (wrong)
+/// boundary but still inside the correct window — and asserts that the
+/// guardian can successfully cancel.  With the bug present the call panics
+/// with `VetoWindowClosed`.
+#[test]
+fn test_cancel_queued_veto_window_uses_correct_conversion_factor() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let admin = Address::generate(&env);
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_addr = sac.address();
+    let token_admin = token::StellarAssetClient::new(&env, &token_addr);
+
+    let votes_id = env.register(TokenVotesContract, ());
+    let votes_client = TokenVotesContractClient::new(&env, &votes_id);
+    votes_client.initialize(&admin, &token_addr);
+
+    let mock_target_id = env.register(MockTarget, ());
+
+    let timelock_id = env.register(TimelockContract, ());
+    let governor_id = env.register(GovernorContract, ());
+
+    let timelock_client = TimelockContractClient::new(&env, &timelock_id);
+    let governor_client = GovernorContractClient::new(&env, &governor_id);
+
+    // 100-second min_delay → 20-ledger veto window (100 / 5), not 10 (100 / 10).
+    let min_delay: u64 = 100;
+    timelock_client.initialize(&admin, &governor_id, &min_delay, &1_209_600);
+
+    let guardian = Address::generate(&env);
+    governor_client.initialize(
+        &admin,
+        &votes_id,
+        &timelock_id,
+        &10_u32,
+        &20_u32,
+        &0_u32,
+        &0_i128,
+        &guardian,
+        &VoteType::Extended,
+        &120_960u32,
+    );
+
+    let alice = Address::generate(&env);
+    token_admin.mint(&alice, &500_i128);
+    votes_client.delegate(&alice, &alice);
+
+    let proposer = Address::generate(&env);
+    let fn_name = Symbol::new(&env, "exec_gov");
+    let calldata = Bytes::new(&env);
+    let description = soroban_sdk::String::from_str(&env, "Regression #600");
+    let description_hash = env
+        .crypto()
+        .sha256(&Bytes::from_slice(&env, b"Regression #600"))
+        .into();
+    let metadata_uri = soroban_sdk::String::from_str(&env, "ipfs://regression-600");
+
+    let mut targets = soroban_sdk::Vec::new(&env);
+    targets.push_back(mock_target_id.clone());
+    let mut fn_names = soroban_sdk::Vec::new(&env);
+    fn_names.push_back(fn_name);
+    let mut calldatas = soroban_sdk::Vec::new(&env);
+    calldatas.push_back(calldata);
+
+    let proposal_id = governor_client.propose(
+        &proposer,
+        &description,
+        &description_hash,
+        &metadata_uri,
+        &targets,
+        &fn_names,
+        &calldatas,
+    );
+
+    // Advance into voting, cast a winning vote, then past end_ledger.
+    env.ledger().with_mut(|l| l.sequence_number = 11);
+    governor_client.cast_vote(&alice, &proposal_id, &VoteSupport::For);
+
+    env.ledger().with_mut(|l| l.sequence_number = 31);
+    assert_eq!(governor_client.state(&proposal_id), ProposalState::Succeeded);
+
+    // Record the ledger at queue time; advance 11 ledgers (old buggy boundary +1).
+    let queue_ledger = env.ledger().sequence();
+    governor_client.queue(&proposal_id);
+    assert_eq!(governor_client.state(&proposal_id), ProposalState::Queued);
+
+    // 11 ledgers past queue point: old code (/ 10) thinks window closed at +10,
+    // correct code (/ 5) knows window closes at +20.
+    env.ledger()
+        .with_mut(|l| l.sequence_number = queue_ledger + 11);
+
+    // Must succeed — we are still inside the correct veto window.
+    governor_client.cancel_queued(&guardian, &proposal_id);
+
+    assert_eq!(
+        governor_client.state(&proposal_id),
+        ProposalState::Cancelled,
+        "proposal must be Cancelled: guardian is still within the veto window at ledger +11"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #600

`cancel_queued` computed the guardian veto window by dividing `timelock.min_delay()` (seconds) by **10** to convert to ledgers, while `extend_proposal_ttl` in the same file divided by **5**. The inconsistency silently halved the guardian's safety window — with a 24-hour timelock delay the guardian had ~12 h of veto time instead of the intended ~24 h.

### Root cause

```rust
// Before — wrong conversion factor
let veto_window_end_ledger = queue_time + ((delay / 10) as u32);

// extend_proposal_ttl in the same file uses 5, not 10:
((delay_seconds + execution_window_seconds) / 5) as u32
```

### Fix

- Extract `const SECONDS_PER_LEDGER: u64 = 5` inside `GovernorContract` as the single authoritative constant.
- Use it in both `cancel_queued` and `extend_proposal_ttl` — no more conflicting magic numbers.
- Replace raw `+` with `saturating_add` to guard against `u32` overflow on very long delays.

```rust
// After
const SECONDS_PER_LEDGER: u64 = 5;

let delay_ledgers = (delay / Self::SECONDS_PER_LEDGER) as u32;
let veto_window_end_ledger = queue_time.saturating_add(delay_ledgers);
```

## Test plan

- [x] Existing `test_cancel_queued_during_veto_window` still passes — immediate cancellation works
- [x] Existing `test_cancel_queued_after_window_closes` still passes — far-future cancellation is rejected
- [x] New regression test `test_cancel_queued_veto_window_uses_correct_conversion_factor`:
  - Sets `min_delay = 100s` (window = 20 ledgers under the fix, was 10 ledgers under the bug)
  - Advances 11 ledgers past the queue point (old boundary + 1)
  - Asserts guardian **can** cancel — this panicked with `VetoWindowClosed` before the fix
- [x] All 54 governor contract tests pass
