### PR TITLE
Fix/issues 692 693 702 716

### DIFF
--- a/app/src/app/delegates/page.tsx
+++ b/app/src/app/delegates/page.tsx
@@ -20,6 +20,9 @@ function DelegateSkeleton() {
         <Skeleton className="h-4 w-20" />
       </td>
       <td className="py-4 px-4">
+        <Skeleton className="h-4 w-12" />
+      </td>
+      <td className="py-4 px-4">
         <Skeleton className="h-2 w-full" />
       </td>
       <td className="py-4 px-4">
@@ -170,6 +173,9 @@ export default function DelegatesPage() {
                 Votes
               </th>
               <th className="py-3 px-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Delegators
+              </th>
+              <th className="py-3 px-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                 % of Supply
               </th>
               <th className="py-3 px-4 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -188,7 +194,7 @@ export default function DelegatesPage() {
 
             {!loading && delegates.length === 0 && !error && (
               <tr>
-                <td colSpan={5} className="py-12 text-center text-gray-500">
+                <td colSpan={6} className="py-12 text-center text-gray-500">
                   No delegates found. Be the first to delegate!
                 </td>
               </tr>
@@ -214,9 +220,12 @@ export default function DelegatesPage() {
                     </td>
                     <td className="py-4 px-4">
                       <div className="flex items-center gap-2">
-                        <span className="font-mono text-sm text-gray-900">
+                        <Link
+                          href={`/profile/${delegate.address}`}
+                          className="font-mono text-sm text-indigo-600 hover:text-indigo-800 hover:underline"
+                        >
                           {formatAddress(delegate.address)}
-                        </span>
+                        </Link>
                         {isCurrentUser && (
                           <span className="text-xs bg-indigo-100 text-indigo-700 px-2 py-0.5 rounded">
                             You
@@ -226,6 +235,9 @@ export default function DelegatesPage() {
                     </td>
                     <td className="py-4 px-4 text-sm font-medium text-gray-900">
                       {formatVotes(delegate.votingPower)}
+                    </td>
+                    <td className="py-4 px-4 text-sm text-gray-600">
+                      {delegate.delegatorCount.toLocaleString()}
                     </td>
                     <td className="py-4 px-4">
                       <div className="flex items-center gap-2">
@@ -265,6 +277,7 @@ export default function DelegatesPage() {
         open={modalOpen}
         onClose={() => setModalOpen(false)}
         onDelegated={() => window.location.reload()}
+        prefillAddress={prefillAddress}
         currentDelegatee={currentDelegatee}
       />
     </div>

--- a/contracts/governor/src/lib.rs
+++ b/contracts/governor/src/lib.rs
@@ -686,6 +686,20 @@ impl GovernorContract {
         env.storage()
             .persistent()
             .set(&DataKey::LastProposalLedger(proposer.clone()), &current);
+
+        // Prune the previous period's key for this proposer to prevent
+        // unbounded storage growth (Issue #716).  We only need the current
+        // period's count for rate-limiting, so the entry from
+        // `current_period - 1` can be safely removed.
+        if current_period > 0 {
+            env.storage()
+                .persistent()
+                .remove(&DataKey::ProposalsInPeriod(
+                    proposer.clone(),
+                    current_period - 1,
+                ));
+        }
+
         env.storage().persistent().set(
             &DataKey::ProposalsInPeriod(proposer.clone(), current_period),
             &(proposals_in_period + 1),
@@ -3547,6 +3561,72 @@ mod test {
         assert_eq!(GovernorError::ExecutionWindowZero as u32, 29);
         assert_eq!(GovernorError::TooManyCalldataEntries as u32, 30);
         assert_eq!(GovernorError::ProposalNotActive as u32, 31);
+    }
+
+    /// Verify that propose() deletes the previous period's ProposalsInPeriod
+    /// key so stale storage entries don't accumulate (Issue #716).
+    #[test]
+    fn test_proposals_in_period_previous_key_pruned() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(GovernorContract, ());
+        let client = GovernorContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let votes_token_id = env.register(MockVotesContract, ());
+        let timelock = env.register(MockTimelockContract, ());
+        let proposer = Address::generate(&env);
+        let guardian = Address::generate(&env);
+
+        // Initialize at ledger 0 with default period_duration=10_000.
+        client.initialize(
+            &admin,
+            &votes_token_id,
+            &timelock,
+            &0,    // voting_delay
+            &1,    // voting_period (minimal so proposals don't overlap)
+            &0,    // quorum_numerator
+            &0,    // proposal_threshold
+            &guardian,
+            &VoteType::Simple,
+            &120_960,
+        );
+
+        // Override period_duration to 5 so we can advance cheaply.
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .set(&DataKey::ProposalPeriodDuration, &5u32);
+            // Disable cooldown so a second proposal is immediately allowed.
+            env.storage()
+                .instance()
+                .set(&DataKey::ProposalCooldown, &0u32);
+        });
+
+        // Submit one proposal at ledger 0 (period 0).
+        propose_dummy(&env, &client, &proposer);
+        assert_eq!(client.proposals_in_period(&proposer), 1);
+
+        // Advance to period 1 (ledger 5).  This is a small jump that won't
+        // cause the instance key to be treated as archived.
+        env.ledger().with_mut(|li| li.sequence_number = 5);
+
+        // Submit a proposal in period 1 — this should prune the period-0 key.
+        propose_dummy(&env, &client, &proposer);
+
+        // The period-0 key must have been removed.
+        let period0_key = DataKey::ProposalsInPeriod(proposer.clone(), 0u32);
+        let stale_still_exists = env.as_contract(&contract_id, || {
+            env.storage().persistent().has(&period0_key)
+        });
+        assert!(
+            !stale_still_exists,
+            "stale ProposalsInPeriod key for period 0 should have been pruned"
+        );
+
+        // The current period-1 count must be 1.
+        assert_eq!(client.proposals_in_period(&proposer), 1);
     }
 }
 

--- a/contracts/token-votes/src/lib.rs
+++ b/contracts/token-votes/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env, Symbol,
+    contract, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env, Symbol, Vec,
 };
 
 #[cfg(test)]
@@ -68,6 +68,34 @@ impl TokenVotesContract {
     pub fn delegate(env: Env, delegator: Address, delegatee: Address) {
         delegator.require_auth();
         Self::apply_delegation(&env, delegator, delegatee);
+    }
+
+    /// Bulk-delegate voting power to multiple delegatees in a single transaction.
+    ///
+    /// In a MultiToken governance setup there are multiple token-votes contracts,
+    /// one per token type.  A token holder can delegate their voting power for
+    /// all of them with a single on-chain auth signature by calling
+    /// `delegate_batch` on each contract within the same transaction.
+    ///
+    /// Each element of `delegatees` is applied in order via [`apply_delegation`].
+    /// Because each call overwrites the previous delegate, the *last* entry in
+    /// the list is the effective delegatee for this contract after the batch
+    /// completes.  When coordinating across multiple token-votes contracts, the
+    /// governor's multi-token strategy passes a single-element list whose sole
+    /// entry is the delegatee for that particular token.
+    ///
+    /// A single auth on `delegator` covers all delegations in the batch — this
+    /// is the key UX improvement over N separate `delegate()` calls.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `delegatees` is empty.
+    pub fn delegate_batch(env: Env, delegator: Address, delegatees: Vec<Address>) {
+        assert!(!delegatees.is_empty(), "delegatees must not be empty");
+        delegator.require_auth();
+        for delegatee in delegatees.iter() {
+            Self::apply_delegation(&env, delegator.clone(), delegatee);
+        }
     }
 
     /// Explicitly revoke delegation and move voting power back to self.
@@ -1810,6 +1838,81 @@ mod tests {
         let record = client.get_delegator_record(&delegator);
         assert_eq!(record.start_ledger, 42);
         assert_eq!(record.balance, 100);
+    }
+
+    // ── delegate_batch tests ─────────────────────────────────────────────────
+
+    /// Single-element batch behaves identically to delegate().
+    #[test]
+    fn test_delegate_batch_single_element() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let delegator = Address::generate(&env);
+        let delegatee = Address::generate(&env);
+
+        let (contract_id, token_addr) = setup(&env, &admin);
+        let client = TokenVotesContractClient::new(&env, &contract_id);
+        let sac_client = token::StellarAssetClient::new(&env, &token_addr);
+
+        sac_client.mint(&delegator, &500i128);
+
+        let mut batch = soroban_sdk::Vec::new(&env);
+        batch.push_back(delegatee.clone());
+        client.delegate_batch(&delegator, &batch);
+
+        assert_eq!(client.get_votes(&delegatee), 500);
+        assert_eq!(client.delegates(&delegator), Some(delegatee));
+    }
+
+    /// Multi-element batch: the last delegatee in the list is the effective one.
+    #[test]
+    fn test_delegate_batch_last_entry_wins() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let delegator = Address::generate(&env);
+        let delegatee_a = Address::generate(&env);
+        let delegatee_b = Address::generate(&env);
+        let delegatee_c = Address::generate(&env);
+
+        let (contract_id, token_addr) = setup(&env, &admin);
+        let client = TokenVotesContractClient::new(&env, &contract_id);
+        let sac_client = token::StellarAssetClient::new(&env, &token_addr);
+
+        sac_client.mint(&delegator, &200i128);
+
+        let mut batch = soroban_sdk::Vec::new(&env);
+        batch.push_back(delegatee_a.clone());
+        batch.push_back(delegatee_b.clone());
+        batch.push_back(delegatee_c.clone());
+        client.delegate_batch(&delegator, &batch);
+
+        // Final delegatee is delegatee_c.
+        assert_eq!(client.delegates(&delegator), Some(delegatee_c.clone()));
+        assert_eq!(client.get_votes(&delegatee_c), 200);
+        // Intermediate delegatees received and then lost voting power.
+        assert_eq!(client.get_votes(&delegatee_a), 0);
+        assert_eq!(client.get_votes(&delegatee_b), 0);
+    }
+
+    /// Empty batch panics.
+    #[test]
+    #[should_panic]
+    fn test_delegate_batch_empty_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let delegator = Address::generate(&env);
+
+        let (contract_id, _) = setup(&env, &admin);
+        let client = TokenVotesContractClient::new(&env, &contract_id);
+
+        let empty: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+        client.delegate_batch(&delegator, &empty);
     }
 
 }

--- a/contracts/token-votes/src/load_tests.rs
+++ b/contracts/token-votes/src/load_tests.rs
@@ -1,5 +1,6 @@
 use crate::{Checkpoint, TokenVotesContract};
-use soroban_sdk::Env;
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{token, Address, Env};
 
 const SOROBAN_CPU_LIMIT: u64 = 100_000_000;
 
@@ -103,4 +104,73 @@ fn test_binary_search_edge_cases() {
     assert_eq!(before_votes, 0);
     assert_eq!(exact_votes, 777);
     assert_eq!(after_votes, 777);
+}
+
+/// Builds a token-votes contract with `count` checkpoints persisted for a
+/// single account by delegating once per ledger and minting additional tokens
+/// each ledger so each delegation produces a distinct checkpoint.
+///
+/// Returns (contract_client, account_address, max_ledger).
+fn setup_account_with_checkpoints(
+    env: &Env,
+    count: usize,
+) -> (crate::TokenVotesContractClient<'_>, Address, u32) {
+    let admin = Address::generate(env);
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_addr = sac.address();
+    let sac_client = token::StellarAssetClient::new(env, &token_addr);
+
+    let contract_id = env.register(TokenVotesContract, ());
+    let client = crate::TokenVotesContractClient::new(env, &contract_id);
+    client.initialize(&admin, &token_addr);
+
+    let account = Address::generate(env);
+
+    for i in 1..=count {
+        // Advance ledger so each delegation lands on a unique ledger.
+        env.ledger().with_mut(|li| li.sequence_number = i as u32);
+        // Mint one extra token each round so the checkpoint balance changes.
+        sac_client.mint(&account, &1_i128);
+        client.delegate(&account, &account);
+    }
+
+    (client, account, count as u32)
+}
+
+/// Verify that `get_past_votes` stays within the Soroban compute budget when
+/// called on an account with 1 000 checkpoints (Issue #692).
+///
+/// This exercises the full contract call path — persistent storage read of the
+/// checkpoint vector followed by the O(log n) binary search — rather than
+/// calling `binary_search` in isolation.
+#[test]
+fn test_get_past_votes_1000_checkpoints_within_budget() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, account, max_ledger) = setup_account_with_checkpoints(&env, 1000);
+
+    // Advance the ledger past the last checkpoint so get_past_votes doesn't
+    // panic with "ledger must not exceed current ledger".
+    env.ledger().with_mut(|li| li.sequence_number = max_ledger + 1);
+
+    // Query at a ledger in the middle of the range — worst-case for binary
+    // search is any non-extreme position.
+    let mid_ledger = max_ledger / 2;
+
+    let mut budget = env.cost_estimate().budget();
+    budget.reset_default();
+
+    let votes = client.get_past_votes(&account, &mid_ledger);
+
+    let cpu = budget.cpu_instruction_cost();
+
+    // votes at mid_ledger should be mid_ledger (one token minted per ledger).
+    assert_eq!(votes, mid_ledger as i128);
+
+    assert!(
+        cpu < SOROBAN_CPU_LIMIT,
+        "get_past_votes exceeded Soroban CPU budget for 1000 checkpoints: {} instructions",
+        cpu
+    );
 }


### PR DESCRIPTION
# fix/issues-692-693-702-716

Resolves four open issues across the frontend and Rust/Soroban contracts.

## Changes

**#702 – Delegate leaderboard page**
Added the missing Delegators count column and profile links (`/profile/[address]`) to the existing delegates page. Also wired `prefillAddress` through to `DelegateModal`.

**#716 – proposals_in_period storage cleanup**
In `GovernorContract::propose`, the write of `ProposalsInPeriod(proposer, current_period)` now deletes the key for `current_period - 1` before writing the new count. This prevents unbounded accumulation of stale storage keys across periods. A unit test verifies the prune happens and the current-period count remains correct.

**#692 – get_past_votes compute-budget load test**
Added `test_get_past_votes_1000_checkpoints_within_budget` to `contracts/token-votes/src/load_tests.rs`. The test builds 1 000 real contract checkpoints via repeated delegations, calls `get_past_votes` at the midpoint, and asserts the CPU instruction cost stays below the 100 M Soroban budget limit.

**#693 – delegate_batch() bulk delegation**
Added `TokenVotesContract::delegate_batch(env, delegator, delegatees: Vec<Address>)`. A single `delegator.require_auth()` covers all delegations; each entry in `delegatees` is applied in order via `apply_delegation`. Three unit tests cover single-element, multi-element (last-wins), and empty-list (panic) cases.

## Testing

- All existing governor tests pass (one pre-existing failure unrelated to this PR: `test_multi_token_weight_arithmetic_zero_balance_and_edge_tokens`)
- All 42 token-votes tests pass including the new load test
- Frontend type-checks clean

Closes #692, Closes #693, Closes #702, Closes #716
