### PR TITLE
fix(backend): resolve governor contract id from DB at runtime to avoid stale config (#689)

### DIFF
--- a/backend/src/__tests__/security.test.ts
+++ b/backend/src/__tests__/security.test.ts
@@ -1,15 +1,26 @@
 import { AlertType, AlertSeverity, SecurityMonitorService } from "../services/security-monitor";
+import pool from "../db/pool";
 
 // Mock pool
 jest.mock("../db/pool", () => ({
   query: jest.fn(),
 }));
 
+const queryMock = pool.query as jest.Mock;
+
 describe("SecurityMonitorService", () => {
   let service: SecurityMonitorService;
 
   beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.TOKEN_VOTES_CONTRACT_ID = "CTOKENVOTES123";
+    process.env.GOVERNOR_CONTRACT_ID = "CENVGOVERNOR123";
     service = new SecurityMonitorService();
+  });
+
+  afterEach(() => {
+    delete process.env.TOKEN_VOTES_CONTRACT_ID;
+    delete process.env.GOVERNOR_CONTRACT_ID;
   });
 
   it("should define correctly the AlertType and AlertSeverity", () => {
@@ -22,5 +33,60 @@ describe("SecurityMonitorService", () => {
   // For now, we'll just verify the service initializes.
   it("should initialize with default horizon server", () => {
     expect(service).toBeDefined();
+  });
+
+  it("uses governor contract ID from DB when available", async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ value: "CDBGOVERNOR123" }] });
+
+    const checkGovernorSpy = jest
+      .spyOn(service as any, "checkGovernorEvents")
+      .mockResolvedValue(undefined);
+    const checkTokenVotesSpy = jest
+      .spyOn(service as any, "checkTokenVotesEvents")
+      .mockResolvedValue(undefined);
+
+    await (service as any).processEvents(10, 20);
+
+    expect(queryMock).toHaveBeenCalledWith(
+      "SELECT value FROM monitoring_state WHERE key = 'active_governor_contract_id' LIMIT 1",
+    );
+    expect(checkGovernorSpy).toHaveBeenCalledWith("CDBGOVERNOR123", 10, 20);
+    expect(checkTokenVotesSpy).toHaveBeenCalledWith("CTOKENVOTES123", 10, 20);
+  });
+
+  it("falls back to environment governor contract ID when DB has no value", async () => {
+    queryMock.mockResolvedValueOnce({ rows: [] });
+
+    const checkGovernorSpy = jest
+      .spyOn(service as any, "checkGovernorEvents")
+      .mockResolvedValue(undefined);
+    const checkTokenVotesSpy = jest
+      .spyOn(service as any, "checkTokenVotesEvents")
+      .mockResolvedValue(undefined);
+
+    await (service as any).processEvents(11, 21);
+
+    expect(checkGovernorSpy).toHaveBeenCalledWith("CENVGOVERNOR123", 11, 21);
+    expect(checkTokenVotesSpy).toHaveBeenCalledWith("CTOKENVOTES123", 11, 21);
+  });
+
+  it("picks up governor contract ID changes from DB without restart", async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ value: "CDBGOVERNOR_OLD" }] })
+      .mockResolvedValueOnce({ rows: [{ value: "CDBGOVERNOR_NEW" }] });
+
+    const checkGovernorSpy = jest
+      .spyOn(service as any, "checkGovernorEvents")
+      .mockResolvedValue(undefined);
+    const checkTokenVotesSpy = jest
+      .spyOn(service as any, "checkTokenVotesEvents")
+      .mockResolvedValue(undefined);
+
+    await (service as any).processEvents(12, 22);
+    await (service as any).processEvents(23, 33);
+
+    expect(checkGovernorSpy).toHaveBeenNthCalledWith(1, "CDBGOVERNOR_OLD", 12, 22);
+    expect(checkGovernorSpy).toHaveBeenNthCalledWith(2, "CDBGOVERNOR_NEW", 23, 33);
+    expect(checkTokenVotesSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/backend/src/services/security-monitor.ts
+++ b/backend/src/services/security-monitor.ts
@@ -32,6 +32,7 @@ export class SecurityMonitorService {
   private networkPassphrase: string;
   private interval: NodeJS.Timeout | null = null;
   private isScanning: boolean = false;
+  private currentGovernorContractId: string | null = null;
 
   constructor() {
     const horizonUrl = process.env.STELLAR_HORIZON_URL || "https://horizon-testnet.stellar.org";
@@ -97,7 +98,7 @@ export class SecurityMonitorService {
   }
 
   private async processEvents(startLedger: number, endLedger: number) {
-    const governorId = process.env.GOVERNOR_CONTRACT_ID;
+    const governorId = await this.resolveGovernorContractId();
     const tokenVotesId = process.env.TOKEN_VOTES_CONTRACT_ID;
 
     if (!governorId || !tokenVotesId) {
@@ -112,6 +113,38 @@ export class SecurityMonitorService {
 
     await this.checkGovernorEvents(governorId, startLedger, endLedger);
     await this.checkTokenVotesEvents(tokenVotesId, startLedger, endLedger);
+  }
+
+  private async resolveGovernorContractId(): Promise<string | null> {
+    const fallbackGovernorId = process.env.GOVERNOR_CONTRACT_ID?.trim() || null;
+
+    try {
+      const result = await pool.query(
+        "SELECT value FROM monitoring_state WHERE key = 'active_governor_contract_id' LIMIT 1",
+      );
+      const dbGovernorId =
+        result.rows.length > 0 ? String(result.rows[0].value ?? "").trim() : "";
+
+      if (dbGovernorId.length > 0) {
+        if (this.currentGovernorContractId !== dbGovernorId) {
+          logger.info({ governorContractId: dbGovernorId }, "Resolved governor contract ID from DB");
+          this.currentGovernorContractId = dbGovernorId;
+        }
+        return dbGovernorId;
+      }
+    } catch (error) {
+      logger.warn({ err: error }, "Failed to resolve governor contract ID from DB; using env fallback");
+    }
+
+    if (this.currentGovernorContractId !== fallbackGovernorId) {
+      logger.info(
+        { governorContractId: fallbackGovernorId },
+        "Resolved governor contract ID from environment",
+      );
+      this.currentGovernorContractId = fallbackGovernorId;
+    }
+
+    return fallbackGovernorId;
   }
 
   private async checkGovernorEvents(contractId: string, start: number, end: number) {


### PR DESCRIPTION
Problem

Backend monitoring logic read governor contract ID from environment config, which can become stale after governance upgrades and require restart to refresh.
Solution

Updated SecurityMonitorService to resolve governor contract ID dynamically from DB key active_governor_contract_id in monitoring_state.
Added safe fallback to GOVERNOR_CONTRACT_ID environment variable when DB value is missing or query fails.
Added tests to verify:
DB value is preferred.
Env fallback works.
New DB value is picked up across scans without restart.
Testing

pnpm --filter nebgov-backend run build
pnpm jest src/tests/security.test.ts --runInBand
Closes #689