### PR TITLE
feat(indexer): index ConfigUpdated history with old/new settings and ledger close time (#687)

### DIFF
--- a/packages/indexer/README.md
+++ b/packages/indexer/README.md
@@ -1,0 +1,58 @@
+# NebGov Indexer
+
+The NebGov indexer consumes on-chain governance events and exposes a REST API for historical governance analytics.
+
+## Run Locally
+
+```bash
+pnpm --filter @nebgov/indexer run migrate
+pnpm --filter @nebgov/indexer run dev
+```
+
+The service defaults to port `3001` unless `PORT` is set.
+
+## Key Endpoints
+
+- `GET /health` - indexer health and lag metrics
+- `GET /stats` - governance aggregate statistics
+- `GET /proposals` - proposal list (offset or cursor pagination)
+- `GET /proposals/:id` - single proposal
+- `GET /proposals/:id/votes` - votes for a proposal
+- `GET /delegates` - delegation leaderboard
+- `GET /profile/:address` - proposer/voter profile
+- `GET /wrapper/deposits` - wrapper deposit history
+- `GET /wrapper/withdrawals` - wrapper withdrawal history
+- `GET /treasury/transfers` - treasury transfer history
+- `GET /config-history` - paginated governor config change history
+- `GET /upgrade-history` - paginated governor upgrade history
+
+## Config History
+
+`GET /config-history` returns governance parameter updates indexed from `ConfigUpdated` events.
+
+Query params:
+
+- `limit` (optional, default `20`, max `100`)
+- `offset` (optional, default `0`)
+
+Response shape:
+
+```json
+{
+  "data": [
+    {
+      "id": 42,
+      "ledger": 987654,
+      "old_settings": { "voting_delay": 10 },
+      "new_settings": { "voting_delay": 20 },
+      "ledger_closed_at": "2026-06-01T12:00:00.000Z",
+      "created_at": "2026-06-01T12:00:03.000Z"
+    }
+  ],
+  "pagination": {
+    "limit": 20,
+    "offset": 0,
+    "hasMore": false
+  }
+}
+```

--- a/packages/indexer/migrations/002_config_update_history_columns.sql
+++ b/packages/indexer/migrations/002_config_update_history_columns.sql
@@ -1,0 +1,20 @@
+-- Up Migration
+
+ALTER TABLE config_updates
+  ADD COLUMN IF NOT EXISTS old_settings JSONB,
+  ADD COLUMN IF NOT EXISTS ledger_closed_at TIMESTAMPTZ;
+
+UPDATE config_updates
+SET ledger_closed_at = created_at
+WHERE ledger_closed_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_config_updates_closed_at
+  ON config_updates(ledger_closed_at DESC);
+
+-- Down Migration
+
+DROP INDEX IF EXISTS idx_config_updates_closed_at;
+
+ALTER TABLE config_updates
+  DROP COLUMN IF EXISTS ledger_closed_at,
+  DROP COLUMN IF EXISTS old_settings;

--- a/packages/indexer/src/__tests__/api.test.ts
+++ b/packages/indexer/src/__tests__/api.test.ts
@@ -43,6 +43,53 @@ describe("API Endpoints", () => {
     app = createApp(mockServer);
   });
 
+  describe("GET /config-history", () => {
+    it("should return paginated config update history", async () => {
+      const mockRows = [
+        {
+          id: 2,
+          ledger: 120,
+          old_settings: { voting_delay: 1 },
+          new_settings: { voting_delay: 2 },
+          ledger_closed_at: "2026-06-01T12:00:00Z",
+          created_at: "2026-06-01T12:00:05Z",
+        },
+        {
+          id: 1,
+          ledger: 100,
+          old_settings: { voting_delay: 0 },
+          new_settings: { voting_delay: 1 },
+          ledger_closed_at: "2026-05-30T09:00:00Z",
+          created_at: "2026-05-30T09:00:03Z",
+        },
+      ];
+
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({
+        rows: mockRows,
+        rowCount: mockRows.length,
+      });
+
+      const response = await request(app).get("/config-history?limit=2&offset=0");
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toEqual(mockRows);
+      expect(response.body.pagination).toEqual({ limit: 2, offset: 0, hasMore: true });
+      expect(mockPool.query).toHaveBeenCalledWith(
+        "SELECT * FROM config_updates ORDER BY ledger DESC, id DESC LIMIT $1 OFFSET $2",
+        [2, 0],
+      );
+    });
+
+    it("should return 500 on database error", async () => {
+      (mockPool.query as jest.Mock).mockRejectedValueOnce(new Error("Database error"));
+
+      const response = await request(app).get("/config-history");
+
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({ error: "Internal server error" });
+    });
+  });
+
   describe("GET /proposals/:id", () => {
     it("should return a proposal when found", async () => {
       const mockProposal = {

--- a/packages/indexer/src/__tests__/governor-events.int.test.ts
+++ b/packages/indexer/src/__tests__/governor-events.int.test.ts
@@ -15,6 +15,7 @@ function makeEvent(params: {
   type: string;
   topicArgs?: any[];
   value: unknown;
+  ledgerClosedAt?: string;
 }): SorobanRpc.Api.EventResponse {
   const topic = [
     nativeToScVal(params.type, { type: "symbol" }),
@@ -24,6 +25,7 @@ function makeEvent(params: {
   return {
     type: "contract",
     ledger: params.ledger,
+    ledgerClosedAt: params.ledgerClosedAt ?? "2026-01-01T00:00:00Z",
     contractId: params.contractId as any,
     topic,
     value,
@@ -54,6 +56,7 @@ describe("governor event indexing (integration)", () => {
       contractId: GOVERNOR,
       ledger: 200,
       type: "ConfigUpdated",
+      ledgerClosedAt: "2026-06-01T12:00:00Z",
       value: {
         old_settings: {
           voting_delay: 1,
@@ -84,14 +87,16 @@ describe("governor event indexing (integration)", () => {
     expect(latest).toBe(200);
 
     const rows = await pool.query(
-      "SELECT ledger, new_settings FROM config_updates ORDER BY id DESC LIMIT 1",
+      "SELECT ledger, old_settings, new_settings, ledger_closed_at FROM config_updates ORDER BY id DESC LIMIT 1",
     );
     expect(rows.rows.length).toBe(1);
     expect(rows.rows[0].ledger).toBe(200);
+    expect(rows.rows[0].old_settings.voting_delay).toBe(1);
     const settings = rows.rows[0].new_settings;
     expect(settings.voting_delay).toBe(2);
     expect(settings.voting_period).toBe(3);
     expect(settings.quorum_numerator).toBe(35);
+    expect(rows.rows[0].ledger_closed_at.toISOString()).toBe("2026-06-01T12:00:00.000Z");
   });
 
   it("indexes GovernorUpgraded event into governor_upgrades", async () => {
@@ -157,9 +162,10 @@ describe("governor event indexing (integration)", () => {
     expect(latest).toBe(202);
 
     const rows = await pool.query(
-      "SELECT new_settings FROM config_updates WHERE ledger = 202 ORDER BY id DESC LIMIT 1",
+      "SELECT old_settings, new_settings FROM config_updates WHERE ledger = 202 ORDER BY id DESC LIMIT 1",
     );
     expect(rows.rows.length).toBe(1);
+    expect(rows.rows[0].old_settings).toBeNull();
     expect(rows.rows[0].new_settings.voting_delay).toBe(3);
   });
 

--- a/packages/indexer/src/events.ts
+++ b/packages/indexer/src/events.ts
@@ -345,6 +345,18 @@ interface GovernorSettings {
   proposal_period_duration?: number;
 }
 
+function stringifyJson(value: unknown): string {
+  return JSON.stringify(value, (_key, current) =>
+    typeof current === "bigint" ? current.toString() : current,
+  );
+}
+
+function parseLedgerClosedAt(value: unknown): Date | null {
+  if (typeof value !== "string" || value.length === 0) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
 function toNumber(value: unknown): number | null {
   if (typeof value === "number") return value;
   if (typeof value === "bigint") return Number(value);
@@ -409,17 +421,33 @@ async function handleConfigUpdated(
   topics: unknown[],
 ): Promise<void> {
   const data = scValToNative(event.value) as Record<string, unknown>;
+  const oldSettings =
+    data.old_settings === undefined || data.old_settings === null
+      ? null
+      : toGovernorSettings(data.old_settings);
   const newSettings = toGovernorSettings(data.new_settings);
+
+  if ((data.old_settings !== undefined && data.old_settings !== null) && !oldSettings) {
+    console.error("Failed to parse old_settings from ConfigUpdated event");
+    return;
+  }
 
   if (!newSettings) {
     console.error("Failed to parse new_settings from ConfigUpdated event");
     return;
   }
 
+  const ledgerClosedAt = parseLedgerClosedAt((event as any).ledgerClosedAt);
+
   await pool.query(
-    `INSERT INTO config_updates (ledger, new_settings)
-     VALUES ($1, $2)`,
-    [event.ledger, JSON.stringify(newSettings)],
+    `INSERT INTO config_updates (ledger, old_settings, new_settings, ledger_closed_at)
+     VALUES ($1, $2, $3, $4)`,
+    [
+      event.ledger,
+      oldSettings ? stringifyJson(oldSettings) : null,
+      stringifyJson(newSettings),
+      ledgerClosedAt,
+    ],
   );
 }
 


### PR DESCRIPTION
Problem
The indexer did not provide a full audit trail for governance configuration changes. ConfigUpdated events were missing historical diff context (old vs new) and chain timestamp linkage, making historical governance analysis difficult.

Solution

Added migration to extend config_updates with:
old_settings JSONB
ledger_closed_at TIMESTAMPTZ
index on ledger_closed_at
backfill of ledger_closed_at from created_at for existing rows
Updated ConfigUpdated event indexing to persist:
ledger
old_settings (nullable for legacy events)
new_settings
ledger_closed_at from Soroban event metadata
Added bigint-safe JSON serialization for settings.
Added API tests for GET /config-history.
Added indexer README documentation for /config-history.
Testing

pnpm --filter @nebgov/indexer run build
pnpm --filter @nebgov/indexer exec jest src/tests/api.test.ts -t "GET /config-history"
Full indexer jest run executed; unrelated pre-existing failures observed in existing tests.
Closes
Closes #687