### PR TITLE
feat: guardian-log, invariant test, liquidity test, proposals_count_by_state

### DIFF
--- a/backend/migrations/005_add_guardian_veto_log.sql
+++ b/backend/migrations/005_add_guardian_veto_log.sql
@@ -1,0 +1,16 @@
+-- Up Migration
+
+CREATE TABLE IF NOT EXISTS proposal_cancellations (
+  id SERIAL PRIMARY KEY,
+  proposal_id BIGINT NOT NULL,
+  cancelled_at_ledger INT NOT NULL,
+  caller TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_proposal_cancellations_ledger ON proposal_cancellations(cancelled_at_ledger DESC);
+CREATE INDEX IF NOT EXISTS idx_proposal_cancellations_caller ON proposal_cancellations(caller);
+
+-- Down Migration
+
+DROP TABLE IF EXISTS proposal_cancellations;

--- a/backend/src/routes/security.ts
+++ b/backend/src/routes/security.ts
@@ -75,4 +75,43 @@ router.post("/alerts/:id/resolve", async (req, res) => {
   }
 });
 
+// Get guardian veto history
+router.get("/guardian-log", async (req, res) => {
+  try {
+    const page = Math.max(1, parseInt(req.query.page as string) || 1);
+    const limit = Math.min(Math.max(1, parseInt(req.query.limit as string) || 20), 100);
+    const offset = (page - 1) * limit;
+
+    const result = await pool.query(
+      `SELECT
+         pc.proposal_id,
+         pc.cancelled_at_ledger,
+         pc.caller AS guardian_address,
+         p.description AS proposal_description
+       FROM proposal_cancellations pc
+       LEFT JOIN proposals p ON pc.proposal_id = p.id
+       ORDER BY pc.cancelled_at_ledger DESC
+       LIMIT $1 OFFSET $2`,
+      [limit, offset],
+    );
+
+    const countResult = await pool.query(
+      "SELECT COUNT(*) AS total FROM proposal_cancellations",
+    );
+    const total = parseInt(countResult.rows[0]?.total ?? "0");
+
+    res.json({
+      data: result.rows,
+      pagination: {
+        page,
+        limit,
+        total,
+        total_pages: Math.ceil(total / limit),
+      },
+    });
+  } catch (error) {
+    res.status(500).json({ error: "Failed to fetch guardian veto log" });
+  }
+});
+
 export default router;

--- a/contracts/governor/src/lib.rs
+++ b/contracts/governor/src/lib.rs
@@ -242,6 +242,29 @@ pub struct CanProposeResult {
     pub threshold: i128,
 }
 
+/// Counts of proposals grouped by their current state.
+///
+/// Returned by [`GovernorContract::proposals_count_by_state`] so the UI can
+/// render filter-tab badges without fetching every proposal individually.
+///
+/// # Gas cost
+/// This function iterates every proposal via `state()`, so callers should
+/// budget approximately `O(proposal_count)` read-heavy CPU units. For
+/// governors with thousands of proposals, consider caching the result
+/// off-chain or calling it infrequently.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProposalStateCounts {
+    pub pending: u64,
+    pub active: u64,
+    pub succeeded: u64,
+    pub defeated: u64,
+    pub queued: u64,
+    pub executed: u64,
+    pub cancelled: u64,
+    pub expired: u64,
+}
+
 /// Vote support options.
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
@@ -1747,6 +1770,52 @@ impl GovernorContract {
             .instance()
             .get(&DataKey::ProposalCount)
             .unwrap_or(0)
+    }
+
+    /// Get proposal counts grouped by their current state.
+    ///
+    /// Iterates every proposal (1..=proposal_count) and calls `state()` on
+    /// each, producing a [`ProposalStateCounts`] with counts for each
+    /// possible state. The UI can use this to render filter-tab badges
+    /// without fetching every proposal individually.
+    ///
+    /// # Gas cost
+    ///
+    /// Each iteration performs a persistent storage read and the state
+    /// machine logic from [`Self::state`]. Budget approximately:
+    /// - ~10_000 CPU insns per proposal (read + state evaluation)
+    /// - ~200 bytes memory per proposal
+    ///
+    /// For governors with thousands of proposals, call this function
+    /// infrequently and on a dedicated simulation/Horizon endpoint.
+    pub fn proposals_count_by_state(env: Env) -> ProposalStateCounts {
+        let total = Self::proposal_count(env.clone());
+        let mut counts = ProposalStateCounts {
+            pending: 0,
+            active: 0,
+            succeeded: 0,
+            defeated: 0,
+            queued: 0,
+            executed: 0,
+            cancelled: 0,
+            expired: 0,
+        };
+
+        for id in 1..=total {
+            let state = Self::state(env.clone(), id);
+            match state {
+                ProposalState::Pending => counts.pending += 1,
+                ProposalState::Active => counts.active += 1,
+                ProposalState::Succeeded => counts.succeeded += 1,
+                ProposalState::Defeated => counts.defeated += 1,
+                ProposalState::Queued => counts.queued += 1,
+                ProposalState::Executed => counts.executed += 1,
+                ProposalState::Cancelled => counts.cancelled += 1,
+                ProposalState::Expired => counts.expired += 1,
+            }
+        }
+
+        counts
     }
 
     /// Get the ledger sequence of the last proposal by an address.

--- a/contracts/liquidity/src/tests.rs
+++ b/contracts/liquidity/src/tests.rs
@@ -779,3 +779,70 @@ fn test_liquidity_error_codes_snapshot() {
     assert_eq!(LiquidityError::InsufficientShares as u32, 2);
     assert_eq!(LiquidityError::ImbalancedDeposit as u32, 3);
 }
+
+// ============================================================================
+// TESTS FOR INITIAL DEPOSIT LP TOKEN MINTING (Issue #709)
+// ============================================================================
+
+#[test]
+fn test_initial_deposit_returns_exactly_amount_a_lp_tokens() {
+    let (env, contract_id, governor, provider, _, token_a, token_b) = setup_liquidity();
+    let client = LiquidityContractClient::new(&env, &contract_id);
+
+    setup_pool(&client, &governor, 0, 1, &token_a, &token_b);
+
+    // Initial deposit (total_lp_supply == 0): must return amount_a as LP tokens
+    let (lp_tokens, deposit_b) = client.add_liquidity(&provider, &0, &1, &50_000, &50_000);
+    assert_eq!(lp_tokens, 50_000, "initial deposit must mint exactly amount_a LP tokens");
+    assert_eq!(deposit_b, 50_000);
+
+    let pool = client.get_pool(&0, &1);
+    assert_eq!(pool.reserve_a, 50_000);
+    assert_eq!(pool.reserve_b, 50_000);
+    assert_eq!(pool.total_lp_supply, 50_000);
+}
+
+#[test]
+fn test_second_deposit_returns_proportional_lp_tokens() {
+    let (env, contract_id, governor, provider, _, token_a, token_b) = setup_liquidity();
+    let client = LiquidityContractClient::new(&env, &contract_id);
+    let provider2 = Address::generate(&env);
+
+    setup_pool(&client, &governor, 0, 1, &token_a, &token_b);
+
+    // First deposit: 100_000 A + 100_000 B → total_lp_supply = 100_000
+    let (lp1, _) = client.add_liquidity(&provider, &0, &1, &100_000, &100_000);
+    assert_eq!(lp1, 100_000);
+
+    // Second deposit: 25_000 A → lp = 25_000 * 100_000 / 100_000 = 25_000
+    mint_pair(&env, &token_a, &token_b, &provider2, 25_000, 25_000);
+    let (lp2, _) = client.add_liquidity(&provider2, &0, &1, &25_000, &25_000);
+    assert_eq!(lp2, 25_000, "second deposit must mint proportional LP tokens");
+
+    let pool = client.get_pool(&0, &1);
+    assert_eq!(pool.reserve_a, 125_000);
+    assert_eq!(pool.reserve_b, 125_000);
+}
+
+#[test]
+fn test_total_lp_supply_equals_sum_of_minted_lp_tokens() {
+    let (env, contract_id, governor, provider, _, token_a, token_b) = setup_liquidity();
+    let client = LiquidityContractClient::new(&env, &contract_id);
+    let provider2 = Address::generate(&env);
+
+    setup_pool(&client, &governor, 0, 1, &token_a, &token_b);
+
+    let (lp1, _) = client.add_liquidity(&provider, &0, &1, &100_000, &100_000);
+    mint_pair(&env, &token_a, &token_b, &provider2, 50_000, 50_000);
+    let (lp2, _) = client.add_liquidity(&provider2, &0, &1, &50_000, &50_000);
+
+    let pool = client.get_pool(&0, &1);
+    assert_eq!(
+        pool.total_lp_supply,
+        lp1 + lp2,
+        "pool.total_lp_supply ({}) must equal lp1 ({}) + lp2 ({})",
+        pool.total_lp_supply,
+        lp1,
+        lp2
+    );
+}

--- a/contracts/token-votes/src/invariant_tests.rs
+++ b/contracts/token-votes/src/invariant_tests.rs
@@ -186,5 +186,136 @@ mod tests {
                 env.ledger().with_mut(|l| l.sequence_number += 1);
             }
         }
+
+        /// Invariant 6: Sum of all delegated voting power == total supply at any ledger.
+        ///
+        /// After each state-changing operation (minting, transferring, re-delegation),
+        /// the sum of voting power across all delegatees must equal the total delegated
+        /// supply as reported by get_past_total_supply.
+        #[test]
+        fn total_delegated_voting_power_equals_total_supply(
+            balances in proptest::collection::vec(1i128..1000, 1..10usize)
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (contract_id, token_addr) = setup(&env);
+            let client = TokenVotesContractClient::new(&env, &contract_id);
+            let sac_client = token::StellarAssetClient::new(&env, &token_addr);
+            let delegatee = Address::generate(&env);
+
+            for balance in &balances {
+                let delegator = Address::generate(&env);
+                sac_client.mint(&delegator, balance);
+                client.delegate(&delegator, &delegatee);
+                env.ledger().with_mut(|l| l.sequence_number += 1);
+
+                let current_ledger = env.ledger().sequence();
+
+                // Read AccountList to get all accounts with checkpoints
+                let accounts: soroban_sdk::Vec<Address> = env
+                    .as_contract(&contract_id, || {
+                        env.storage()
+                            .persistent()
+                            .get(&DataKey::AccountList)
+                            .unwrap_or(soroban_sdk::Vec::new(&env))
+                    });
+
+                let mut sum_voting_power: i128 = 0;
+                for i in 0..accounts.len() {
+                    let account = accounts.get(i).unwrap();
+                    sum_voting_power += client.get_past_votes(&account, &current_ledger);
+                }
+
+                let total_supply = client.get_past_total_supply(&current_ledger);
+                prop_assert_eq!(
+                    sum_voting_power,
+                    total_supply,
+                    "After minting+delegation: sum of delegatee voting powers ({}) must equal total supply ({}) at ledger {}",
+                    sum_voting_power,
+                    total_supply,
+                    current_ledger
+                );
+            }
+
+            // Test transfer scenario: move tokens between accounts
+            if balances.len() >= 2 {
+                let delegator_a = Address::generate(&env);
+                let delegator_b = Address::generate(&env);
+                let transfer_amount = balances[0];
+
+                sac_client.mint(&delegator_a, &(transfer_amount * 2));
+                sac_client.mint(&delegator_b, &transfer_amount);
+
+                let delegatee_a = Address::generate(&env);
+                let delegatee_b = Address::generate(&env);
+                client.delegate(&delegator_a, &delegatee_a);
+                client.delegate(&delegator_b, &delegatee_b);
+                env.ledger().with_mut(|l| l.sequence_number += 1);
+
+                let token_client = token::TokenClient::new(&env, &token_addr);
+                token_client.transfer(&delegator_a, &delegator_b, &transfer_amount);
+                env.ledger().with_mut(|l| l.sequence_number += 1);
+
+                let current_ledger = env.ledger().sequence();
+
+                let accounts: soroban_sdk::Vec<Address> = env
+                    .as_contract(&contract_id, || {
+                        env.storage()
+                            .persistent()
+                            .get(&DataKey::AccountList)
+                            .unwrap_or(soroban_sdk::Vec::new(&env))
+                    });
+
+                let mut sum_voting_power: i128 = 0;
+                for i in 0..accounts.len() {
+                    let account = accounts.get(i).unwrap();
+                    sum_voting_power += client.get_past_votes(&account, &current_ledger);
+                }
+
+                let total_supply = client.get_past_total_supply(&current_ledger);
+                prop_assert_eq!(
+                    sum_voting_power,
+                    total_supply,
+                    "After transfer: sum of delegatee voting powers must equal total supply"
+                );
+            }
+
+            // Test re-delegation scenario
+            if !balances.is_empty() {
+                let delegator = Address::generate(&env);
+                let new_delegatee = Address::generate(&env);
+
+                sac_client.mint(&delegator, &balances[0]);
+                client.delegate(&delegator, &delegatee);
+                env.ledger().with_mut(|l| l.sequence_number += 1);
+
+                // Re-delegate to a different delegatee
+                client.delegate(&delegator, &new_delegatee);
+                env.ledger().with_mut(|l| l.sequence_number += 1);
+
+                let current_ledger = env.ledger().sequence();
+
+                let accounts: soroban_sdk::Vec<Address> = env
+                    .as_contract(&contract_id, || {
+                        env.storage()
+                            .persistent()
+                            .get(&DataKey::AccountList)
+                            .unwrap_or(soroban_sdk::Vec::new(&env))
+                    });
+
+                let mut sum_voting_power: i128 = 0;
+                for i in 0..accounts.len() {
+                    let account = accounts.get(i).unwrap();
+                    sum_voting_power += client.get_past_votes(&account, &current_ledger);
+                }
+
+                let total_supply = client.get_past_total_supply(&current_ledger);
+                prop_assert_eq!(
+                    sum_voting_power,
+                    total_supply,
+                    "After re-delegation: sum of delegatee voting powers must equal total supply"
+                );
+            }
+        }
     }
 }

--- a/packages/indexer/migrations/002_add_proposal_cancellations.sql
+++ b/packages/indexer/migrations/002_add_proposal_cancellations.sql
@@ -1,6 +1,6 @@
 -- Up Migration
 
-CREATE TABLE proposal_cancellations (
+CREATE TABLE IF NOT EXISTS proposal_cancellations (
   id SERIAL PRIMARY KEY,
   proposal_id BIGINT NOT NULL REFERENCES proposals(id),
   cancelled_at_ledger INT NOT NULL,
@@ -8,8 +8,8 @@ CREATE TABLE proposal_cancellations (
   created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
-CREATE INDEX idx_proposal_cancellations_ledger ON proposal_cancellations(cancelled_at_ledger DESC);
-CREATE INDEX idx_proposal_cancellations_caller ON proposal_cancellations(caller);
+CREATE INDEX IF NOT EXISTS idx_proposal_cancellations_ledger ON proposal_cancellations(cancelled_at_ledger DESC);
+CREATE INDEX IF NOT EXISTS idx_proposal_cancellations_caller ON proposal_cancellations(caller);
 
 -- Down Migration
 

--- a/packages/indexer/migrations/002_add_proposal_cancellations.sql
+++ b/packages/indexer/migrations/002_add_proposal_cancellations.sql
@@ -1,0 +1,16 @@
+-- Up Migration
+
+CREATE TABLE proposal_cancellations (
+  id SERIAL PRIMARY KEY,
+  proposal_id BIGINT NOT NULL REFERENCES proposals(id),
+  cancelled_at_ledger INT NOT NULL,
+  caller TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_proposal_cancellations_ledger ON proposal_cancellations(cancelled_at_ledger DESC);
+CREATE INDEX idx_proposal_cancellations_caller ON proposal_cancellations(caller);
+
+-- Down Migration
+
+DROP TABLE IF EXISTS proposal_cancellations;

--- a/packages/indexer/src/events.ts
+++ b/packages/indexer/src/events.ts
@@ -15,6 +15,7 @@ const TOPIC_MAP: Record<string, string> = {
   vote_rsn: "VoteCastWithReason",
   queued: "ProposalQueued",
   executed: "ProposalExecuted",
+  cancelled: "ProposalCancelled",
   delegate: "DelegateChanged",
   del_chsh: "DelegateChanged",
   config_updated: "ConfigUpdated",
@@ -25,6 +26,7 @@ const TOPIC_MAP: Record<string, string> = {
   VoteCastWithReason: "VoteCastWithReason",
   ProposalQueued: "ProposalQueued",
   ProposalExecuted: "ProposalExecuted",
+  ProposalCancelled: "ProposalCancelled",
   DelegateChanged: "DelegateChanged",
   ConfigUpdated: "ConfigUpdated",
   GovernorUpgraded: "GovernorUpgraded",
@@ -144,6 +146,9 @@ export async function processEvents(
               break;
             case "GovernorUpgraded":
               await handleGovernorUpgraded(event, topics);
+              break;
+            case "ProposalCancelled":
+              await handleProposalCancelled(event, topics);
               break;
             default:
               break;
@@ -440,4 +445,47 @@ async function handleGovernorUpgraded(
      VALUES ($1, $2)`,
     [event.ledger, hashStr],
   );
+}
+
+async function handleProposalCancelled(
+  event: SorobanRpc.Api.EventResponse,
+  topics: unknown[],
+): Promise<void> {
+  const value = scValToNative(event.value);
+
+  let proposalId: string;
+  let cancelledAtLedger: number;
+  let caller: string;
+
+  if (Array.isArray(value)) {
+    // cancel_queued format: (proposal_id: u64, queue_time: u32, current_ledger: u32)
+    proposalId = String(value[0] as bigint);
+    cancelledAtLedger = Number(value[2]);
+    caller = topics.length > 1 ? String(topics[1]) : "unknown";
+  } else if (value && typeof value === "object") {
+    // emit_proposal_cancelled format: ProposalCancelledEvent { proposal_id, caller }
+    const obj = value as Record<string, unknown>;
+    proposalId = String(obj.proposal_id);
+    cancelledAtLedger = event.ledger;
+    caller = String(obj.caller ?? "unknown");
+  } else {
+    return;
+  }
+
+  await pool.query("UPDATE proposals SET cancelled = true WHERE id = $1", [
+    proposalId,
+  ]);
+
+  await pool.query(
+    `INSERT INTO proposal_cancellations (proposal_id, cancelled_at_ledger, caller)
+     VALUES ($1, $2, $3)
+     ON CONFLICT DO NOTHING`,
+    [proposalId, cancelledAtLedger, caller],
+  );
+
+  invalidatePattern("proposals:");
+  broadcast({
+    type: "proposal_cancelled",
+    data: { proposal_id: proposalId, cancelled_at_ledger: cancelledAtLedger, caller },
+  });
 }


### PR DESCRIPTION
### Summary

Solves 4 issues:

- **Closes #690** — Add \GET /security/guardian-log?page=1&limit=20\ endpoint returning historical guardian veto events. Includes indexer \ProposalCancelled\ handler, \proposal_cancellations\ DB table, and paginated endpoint joining with proposals for description.

- **Closes #695** — Add invariant test verifying sum of all delegated voting power equals total supply at any ledger, covering minting, transfer, and re-delegation scenarios.

- **Closes #709** — Add explicit tests verifying initial deposit returns exactly \mount_a\ LP tokens, second deposit returns proportional LP tokens, and \pool.total_lp_supply == lp1 + lp2\.

- **Closes #710** — Add \proposals_count_by_state()\ to the governor contract returning a \ProposalStateCounts\ struct with counts for pending, active, succeeded, defeated, queued, executed, cancelled, and expired.

### Changes

| File | Change |
|------|--------|
| \contracts/governor/src/lib.rs\ | Added \ProposalStateCounts\ struct + \proposals_count_by_state()\ |
| \contracts/token-votes/src/invariant_tests.rs\ | Added invariant test for total delegated == total supply |
| \contracts/liquidity/src/tests.rs\ | Added 3 tests for initial deposit LP minting |
| \packages/indexer/src/events.ts\ | Added \ProposalCancelled\ topic mapping and handler |
| \packages/indexer/migrations/002_*.sql\ | New \proposal_cancellations\ table |
| \ackend/src/routes/security.ts\ | Added \GET /security/guardian-log\ endpoint |
| \ackend/migrations/005_*.sql\ | Backend migration for \proposal_cancellations\ table |

### Test Results

- **Liquidity**: 36/36 passed
- **Token-votes invariants**: 6/6 passed (including new test)
- **Governor**: 60/61 passed (1 pre-existing failure in multi-token edge case)