### PR TITLE
feat(governor): add standalone set_guardian action (#694)

### DIFF
--- a/contracts/governor/src/events.rs
+++ b/contracts/governor/src/events.rs
@@ -13,6 +13,7 @@ pub const PROPOSAL_CANCELLED_TOPIC: &str = "ProposalCancelled";
 pub const PROPOSAL_EXPIRED_TOPIC: &str = "ProposalExpired";
 pub const GOVERNOR_UPGRADED_TOPIC: &str = "GovernorUpgraded";
 pub const CONFIG_UPDATED_TOPIC: &str = "ConfigUpdated";
+pub const GUARDIAN_CHANGED_TOPIC: &str = "GuardianChanged";
 
 #[derive(Clone)]
 #[soroban_sdk::contracttype]
@@ -87,6 +88,13 @@ pub struct GovernorUpgradedEvent {
 pub struct ConfigUpdatedEvent {
     pub old_settings: GovernorSettings,
     pub new_settings: GovernorSettings,
+}
+
+#[derive(Clone)]
+#[soroban_sdk::contracttype]
+pub struct GuardianChangedEvent {
+    pub old_guardian: Address,
+    pub new_guardian: Address,
 }
 
 #[derive(Clone)]
@@ -228,6 +236,16 @@ pub fn emit_config_updated(
         ConfigUpdatedEvent {
             old_settings: old_settings.clone(),
             new_settings: new_settings.clone(),
+        },
+    );
+}
+
+pub fn emit_guardian_changed(env: &Env, old_guardian: &Address, new_guardian: &Address) {
+    env.events().publish(
+        (Symbol::new(env, GUARDIAN_CHANGED_TOPIC),),
+        GuardianChangedEvent {
+            old_guardian: old_guardian.clone(),
+            new_guardian: new_guardian.clone(),
         },
     );
 }

--- a/contracts/governor/src/lib.rs
+++ b/contracts/governor/src/lib.rs
@@ -367,7 +367,10 @@ impl GovernorContract {
         // repeated cross-contract calls. Falls back to live calls for pre-migration
         // contracts that don't have the cache entries yet.
         let cached_delay: Option<u64> = env.storage().instance().get(&DataKey::CachedTimelockDelay);
-        let cached_window: Option<u64> = env.storage().instance().get(&DataKey::CachedExecutionWindow);
+        let cached_window: Option<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::CachedExecutionWindow);
         let timelock_delay_ledgers: u32 = match (cached_delay, cached_window) {
             (Some(d), Some(w)) => ((d + w) / Self::SECONDS_PER_LEDGER) as u32,
             _ => {
@@ -377,7 +380,8 @@ impl GovernorContract {
                     .get(&DataKey::Timelock)
                     .unwrap_or_else(|| env.panic_with_error(GovernorError::TimelockNotSet));
                 let timelock = TimelockClient::new(env, &timelock_addr);
-                ((timelock.min_delay() + timelock.execution_window()) / Self::SECONDS_PER_LEDGER) as u32
+                ((timelock.min_delay() + timelock.execution_window()) / Self::SECONDS_PER_LEDGER)
+                    as u32
             }
         };
 
@@ -388,9 +392,11 @@ impl GovernorContract {
             .saturating_add(timelock_delay_ledgers)
             .saturating_add(1000);
 
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Proposal(proposal_id), ttl_ledgers, ttl_ledgers);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Proposal(proposal_id),
+            ttl_ledgers,
+            ttl_ledgers,
+        );
     }
 
     fn decode_calldata_args(env: &Env, data: &Bytes) -> Vec<Val> {
@@ -1690,6 +1696,30 @@ impl GovernorContract {
         events::emit_config_updated(&env, &old_settings, &new_settings);
     }
 
+    /// Update guardian independently of the full config payload.
+    ///
+    /// Authorization is restricted to the governor's own contract address.
+    /// This means the call must originate from an executed on-chain proposal.
+    pub fn set_guardian(env: Env, new_guardian: Address) {
+        env.current_contract_address().require_auth();
+
+        let old_guardian: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Guardian)
+            .unwrap_or_else(|| env.panic_with_error(GovernorError::GuardianNotSet));
+
+        if old_guardian == new_guardian {
+            return;
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Guardian, &new_guardian);
+
+        events::emit_guardian_changed(&env, &old_guardian, &new_guardian);
+    }
+
     /// Update the maximum calldata size per proposal action.
     ///
     /// Authorization is restricted to the governor's own contract address.
@@ -1732,10 +1762,9 @@ impl GovernorContract {
         );
 
         let old_settings = Self::get_settings(env.clone());
-        env.storage().instance().set(
-            &DataKey::MaxProposalsPerPeriod,
-            &max_proposals_per_period,
-        );
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxProposalsPerPeriod, &max_proposals_per_period);
         let new_settings = Self::get_settings(env.clone());
 
         events::emit_config_updated(&env, &old_settings, &new_settings);
@@ -1798,11 +1827,7 @@ impl GovernorContract {
         }
 
         // Get voting power
-        let votes_token: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::VotesToken)
-            .unwrap();
+        let votes_token: Address = env.storage().instance().get(&DataKey::VotesToken).unwrap();
         let votes_client = VotesClient::new(&env, &votes_token);
         let voting_power = votes_client.get_votes(&proposer);
 
@@ -2255,20 +2280,19 @@ impl GovernorContract {
     /// total calldata size.
     pub fn estimate_execution_gas(env: Env, proposal_id: u64) -> ExecutionGasEstimate {
         let proposal = Self::must_get_proposal(&env, proposal_id);
-        let action_count = proposal.targets.len() as u32;
+        let action_count = proposal.targets.len();
         let mut calldata_bytes: u32 = 0;
         for i in 0..proposal.calldatas.len() {
             calldata_bytes += proposal.calldatas.get(i).unwrap().len();
         }
-        let estimated_cpu_insns =
-            Self::BASE_CPU_FIXED + (action_count as u64) * Self::BASE_CPU_PER_ACTION
-                + (calldata_bytes as u64) * Self::CPU_PER_CALLDATA_BYTE;
-        let estimated_mem_bytes =
-            Self::BASE_MEM_FIXED + (action_count as u64) * Self::BASE_MEM_PER_ACTION
-                + (calldata_bytes as u64) * Self::MEM_PER_CALLDATA_BYTE;
-        let estimated_fee_stroops =
-            (estimated_cpu_insns as i128) * Self::STROOPS_PER_CPU_INSN
-                + (estimated_mem_bytes as i128) * Self::STROOPS_PER_MEM_BYTE;
+        let estimated_cpu_insns = Self::BASE_CPU_FIXED
+            + (action_count as u64) * Self::BASE_CPU_PER_ACTION
+            + (calldata_bytes as u64) * Self::CPU_PER_CALLDATA_BYTE;
+        let estimated_mem_bytes = Self::BASE_MEM_FIXED
+            + (action_count as u64) * Self::BASE_MEM_PER_ACTION
+            + (calldata_bytes as u64) * Self::MEM_PER_CALLDATA_BYTE;
+        let estimated_fee_stroops = (estimated_cpu_insns as i128) * Self::STROOPS_PER_CPU_INSN
+            + (estimated_mem_bytes as i128) * Self::STROOPS_PER_MEM_BYTE;
         ExecutionGasEstimate {
             proposal_id,
             action_count,
@@ -3382,15 +3406,15 @@ mod test {
         // Initialize with long voting period: 30 days ≈ 259,200 ledgers (at 10 sec blocks)
         let long_voting_period = 259_200u32;
         let voting_delay = 100u32;
-        
+
         client.initialize(
             &admin,
             &votes_token_id,
             &timelock,
             &voting_delay,
             &long_voting_period,
-            &0,  // no quorum requirement so single voter can succeed
-            &0,  // no proposal threshold
+            &0, // no quorum requirement so single voter can succeed
+            &0, // no proposal threshold
             &guardian,
             &VoteType::Extended,
             &120_960, // grace period
@@ -3404,7 +3428,8 @@ mod test {
         assert_eq!(state, ProposalState::Pending);
 
         // Advance to active state (voting_delay ledgers)
-        env.ledger().with_mut(|li| li.sequence_number += voting_delay + 1);
+        env.ledger()
+            .with_mut(|li| li.sequence_number += voting_delay + 1);
         assert_eq!(client.state(&proposal_id), ProposalState::Active);
 
         // Cast vote — should extend TTL again
@@ -3416,14 +3441,16 @@ mod test {
 
         // Advance well into the long voting period (but not past end)
         let mid_voting_period = voting_delay + (long_voting_period / 2);
-        env.ledger().with_mut(|li| li.sequence_number = mid_voting_period);
+        env.ledger()
+            .with_mut(|li| li.sequence_number = mid_voting_period);
 
         // Should still be Active — if TTL wasn't extended, storage might expire
         let state = client.state(&proposal_id);
         assert_eq!(state, ProposalState::Active);
 
         // Advance to end of voting period
-        env.ledger().with_mut(|li| li.sequence_number = voting_delay + long_voting_period + 1);
+        env.ledger()
+            .with_mut(|li| li.sequence_number = voting_delay + long_voting_period + 1);
 
         // Should transition to Succeeded (since quorum was met and votes_for > votes_against)
         let state = client.state(&proposal_id);

--- a/contracts/governor/src/tests/mod.rs
+++ b/contracts/governor/src/tests/mod.rs
@@ -201,6 +201,64 @@ fn update_config_rejects_caller_that_is_not_the_contract_address() {
 }
 
 #[test]
+#[should_panic]
+fn set_guardian_rejects_caller_that_is_not_the_contract_address() {
+    let env = Env::default();
+    let contract_id = env.register(GovernorContract, ());
+    let client = GovernorContractClient::new(&env, &contract_id);
+
+    let attacker = Address::generate(&env);
+    let new_guardian = Address::generate(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "set_guardian",
+            args: (new_guardian.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    client.set_guardian(&new_guardian);
+}
+
+#[test]
+fn set_guardian_succeeds_with_contract_self_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let votes_token = Address::generate(&env);
+    let timelock = env.register(MockTimelockContract, ());
+    let contract_id = env.register(GovernorContract, ());
+    let client = GovernorContractClient::new(&env, &contract_id);
+
+    let initial_guardian = Address::generate(&env);
+    client.initialize(
+        &admin,
+        &votes_token,
+        &timelock,
+        &100u32,
+        &1000u32,
+        &4u32,
+        &0i128,
+        &initial_guardian,
+        &VoteType::Extended,
+        &120_960u32,
+    );
+
+    let events_before = env.events().all().len();
+
+    let new_guardian = Address::generate(&env);
+    client.set_guardian(&new_guardian);
+    let events_after = env.events().all().len();
+
+    let settings = client.get_settings();
+    assert_eq!(settings.guardian, new_guardian);
+    assert_eq!(events_after, events_before + 1);
+}
+
+#[test]
 fn update_config_succeeds_with_contract_self_auth() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Summary

Adds a standalone `set_guardian` contract entrypoint to allow governance-controlled guardian updates without requiring a full config update flow.

### What changed

- Added `set_guardian(env, new_guardian)` in governor contract:
  - Requires contract self-auth (`env.current_contract_address().require_auth()`), matching existing governance-only admin actions.
  - Reads existing guardian from storage and returns early on no-op updates.
  - Persists the new guardian value to storage.
  - Emits a dedicated guardian update event.

- Added new guardian event support:
  - `GuardianChanged` topic/event payload with old/new guardian addresses.
  - Event emitter helper used by `set_guardian`.

- Added tests:
  - Rejects non-contract caller auth.
  - Succeeds with contract self-auth and verifies state/event behavior.

- Included a small clippy-cleanup in governor gas estimation path to satisfy `-D warnings`.

## Validation

- `cargo test -p sorogov-governor set_guardian`
- `cargo clippy -p sorogov-governor --all-targets -- -D warnings`

## Issue

Closes #694