### PR TITLE
fix(accessibility): ProposalStateBadge — visible labels, icons, borders, add axe and contracts tests

### DIFF
--- a/app/src/__tests__/accessibility.test.tsx
+++ b/app/src/__tests__/accessibility.test.tsx
@@ -6,7 +6,8 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { VotingModal } from '../components/VotingModal';
-import { VoteSupport } from '@nebgov/sdk';
+import { ProposalStateBadge } from '../components/ProposalStateBadge';
+import { ProposalState, VoteSupport } from '@nebgov/sdk';
 
 // Extend Jest matchers
 expect.extend(toHaveNoViolations);
@@ -111,23 +112,68 @@ describe('Accessibility Tests', () => {
     });
   });
 
-  describe('Color Contrast', () => {
-    it('should meet WCAG AA contrast requirements for status badges', () => {
-      // This is a basic test - in a real scenario, you'd use tools like 
-      // @testing-library/jest-dom with custom matchers or axe-core
-      const statusColors = {
-        'bg-yellow-100 text-yellow-800': { bg: '#fef3c7', text: '#92400e' },
-        'bg-blue-100 text-blue-800': { bg: '#dbeafe', text: '#1e40af' },
-        'bg-green-100 text-green-800': { bg: '#dcfce7', text: '#166534' },
-        'bg-red-100 text-red-800': { bg: '#fee2e2', text: '#991b1b' },
-        'bg-purple-100 text-purple-800': { bg: '#f3e8ff', text: '#6b21a8' },
-        'bg-gray-100 text-gray-800': { bg: '#f3f4f6', text: '#1f2937' },
-      };
+  describe('ProposalStateBadge', () => {
+    const STATES = [
+      ProposalState.Pending,
+      ProposalState.Active,
+      ProposalState.Succeeded,
+      ProposalState.Defeated,
+      ProposalState.Queued,
+      ProposalState.Executed,
+      ProposalState.Cancelled,
+      ProposalState.Expired,
+    ];
 
-      // In a real implementation, you would calculate contrast ratios
-      // and ensure they meet WCAG AA standards (4.5:1 for normal text)
-      Object.keys(statusColors).forEach(colorClass => {
-        expect(colorClass).toBeTruthy(); // Placeholder for actual contrast checking
+    it.each(STATES)('renders a visible label for state %s', (state) => {
+      const { getByText } = render(<ProposalStateBadge state={state} />);
+      expect(getByText(state, { exact: false })).toBeInTheDocument();
+    });
+
+    it('should not have accessibility violations for proposal state badges', async () => {
+      const { container } = render(
+        <div>
+          {STATES.map((state) => (
+            <ProposalStateBadge key={state} state={state} />
+          ))}
+        </div>
+      );
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe('Color Contrast', () => {
+    const statusColors: Record<string, { bg: string; text: string }> = {
+      Pending: { bg: '#fef3c7', text: '#92400e' },
+      Active: { bg: '#dbeafe', text: '#1e40af' },
+      Succeeded: { bg: '#dcfce7', text: '#166534' },
+      Defeated: { bg: '#fee2e2', text: '#991b1b' },
+      Queued: { bg: '#f3e8ff', text: '#6b21a8' },
+      Executed: { bg: '#f3e8ff', text: '#6b21a8' },
+      Cancelled: { bg: '#f3f4f6', text: '#374151' },
+      Expired: { bg: '#fff1f2', text: '#9f1239' },
+    };
+
+    const hexToLuminance = (hex: string) => {
+      const normalized = hex.replace('#', '');
+      const rgb = [0, 1, 2].map((index) => parseInt(normalized.slice(index * 2, index * 2 + 2), 16) / 255);
+      const adjusted = rgb.map((channel) => (channel <= 0.03928 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4)));
+      return 0.2126 * adjusted[0] + 0.7152 * adjusted[1] + 0.0722 * adjusted[2];
+    };
+
+    const contrastRatio = (hexA: string, hexB: string) => {
+      const lumA = hexToLuminance(hexA);
+      const lumB = hexToLuminance(hexB);
+      const lighter = Math.max(lumA, lumB);
+      const darker = Math.min(lumA, lumB);
+      return (lighter + 0.05) / (darker + 0.05);
+    };
+
+    it('should meet WCAG AA contrast requirements for status badge text', () => {
+      Object.entries(statusColors).forEach(([label, { bg, text }]) => {
+        const ratio = contrastRatio(bg, text);
+        expect(ratio).toBeGreaterThanOrEqual(4.5);
       });
     });
   });

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -13,6 +13,7 @@ import { ErrorBoundary } from "../components/ErrorBoundary";
 import { ProposalCardSkeleton } from "../components/ui/ProposalCardSkeleton";
 import { useDebounce } from "../hooks/useDebounce";
 import { getErrorMessage, reportFrontendError } from "../lib/frontend-error";
+import { ProposalStateBadge } from "../components/ProposalStateBadge";
 
 
 interface ProposalSummary {
@@ -426,7 +427,7 @@ function ProposalsPageInner() {
                     role="status"
                     aria-label={`Proposal status: ${p.state}`}
                   >
-                    {p.state}
+                    <ProposalStateBadge state={p.state} />
                   </span>
                 </div>
               </Link>

--- a/app/src/components/ProposalStateBadge.tsx
+++ b/app/src/components/ProposalStateBadge.tsx
@@ -1,14 +1,14 @@
 import { ProposalState } from "@nebgov/sdk";
 
-const STATE_COLORS: Record<ProposalState, string> = {
-  [ProposalState.Pending]: "bg-yellow-100 text-yellow-800",
-  [ProposalState.Active]: "bg-blue-100 text-blue-800",
-  [ProposalState.Succeeded]: "bg-green-100 text-green-800",
-  [ProposalState.Defeated]: "bg-red-100 text-red-800",
-  [ProposalState.Queued]: "bg-purple-100 text-purple-800",
-  [ProposalState.Executed]: "bg-gray-100 text-gray-800",
-  [ProposalState.Cancelled]: "bg-gray-100 text-gray-500",
-  [ProposalState.Expired]: "bg-rose-100 text-rose-800",
+const STATE_CONFIG: Record<ProposalState, { color: string; icon: string; label: string }> = {
+  [ProposalState.Pending]: { color: "bg-yellow-100 text-yellow-800 border border-yellow-200", icon: '⏳', label: 'Pending' },
+  [ProposalState.Active]: { color: "bg-blue-100 text-blue-800 border border-blue-200", icon: '●', label: 'Active' },
+  [ProposalState.Succeeded]: { color: "bg-green-100 text-green-800 border border-green-200", icon: '✓', label: 'Succeeded' },
+  [ProposalState.Defeated]: { color: "bg-red-100 text-red-800 border border-red-200", icon: '✕', label: 'Defeated' },
+  [ProposalState.Queued]: { color: "bg-purple-100 text-purple-800 border border-purple-200", icon: '⏳', label: 'Queued' },
+  [ProposalState.Executed]: { color: "bg-purple-100 text-purple-800 border border-purple-200", icon: '✅', label: 'Executed' },
+  [ProposalState.Cancelled]: { color: "bg-gray-100 text-gray-700 border border-gray-200", icon: '⊘', label: 'Cancelled' },
+  [ProposalState.Expired]: { color: "bg-rose-100 text-rose-800 border border-rose-200", icon: '⌛', label: 'Expired' },
 };
 
 interface Props {
@@ -16,9 +16,11 @@ interface Props {
 }
 
 export function ProposalStateBadge({ state }: Props) {
+  const meta = STATE_CONFIG[state];
+
   return (
-    <span className={`px-3 py-1 rounded-full text-xs font-medium ${STATE_COLORS[state]}`}>
-      {state}
+    <span className={`px-3 py-1 rounded-full text-xs font-medium ${meta.color}`}>
+      {meta.icon} {meta.label}
     </span>
   );
 }


### PR DESCRIPTION
Summary

This PR fixes accessibility issues in the Proposal state badges by ensuring badges do not rely on color alone. The badge now renders a visible icon and a text label for every state, includes a subtle border for visual separation, and adds automated accessibility tests (axe and programmatic contrast checks).

Files changed

- app/src/components/ProposalStateBadge.tsx — visible icon + label, updated color/border classes
- app/src/__tests__/accessibility.test.tsx — added ProposalStateBadge axe checks and WCAG AA contrast tests
- app/src/app/page.tsx — updated usages to the new badge styles

Acceptance checklist

- [x] All proposal states display both color AND text label
- [x] Text label is visible at all times (not just on hover/tooltip)
- [x] `jest-axe` accessibility test passes for the `ProposalStateBadge` rendering
- [x] Color contrast ratios meet WCAG AA (4.5:1 for normal text) for badge text/background (programmatically checked in tests)
- [ ] Colorblind simulation tested (Deuteranopia, Protanopia) — please verify in reviewer browser DevTools

Test notes

- Ran `pnpm test -- --runInBand src/components/__tests__/ProposalStateBadge.test.tsx`: passed (snapshots updated)
- Ran `pnpm test -- --runInBand src/__tests__/accessibility.test.tsx`: badge-related tests pass, contrast checks pass; unrelated `VotingModal` tests currently assert keyboard/tabindex and disabled button behavior and fail in this suite (no functional change to VotingModal in this PR)

closes #539 
