### PR TITLE
fix(guardian): reject zero-weight votes in cast_vote and cast_vote_with_reason

### DIFF
--- a/contracts/governor/src/lib.rs
+++ b/contracts/governor/src/lib.rs
@@ -769,7 +769,7 @@ impl GovernorContract {
         // using the active voting strategy (single token or multi-token weighted).
         let raw_weight: i128 = Self::compute_votes(&env, &voter, &proposal.start_ledger);
 
-        if raw_weight < 0 {
+        if raw_weight <= 0 {
             env.panic_with_error(GovernorError::ZeroVotingPower);
         }
 
@@ -837,7 +837,7 @@ impl GovernorContract {
 
         // Look up the voter's snapshot voting power at the proposal's start ledger
         let raw_weight: i128 = Self::compute_votes(&env, &voter, &proposal.start_ledger);
-        if raw_weight < 0 {
+        if raw_weight <= 0 {
             env.panic_with_error(GovernorError::ZeroVotingPower);
         }
 


### PR DESCRIPTION
## Summary

Closes #601

Change the voting power guard from `raw_weight < 0` to `raw_weight <= 0` in both `cast_vote` and `cast_vote_with_reason`.

## Problem

Previously, a voter with zero token balance (`raw_weight == 0`) could pass the guard check (`< 0`), resulting in:

1. Persistent storage writes (`HasVoted`, `VoteReceipt`) — wastes ledger rent
2. Soroban computation budget consumed for cross-contract calls
3. `VoteCast` event recorded with zero weight — inflates participation metrics
4. Voter permanently marked as having voted — cannot vote again on future proposals

## Fix

```rust
// Before
if raw_weight < 0 {

// After  
if raw_weight <= 0 {
```

Both `cast_vote` (line 772) and `cast_vote_with_reason` (line 840) are updated. The error name `ZeroVotingPower` now correctly matches its semantics.

## Testing

- Existing tests should continue to pass
- New tests should verify that `cast_vote` from an address with zero token balance fails with `ZeroVotingPower`