### PR TITLE
feat(governor): add get_proposal_list on-chain pagination and SDK fallback listing (#691)

### DIFF
--- a/contracts/governor/src/lib.rs
+++ b/contracts/governor/src/lib.rs
@@ -322,6 +322,8 @@ pub enum DataKey {
     CachedTimelockDelay,
     /// Cached timelock execution_window (seconds) written once at initialize time.
     CachedExecutionWindow,
+    /// Ordered list of proposal ids for pagination.
+    ProposalList,
 }
 
 #[contract]
@@ -367,7 +369,10 @@ impl GovernorContract {
         // repeated cross-contract calls. Falls back to live calls for pre-migration
         // contracts that don't have the cache entries yet.
         let cached_delay: Option<u64> = env.storage().instance().get(&DataKey::CachedTimelockDelay);
-        let cached_window: Option<u64> = env.storage().instance().get(&DataKey::CachedExecutionWindow);
+        let cached_window: Option<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::CachedExecutionWindow);
         let timelock_delay_ledgers: u32 = match (cached_delay, cached_window) {
             (Some(d), Some(w)) => ((d + w) / Self::SECONDS_PER_LEDGER) as u32,
             _ => {
@@ -377,7 +382,8 @@ impl GovernorContract {
                     .get(&DataKey::Timelock)
                     .unwrap_or_else(|| env.panic_with_error(GovernorError::TimelockNotSet));
                 let timelock = TimelockClient::new(env, &timelock_addr);
-                ((timelock.min_delay() + timelock.execution_window()) / Self::SECONDS_PER_LEDGER) as u32
+                ((timelock.min_delay() + timelock.execution_window()) / Self::SECONDS_PER_LEDGER)
+                    as u32
             }
         };
 
@@ -388,9 +394,11 @@ impl GovernorContract {
             .saturating_add(timelock_delay_ledgers)
             .saturating_add(1000);
 
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Proposal(proposal_id), ttl_ledgers, ttl_ledgers);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Proposal(proposal_id),
+            ttl_ledgers,
+            ttl_ledgers,
+        );
     }
 
     fn decode_calldata_args(env: &Env, data: &Bytes) -> Vec<Val> {
@@ -489,6 +497,9 @@ impl GovernorContract {
             .instance()
             .set(&DataKey::ProposalGracePeriod, &proposal_grace_period);
         env.storage().instance().set(&DataKey::ProposalCount, &0u64);
+        env.storage()
+            .persistent()
+            .set(&DataKey::ProposalList, &Vec::<u64>::new(&env));
         env.storage().instance().set(
             &DataKey::CurrentWasmHash,
             &BytesN::from_array(&env, &[0u8; 32]),
@@ -681,6 +692,16 @@ impl GovernorContract {
         env.storage()
             .instance()
             .set(&DataKey::ProposalCount, &proposal_id);
+
+        let mut proposal_list: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ProposalList)
+            .unwrap_or(Vec::new(&env));
+        proposal_list.push_back(proposal_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::ProposalList, &proposal_list);
 
         // Update rate limiting storage
         env.storage()
@@ -1732,10 +1753,9 @@ impl GovernorContract {
         );
 
         let old_settings = Self::get_settings(env.clone());
-        env.storage().instance().set(
-            &DataKey::MaxProposalsPerPeriod,
-            &max_proposals_per_period,
-        );
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxProposalsPerPeriod, &max_proposals_per_period);
         let new_settings = Self::get_settings(env.clone());
 
         events::emit_config_updated(&env, &old_settings, &new_settings);
@@ -1798,11 +1818,7 @@ impl GovernorContract {
         }
 
         // Get voting power
-        let votes_token: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::VotesToken)
-            .unwrap();
+        let votes_token: Address = env.storage().instance().get(&DataKey::VotesToken).unwrap();
         let votes_client = VotesClient::new(&env, &votes_token);
         let voting_power = votes_client.get_votes(&proposer);
 
@@ -2227,6 +2243,34 @@ impl GovernorContract {
         Self::must_get_proposal(&env, proposal_id)
     }
 
+    /// Get a paginated list of proposals in creation order.
+    pub fn get_proposal_list(env: Env, offset: u64, limit: u64) -> Vec<Proposal> {
+        if limit == 0 {
+            return Vec::new(&env);
+        }
+
+        let proposal_ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ProposalList)
+            .unwrap_or(Vec::new(&env));
+
+        let total = proposal_ids.len() as u64;
+        if offset >= total {
+            return Vec::new(&env);
+        }
+
+        let end = core::cmp::min(offset.saturating_add(limit), total);
+        let mut proposals = Vec::new(&env);
+
+        for i in offset..end {
+            let proposal_id = proposal_ids.get(i as u32).unwrap();
+            proposals.push_back(Self::must_get_proposal(&env, proposal_id));
+        }
+
+        proposals
+    }
+
     // ============================================================================
     // Execution Gas Estimation (Issue #715)
     // ============================================================================
@@ -2255,20 +2299,19 @@ impl GovernorContract {
     /// total calldata size.
     pub fn estimate_execution_gas(env: Env, proposal_id: u64) -> ExecutionGasEstimate {
         let proposal = Self::must_get_proposal(&env, proposal_id);
-        let action_count = proposal.targets.len() as u32;
+        let action_count = proposal.targets.len();
         let mut calldata_bytes: u32 = 0;
         for i in 0..proposal.calldatas.len() {
             calldata_bytes += proposal.calldatas.get(i).unwrap().len();
         }
-        let estimated_cpu_insns =
-            Self::BASE_CPU_FIXED + (action_count as u64) * Self::BASE_CPU_PER_ACTION
-                + (calldata_bytes as u64) * Self::CPU_PER_CALLDATA_BYTE;
-        let estimated_mem_bytes =
-            Self::BASE_MEM_FIXED + (action_count as u64) * Self::BASE_MEM_PER_ACTION
-                + (calldata_bytes as u64) * Self::MEM_PER_CALLDATA_BYTE;
-        let estimated_fee_stroops =
-            (estimated_cpu_insns as i128) * Self::STROOPS_PER_CPU_INSN
-                + (estimated_mem_bytes as i128) * Self::STROOPS_PER_MEM_BYTE;
+        let estimated_cpu_insns = Self::BASE_CPU_FIXED
+            + (action_count as u64) * Self::BASE_CPU_PER_ACTION
+            + (calldata_bytes as u64) * Self::CPU_PER_CALLDATA_BYTE;
+        let estimated_mem_bytes = Self::BASE_MEM_FIXED
+            + (action_count as u64) * Self::BASE_MEM_PER_ACTION
+            + (calldata_bytes as u64) * Self::MEM_PER_CALLDATA_BYTE;
+        let estimated_fee_stroops = (estimated_cpu_insns as i128) * Self::STROOPS_PER_CPU_INSN
+            + (estimated_mem_bytes as i128) * Self::STROOPS_PER_MEM_BYTE;
         ExecutionGasEstimate {
             proposal_id,
             action_count,
@@ -2701,6 +2744,81 @@ mod test {
         // Verify proposal was created
         assert_eq!(proposal_id, 1);
         assert_eq!(client.proposal_count(), 1);
+    }
+
+    #[test]
+    fn test_get_proposal_list_pagination() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(GovernorContract, ());
+        let client = GovernorContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let proposer = Address::generate(&env);
+        let votes_token_id = env.register(MockVotesContract, ());
+        let timelock = env.register(MockTimelockContract, ());
+        let guardian = Address::generate(&env);
+
+        client.initialize(
+            &admin,
+            &votes_token_id,
+            &timelock,
+            &100,
+            &1000,
+            &50,
+            &100,
+            &guardian,
+            &VoteType::Extended,
+            &120_960,
+        );
+
+        let p1 = propose_dummy(&env, &client, &proposer);
+        env.ledger().with_mut(|l| l.sequence_number += 101);
+        let p2 = propose_dummy(&env, &client, &proposer);
+        env.ledger().with_mut(|l| l.sequence_number += 101);
+        let p3 = propose_dummy(&env, &client, &proposer);
+
+        let page = client.get_proposal_list(&1, &2);
+
+        assert_eq!(page.len(), 2);
+        assert_eq!(page.get(0).unwrap().id, p2);
+        assert_eq!(page.get(1).unwrap().id, p3);
+        assert_eq!(p1, 1);
+    }
+
+    #[test]
+    fn test_get_proposal_list_bounds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(GovernorContract, ());
+        let client = GovernorContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let proposer = Address::generate(&env);
+        let votes_token_id = env.register(MockVotesContract, ());
+        let timelock = env.register(MockTimelockContract, ());
+        let guardian = Address::generate(&env);
+
+        client.initialize(
+            &admin,
+            &votes_token_id,
+            &timelock,
+            &100,
+            &1000,
+            &50,
+            &100,
+            &guardian,
+            &VoteType::Extended,
+            &120_960,
+        );
+
+        let _ = propose_dummy(&env, &client, &proposer);
+
+        let empty_limit = client.get_proposal_list(&0, &0);
+        let empty_offset = client.get_proposal_list(&10, &5);
+
+        assert_eq!(empty_limit.len(), 0);
+        assert_eq!(empty_offset.len(), 0);
     }
 
     #[test]
@@ -3382,15 +3500,15 @@ mod test {
         // Initialize with long voting period: 30 days ≈ 259,200 ledgers (at 10 sec blocks)
         let long_voting_period = 259_200u32;
         let voting_delay = 100u32;
-        
+
         client.initialize(
             &admin,
             &votes_token_id,
             &timelock,
             &voting_delay,
             &long_voting_period,
-            &0,  // no quorum requirement so single voter can succeed
-            &0,  // no proposal threshold
+            &0, // no quorum requirement so single voter can succeed
+            &0, // no proposal threshold
             &guardian,
             &VoteType::Extended,
             &120_960, // grace period
@@ -3404,7 +3522,8 @@ mod test {
         assert_eq!(state, ProposalState::Pending);
 
         // Advance to active state (voting_delay ledgers)
-        env.ledger().with_mut(|li| li.sequence_number += voting_delay + 1);
+        env.ledger()
+            .with_mut(|li| li.sequence_number += voting_delay + 1);
         assert_eq!(client.state(&proposal_id), ProposalState::Active);
 
         // Cast vote — should extend TTL again
@@ -3416,14 +3535,16 @@ mod test {
 
         // Advance well into the long voting period (but not past end)
         let mid_voting_period = voting_delay + (long_voting_period / 2);
-        env.ledger().with_mut(|li| li.sequence_number = mid_voting_period);
+        env.ledger()
+            .with_mut(|li| li.sequence_number = mid_voting_period);
 
         // Should still be Active — if TTL wasn't extended, storage might expire
         let state = client.state(&proposal_id);
         assert_eq!(state, ProposalState::Active);
 
         // Advance to end of voting period
-        env.ledger().with_mut(|li| li.sequence_number = voting_delay + long_voting_period + 1);
+        env.ledger()
+            .with_mut(|li| li.sequence_number = voting_delay + long_voting_period + 1);
 
         // Should transition to Succeeded (since quorum was met and votes_for > votes_against)
         let state = client.state(&proposal_id);

--- a/sdk/src/__tests__/governor-list.test.ts
+++ b/sdk/src/__tests__/governor-list.test.ts
@@ -1,0 +1,102 @@
+var mockScValToNative = jest.fn();
+var mockNativeToScVal = jest.fn();
+var mockSimulate = jest.fn();
+var mockGetAccount = jest.fn();
+var mockIsSimulationError = jest.fn();
+
+import { GovernorClient } from "../governor";
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const actual = jest.requireActual("@stellar/stellar-sdk");
+  return {
+    ...actual,
+    scValToNative: mockScValToNative,
+    nativeToScVal: mockNativeToScVal,
+    SorobanRpc: {
+      ...actual.SorobanRpc,
+      Server: jest.fn().mockImplementation(() => ({
+        simulateTransaction: mockSimulate,
+        getAccount: mockGetAccount,
+      })),
+      Api: {
+        ...actual.SorobanRpc.Api,
+        isSimulationError: mockIsSimulationError,
+      },
+    },
+    Contract: jest.fn().mockImplementation(() => ({
+      call: jest.fn().mockReturnValue({}),
+      contractId: jest.fn().mockReturnValue("CAAA"),
+    })),
+    TransactionBuilder: jest.fn().mockImplementation(() => ({
+      addOperation: jest.fn().mockReturnThis(),
+      setTimeout: jest.fn().mockReturnThis(),
+      build: jest.fn().mockReturnValue({}),
+    })),
+  };
+});
+
+describe("GovernorClient listProposals", () => {
+  const governorAddress = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+  const simulationAccount = "GBFUUXATVOGXGD4KS3I423QFZSPE4ZFOQ3TCJVWFUYSIPULXIRVRE2DT";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const { Account } = require("@stellar/stellar-sdk");
+    mockGetAccount.mockResolvedValue(new Account(simulationAccount, "1"));
+    mockNativeToScVal.mockReturnValue({});
+    mockIsSimulationError.mockReturnValue(false);
+  });
+
+  it("uses get_proposal_list when contract supports it", async () => {
+    const client = new GovernorClient({
+      governorAddress,
+      timelockAddress: governorAddress,
+      votesAddress: governorAddress,
+      network: "testnet",
+      simulationAccount,
+    });
+
+    mockSimulate.mockResolvedValueOnce({ result: { retval: {} } });
+    mockScValToNative.mockReturnValueOnce([
+      { id: 1n, description: "p1" },
+      { id: 2n, description: "p2" },
+    ]);
+
+    const proposals = await client.listProposals(0, 2);
+
+    expect(proposals).toHaveLength(2);
+    expect(proposals[0].id).toBe(1n);
+    expect(proposals[1].id).toBe(2n);
+  });
+
+  it("falls back to proposal_count/get_proposal when get_proposal_list is unavailable", async () => {
+    const client = new GovernorClient({
+      governorAddress,
+      timelockAddress: governorAddress,
+      votesAddress: governorAddress,
+      network: "testnet",
+      simulationAccount,
+    });
+
+    mockSimulate
+      .mockResolvedValueOnce({ error: "unknown function get_proposal_list" })
+      .mockResolvedValueOnce({ result: { retval: {} } })
+      .mockResolvedValueOnce({ result: { retval: {} } })
+      .mockResolvedValueOnce({ result: { retval: {} } });
+    mockIsSimulationError
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false);
+    mockScValToNative
+      .mockReturnValueOnce(3)
+      .mockReturnValueOnce({ id: 2n, description: "p2" })
+      .mockReturnValueOnce({ id: 3n, description: "p3" });
+
+    const proposals = await client.listProposals(1, 2);
+
+    expect(proposals).toHaveLength(2);
+    expect(proposals[0].id).toBe(2n);
+    expect(proposals[1].id).toBe(3n);
+  });
+});

--- a/sdk/src/governor.ts
+++ b/sdk/src/governor.ts
@@ -1322,9 +1322,7 @@ export class GovernorClient {
             topics: [["VoteCast", "vote"], [voter]],
           },
         ],
-        pagination: {
-          limit: limit * 2, // Fetch extra to filter for relevant events
-        },
+        limit: limit * 2, // Fetch extra to filter for relevant events
       });
 
       const history: VotingHistoryEntry[] = [];
@@ -1336,12 +1334,9 @@ export class GovernorClient {
         if (String(voterTopic) !== voter) continue;
 
         // Parse event data
-        const data = event.value?.body?.val;
-        if (!data) continue;
-
-        const native = scValToNative(data) as Record<string, unknown>;
+        const native = scValToNative(event.value) as Record<string, unknown>;
         const proposalId = toBigInt(native.proposal_id ?? native.proposalId);
-        const supportRaw = native.support ?? native.support;
+        const supportRaw = native.support;
         const support = typeof supportRaw === "number" 
           ? supportRaw 
           : Number(supportRaw);
@@ -2169,6 +2164,72 @@ export class GovernorClient {
     }
 
     return results;
+  }
+
+  /**
+   * List proposals using on-chain pagination when available.
+   *
+   * For older governor deployments that do not expose `get_proposal_list`,
+   * this falls back to the legacy `proposal_count` + `get_proposal` strategy.
+   */
+  async listProposals(offset = 0, limit = 20): Promise<Proposal[]> {
+    const safeOffset = Math.max(0, Math.floor(offset));
+    const safeLimit = Math.max(0, Math.floor(limit));
+
+    if (safeLimit === 0) {
+      return [];
+    }
+
+    return this.retry(async () => {
+      try {
+        const result = await this.server.simulateTransaction(
+          new TransactionBuilder(
+            await this.server.getAccount(this.readAccount()),
+            { fee: BASE_FEE, networkPassphrase: this.networkPassphrase },
+          )
+            .addOperation(
+              this.contract.call(
+                "get_proposal_list",
+                nativeToScVal(BigInt(safeOffset), { type: "u64" }),
+                nativeToScVal(BigInt(safeLimit), { type: "u64" }),
+              ),
+            )
+            .setTimeout(30)
+            .build(),
+        );
+
+        if (SorobanRpc.Api.isSimulationError(result)) {
+          throw new Error(result.error);
+        }
+
+        const raw = (result as SorobanRpc.Api.SimulateTransactionSuccessResponse)
+          .result?.retval;
+        if (!raw) {
+          return [];
+        }
+
+        return scValToNative(raw) as Proposal[];
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!message.includes("get_proposal_list")) {
+          throw error;
+        }
+
+        const total = Number(await this.proposalCount());
+        if (safeOffset >= total) {
+          return [];
+        }
+
+        const endExclusive = Math.min(total, safeOffset + safeLimit);
+        const ids: bigint[] = [];
+        for (let i = safeOffset; i < endExclusive; i++) {
+          ids.push(BigInt(i + 1));
+        }
+
+        const proposals = await Promise.all(ids.map((id) => this.getProposal(id)));
+        return proposals;
+      }
+    }, this.isNetworkError.bind(this));
   }
 
   /**


### PR DESCRIPTION
Problem:
On-chain proposal enumeration was missing. Proposal listing required indexer infrastructure, creating a gap for deployments and SDK consumers without indexer access.

Solution:

Added ProposalList persistent storage tracking proposal ids in creation order.
Appended proposal ids during propose.
Added get_proposal_list(env, offset, limit) returning paginated Proposal results.
Updated SDK GovernorClient with listProposals(offset, limit):
uses get_proposal_list when available
falls back to proposal_count + get_proposal for backwards compatibility
Added SDK tests for both paths.
Testing:

cargo test -p sorogov-governor test_get_proposal_list
cargo clippy -p sorogov-governor --all-targets -- -D warnings
pnpm --filter @nebgov/sdk exec tsc --noEmit
pnpm --filter @nebgov/sdk run build
pnpm --filter @nebgov/sdk exec jest src/tests/governor-list.test.ts
Closes:
Closes #691

