### PR TITLE
fix: OOM in getTopDelegates, participation rate display, 503 retry tests, MultiToken integration tests

### DIFF
--- a/app/src/app/delegates/page.tsx
+++ b/app/src/app/delegates/page.tsx
@@ -40,15 +40,21 @@ function formatVotes(votes: bigint): string {
   return num.toLocaleString();
 }
 
+const PAGE_SIZE = 20;
+
 export default function DelegatesPage() {
   const [delegates, setDelegates] = useState<TopDelegate[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [totalDelegated, setTotalDelegated] = useState(0n);
   const [totalSupply, setTotalSupply] = useState(0n);
   const [modalOpen, setModalOpen] = useState(false);
   const [prefillAddress, setPrefillAddress] = useState<string>("");
   const [currentDelegatee, setCurrentDelegatee] = useState<string | null>(null);
+  const [offset, setOffset] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+  const [client, setClient] = useState<VotesClient | null>(null);
   const { publicKey } = useWallet();
 
   useEffect(() => {
@@ -65,24 +71,28 @@ export default function DelegatesPage() {
           throw new Error("Missing required environment variables.");
         }
 
-        const client = new VotesClient({
+        const votesClient = new VotesClient({
           governorAddress,
           timelockAddress,
           votesAddress,
           network,
           ...(rpcUrl && { rpcUrl }),
         });
+        setClient(votesClient);
 
-        const supply = await client.getTotalSupply();
+        const supply = await votesClient.getTotalSupply();
         setTotalSupply(supply);
 
-        const topDelegates = await client.getTopDelegates(20);
-        setDelegates(topDelegates);
-        const total = topDelegates.reduce((sum, d) => sum + d.votingPower, 0n);
+        const result = await votesClient.getTopDelegates({ limit: PAGE_SIZE, offset: 0 });
+        const page = Array.isArray(result) ? result : result.delegates;
+        setDelegates(page);
+        const total = page.reduce((sum, d) => sum + d.votingPower, 0n);
         setTotalDelegated(total);
+        setOffset(PAGE_SIZE);
+        setHasMore(page.length === PAGE_SIZE);
 
         if (publicKey) {
-          setCurrentDelegatee(await client.getDelegatee(publicKey));
+          setCurrentDelegatee(await votesClient.getDelegatee(publicKey));
         } else {
           setCurrentDelegatee(null);
         }
@@ -98,6 +108,22 @@ export default function DelegatesPage() {
 
     fetchDelegates();
   }, [publicKey]);
+
+  async function loadMore() {
+    if (!client || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const result = await client.getTopDelegates({ limit: PAGE_SIZE, offset });
+      const page = Array.isArray(result) ? result : result.delegates;
+      setDelegates((prev) => [...prev, ...page]);
+      setOffset((prev) => prev + PAGE_SIZE);
+      setHasMore(page.length === PAGE_SIZE);
+    } catch (err) {
+      console.error("Error loading more delegates:", err);
+    } finally {
+      setLoadingMore(false);
+    }
+  }
 
   function handleDelegateClick(address: string) {
     setPrefillAddress(address);
@@ -256,6 +282,18 @@ export default function DelegatesPage() {
           </tbody>
         </table>
       </div>
+
+      {hasMore && (
+        <div className="mt-6 text-center">
+          <button
+            onClick={loadMore}
+            disabled={loadingMore}
+            className="px-6 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {loadingMore ? "Loading..." : "Load More"}
+          </button>
+        </div>
+      )}
 
       <p className="mt-4 text-xs text-gray-400 text-center">
         Estimated data — depends on network conditions

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -7,7 +7,7 @@
 import { useState, useEffect, useMemo, Suspense } from "react";
 import Link from "next/link";
 import { useSearchParams, useRouter } from "next/navigation";
-import { GovernorClient, ProposalState, Network } from "@nebgov/sdk";
+import { GovernorClient, VotesClient, ProposalState, Network } from "@nebgov/sdk";
 import { ErrorState } from "../components/ErrorState";
 import { ErrorBoundary } from "../components/ErrorBoundary";
 import { ProposalCardSkeleton } from "../components/ui/ProposalCardSkeleton";
@@ -22,6 +22,7 @@ interface ProposalSummary {
   state: ProposalState;
   votesFor: bigint;
   votesAgainst: bigint;
+  votesAbstain: bigint;
   endLedger: number;
 }
 
@@ -66,6 +67,7 @@ function ProposalsPageInner() {
   const [error, setError] = useState<string | null>(null);
   const [nextCursor, setNextCursor] = useState<number | undefined>();
   const [hasMore, setHasMore] = useState(false);
+  const [totalSupply, setTotalSupply] = useState(0n);
 
   const [searchValue, setSearchValue] = useState(search);
   const debouncedSearch = useDebounce(searchValue, 300);
@@ -158,10 +160,17 @@ function ProposalsPageInner() {
           const response = await fetch(url.toString());
           if (response.ok) {
             const data = await response.json();
+            const mapped = (data.proposals ?? []).map((p: any) => ({
+              ...p,
+              votesAbstain: BigInt(p.votesAbstain ?? 0),
+              votesFor: BigInt(p.votesFor ?? 0),
+              votesAgainst: BigInt(p.votesAgainst ?? 0),
+              id: BigInt(p.id),
+            }));
             if (append) {
-              setProposals((prev) => [...prev, ...data.proposals]);
+              setProposals((prev) => [...prev, ...mapped]);
             } else {
-              setProposals(data.proposals);
+              setProposals(mapped);
             }
             setNextCursor(data.nextCursor);
             setHasMore(data.hasMore || false);
@@ -182,6 +191,17 @@ function ProposalsPageInner() {
         network,
         ...(rpcUrl && { rpcUrl }),
       });
+
+      if (!append) {
+        const votesClient = new VotesClient({
+          governorAddress,
+          timelockAddress,
+          votesAddress,
+          network,
+          ...(rpcUrl && { rpcUrl }),
+        });
+        votesClient.getTotalSupply().then(setTotalSupply).catch(() => {});
+      }
 
       const count = await client.proposalCount();
       if (count === 0n) {
@@ -211,6 +231,7 @@ function ProposalsPageInner() {
           state: r.state!,
           votesFor: r.votes!.votesFor,
           votesAgainst: r.votes!.votesAgainst,
+          votesAbstain: r.votes!.votesAbstain,
           endLedger: 0,
         }));
 
@@ -398,40 +419,55 @@ function ProposalsPageInner() {
       {!loading && !error && filtered.length > 0 && (
         <>
           <div className="space-y-4">
-            {filtered.map((p) => (
-              <Link
-                key={p.id.toString()}
-                href={`/proposal/${p.id}`}
-                className="block bg-white border border-gray-200 rounded-xl p-6 hover:border-indigo-300 hover:shadow-sm transition-all"
-              >
-                <div className="flex items-start justify-between">
-                  <div className="flex-1 min-w-0">
-                    <p className="text-xs text-gray-400 mb-1">
-                      Proposal #{p.id.toString()}
-                    </p>
-                    <h2 className="text-lg font-semibold text-gray-900 truncate">
-                      {p.description}
-                    </h2>
-                    <div className="mt-3 flex items-center gap-4 text-sm text-gray-500">
-                      <span>
-                        For: {(Number(p.votesFor) / 1e7).toLocaleString()}
-                      </span>
-                      <span>
-                        Against:{" "}
-                        {(Number(p.votesAgainst) / 1e7).toLocaleString()}
-                      </span>
+            {filtered.map((p) => {
+              const totalVotes = p.votesFor + p.votesAgainst + p.votesAbstain;
+              const participationPct =
+                totalSupply > 0n
+                  ? Number((totalVotes * 10000n) / totalSupply) / 100
+                  : null;
+              return (
+                <Link
+                  key={p.id.toString()}
+                  href={`/proposal/${p.id}`}
+                  className="block bg-white border border-gray-200 rounded-xl p-6 hover:border-indigo-300 hover:shadow-sm transition-all"
+                >
+                  <div className="flex items-start justify-between">
+                    <div className="flex-1 min-w-0">
+                      <p className="text-xs text-gray-400 mb-1">
+                        Proposal #{p.id.toString()}
+                      </p>
+                      <h2 className="text-lg font-semibold text-gray-900 truncate">
+                        {p.description}
+                      </h2>
+                      <div className="mt-3 flex items-center gap-4 text-sm text-gray-500">
+                        <span>
+                          For: {(Number(p.votesFor) / 1e7).toLocaleString()}
+                        </span>
+                        <span>
+                          Against:{" "}
+                          {(Number(p.votesAgainst) / 1e7).toLocaleString()}
+                        </span>
+                        {participationPct !== null && (
+                          <span
+                            className="text-xs text-gray-400"
+                            title="(for + against + abstain) / total supply"
+                          >
+                            {participationPct.toFixed(1)}% participation
+                          </span>
+                        )}
+                      </div>
                     </div>
+                    <span
+                      className={`ml-4 shrink-0 px-3 py-1 rounded-full text-xs font-medium ${STATE_COLORS[p.state]}`}
+                      role="status"
+                      aria-label={`Proposal status: ${p.state}`}
+                    >
+                      <ProposalStateBadge state={p.state} />
+                    </span>
                   </div>
-                  <span
-                    className={`ml-4 shrink-0 px-3 py-1 rounded-full text-xs font-medium ${STATE_COLORS[p.state]}`}
-                    role="status"
-                    aria-label={`Proposal status: ${p.state}`}
-                  >
-                    <ProposalStateBadge state={p.state} />
-                  </span>
-                </div>
-              </Link>
-            ))}
+                </Link>
+              );
+            })}
           </div>
 
           {hasMore && (

--- a/sdk/src/__tests__/factory.test.ts
+++ b/sdk/src/__tests__/factory.test.ts
@@ -6,7 +6,8 @@ var mockGetTransaction = jest.fn();
 
 import { FactoryClient } from "../factory";
 import { xdr } from "@stellar/stellar-sdk";
-import type { FactoryConfig, VoteType } from "../types";
+import type { FactoryConfig } from "../types";
+import { VoteType } from "../types";
 
 jest.mock("@stellar/stellar-sdk", () => {
   const actual = jest.requireActual("@stellar/stellar-sdk");

--- a/sdk/src/__tests__/integration.test.ts
+++ b/sdk/src/__tests__/integration.test.ts
@@ -114,3 +114,114 @@ describeIfConfigured("VotesClient integration (testnet)", () => {
     }
   }, 30_000);
 });
+
+// ─── MultiToken voting strategy integration tests ─────────────────────────────
+//
+// Requires a governor deployed with MultiToken(2 tokens, 5000 BPS each).
+// Set these env vars to run:
+//   MULTI_TOKEN_GOVERNOR_ADDRESS
+//   MULTI_TOKEN_TIMELOCK_ADDRESS
+//   MULTI_TOKEN_VOTES_ADDRESS_1   (first token-votes contract, weight 5000 BPS)
+//   MULTI_TOKEN_VOTES_ADDRESS_2   (second token-votes contract, weight 5000 BPS)
+//
+// The strategy weights sum to 10000 BPS (100%), so each token contributes 50%
+// of the holder's balance to their effective voting power.
+
+const MULTI_TOKEN_GOVERNOR_ADDRESS = process.env.MULTI_TOKEN_GOVERNOR_ADDRESS;
+const MULTI_TOKEN_TIMELOCK_ADDRESS = process.env.MULTI_TOKEN_TIMELOCK_ADDRESS;
+const MULTI_TOKEN_VOTES_ADDRESS_1 = process.env.MULTI_TOKEN_VOTES_ADDRESS_1;
+const MULTI_TOKEN_VOTES_ADDRESS_2 = process.env.MULTI_TOKEN_VOTES_ADDRESS_2;
+
+const hasMultiTokenEnv = Boolean(
+  TESTNET_SECRET_KEY &&
+    MULTI_TOKEN_GOVERNOR_ADDRESS &&
+    MULTI_TOKEN_TIMELOCK_ADDRESS &&
+    MULTI_TOKEN_VOTES_ADDRESS_1 &&
+    MULTI_TOKEN_VOTES_ADDRESS_2,
+);
+
+const describeIfMultiToken = hasMultiTokenEnv ? describe : describe.skip;
+
+describeIfMultiToken("GovernorClient integration — MultiToken voting strategy", () => {
+  let signer: Keypair;
+  let governor: GovernorClient;
+  let votes1: VotesClient;
+  let votes2: VotesClient;
+
+  beforeAll(() => {
+    signer = Keypair.fromSecret(TESTNET_SECRET_KEY as string);
+
+    const baseConfig: GovernorConfig = {
+      governorAddress: MULTI_TOKEN_GOVERNOR_ADDRESS as string,
+      timelockAddress: MULTI_TOKEN_TIMELOCK_ADDRESS as string,
+      votesAddress: MULTI_TOKEN_VOTES_ADDRESS_1 as string,
+      network: "testnet",
+      rpcUrl: TESTNET_RPC_URL,
+      simulationAccount: signer.publicKey(),
+    };
+
+    governor = new GovernorClient(baseConfig);
+
+    votes1 = new VotesClient(baseConfig);
+    votes2 = new VotesClient({
+      ...baseConfig,
+      votesAddress: MULTI_TOKEN_VOTES_ADDRESS_2 as string,
+    });
+  });
+
+  it("getSettings() returns a valid governor settings object", async () => {
+    const settings = await governor.getSettings(signer.publicKey());
+    expect(settings.votingPeriod > 0).toBe(true);
+    expect(settings.quorumNumerator >= 0).toBe(true);
+    expect(settings.proposalThreshold >= 0n).toBe(true);
+    expect(Object.values(VoteType)).toContain(settings.voteType);
+  }, 30_000);
+
+  it("canPropose() uses combined voting power from both tokens", async () => {
+    // Under MultiToken(token1: 5000 BPS, token2: 5000 BPS) the combined
+    // voting power is: floor(token1_votes * 5000 / 10000) + floor(token2_votes * 5000 / 10000)
+    const [token1Votes, token2Votes, canProposeResult] = await Promise.all([
+      votes1.getVotes(signer.publicKey()),
+      votes2.getVotes(signer.publicKey()),
+      governor.canPropose(signer.publicKey()),
+    ]);
+
+    const expectedCombined =
+      (token1Votes * 5000n) / 10000n + (token2Votes * 5000n) / 10000n;
+
+    // The on-chain voting power should match the BPS-weighted sum
+    expect(canProposeResult.votingPower).toEqual(expectedCombined);
+    expect(typeof canProposeResult.allowed).toBe("boolean");
+    expect(canProposeResult.threshold >= 0n).toBe(true);
+  }, 30_000);
+
+  it("proposalCount() returns a non-negative bigint", async () => {
+    const count = await governor.proposalCount();
+    expect(typeof count).toBe("bigint");
+    expect(count >= 0n).toBe(true);
+  }, 30_000);
+
+  it("getProposalVotes() weight reflects BPS scaling when a proposal exists", async () => {
+    const count = await governor.proposalCount();
+    if (count < 1n) {
+      // No proposals yet — skip vote weight check
+      expect(count).toBe(0n);
+      return;
+    }
+
+    const votes = await governor.getProposalVotes(1n);
+    // Votes should be non-negative bigints scaled by BPS weights on-chain
+    expect(typeof votes.votesFor).toBe("bigint");
+    expect(typeof votes.votesAgainst).toBe("bigint");
+    expect(typeof votes.votesAbstain).toBe("bigint");
+    expect(votes.votesFor >= 0n).toBe(true);
+    expect(votes.votesAgainst >= 0n).toBe(true);
+    expect(votes.votesAbstain >= 0n).toBe(true);
+  }, 30_000);
+
+  it("getLatestLedger() returns a valid ledger number", async () => {
+    const ledger = await governor.getLatestLedger();
+    expect(Number.isInteger(ledger)).toBe(true);
+    expect(ledger > 0).toBe(true);
+  }, 30_000);
+});

--- a/sdk/src/__tests__/retry.test.ts
+++ b/sdk/src/__tests__/retry.test.ts
@@ -1,4 +1,5 @@
 import { GovernorClient } from "../governor";
+import { TimelockClient } from "../timelock";
 import { VoteSupport } from "../types";
 
 // Mocking Stellar SDK
@@ -14,19 +15,20 @@ jest.mock("@stellar/stellar-sdk", () => {
   const actual = jest.requireActual("@stellar/stellar-sdk");
   return {
     ...actual,
-    scValToNative: mockScValToNative,
+    scValToNative: (...args: unknown[]) => mockScValToNative(...args),
     SorobanRpc: {
       ...actual.SorobanRpc,
       Server: jest.fn().mockImplementation(() => ({
-        simulateTransaction: mockSimulate,
-        getAccount: mockGetAccount,
-        prepareTransaction: mockPrepareTransaction,
-        sendTransaction: mockSendTransaction,
-        getTransaction: mockGetTransaction,
+        simulateTransaction: (...args: unknown[]) => mockSimulate(...args),
+        getAccount: (...args: unknown[]) => mockGetAccount(...args),
+        prepareTransaction: (...args: unknown[]) => mockPrepareTransaction(...args),
+        sendTransaction: (...args: unknown[]) => mockSendTransaction(...args),
+        getTransaction: (...args: unknown[]) => mockGetTransaction(...args),
         getLatestLedger: jest.fn().mockResolvedValue({ sequence: 123 }),
       })),
       Api: {
-        isSimulationError: mockIsSimulationError,
+        ...actual.SorobanRpc.Api,
+        isSimulationError: (...args: unknown[]) => mockIsSimulationError(...args),
       },
     },
     Contract: jest.fn().mockImplementation((addr) => ({
@@ -42,16 +44,20 @@ jest.mock("@stellar/stellar-sdk", () => {
   };
 });
 
+const VALID_DESC_HASH = "0".repeat(64);
+
 describe("SDK Retry Logic", () => {
   let client: GovernorClient;
   const validCAddr = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
   const validGAddr = "GBFUUXATVOGXGD4KS3I423QFZSPE4ZFOQ3TCJVWFUYSIPULXIRVRE2DT";
+  const mockSigner = { sign: jest.fn(), publicKey: () => validGAddr } as any;
 
   beforeEach(() => {
     jest.clearAllMocks();
     const { Account } = require("@stellar/stellar-sdk");
     mockGetAccount.mockResolvedValue(new Account(validGAddr, "1"));
     mockIsSimulationError.mockReturnValue(false);
+    mockGetTransaction.mockResolvedValue({ status: "SUCCESS", returnValue: {} });
 
     client = new GovernorClient({
       governorAddress: validCAddr,
@@ -59,7 +65,7 @@ describe("SDK Retry Logic", () => {
       votesAddress: validCAddr,
       network: "testnet",
       maxAttempts: 3,
-      baseDelayMs: 1, // Minimize delay for tests
+      baseDelayMs: 1,
     });
   });
 
@@ -73,52 +79,46 @@ describe("SDK Retry Logic", () => {
     mockScValToNative.mockReturnValue(["Active"]);
 
     const state = await client.getProposalState(1n);
-    
+
     expect(mockSimulate).toHaveBeenCalledTimes(3);
     expect(state).toBeDefined();
-  });
+  }, 10_000);
 
   it("should retry submission methods on network error", async () => {
     mockPrepareTransaction
       .mockRejectedValueOnce(new Error("Network timeout"))
       .mockResolvedValue({ sign: jest.fn() });
-    
+
     mockSendTransaction.mockResolvedValue({
       status: "PENDING",
       hash: "tx123",
     });
-    mockGetTransaction.mockResolvedValue({
-      status: "SUCCESS",
-      returnValue: {},
-    });
     mockScValToNative.mockReturnValue(42n);
 
     const id = await client.propose(
-      { sign: jest.fn() } as any,
+      mockSigner,
       "Title",
-      "hash",
+      VALID_DESC_HASH,
       "uri",
       [validCAddr],
       ["fn"],
-      [Buffer.from([])]
+      [Buffer.from([])],
     );
 
     expect(mockPrepareTransaction).toHaveBeenCalledTimes(2);
     expect(id).toBe(42n);
-  });
+  }, 10_000);
 
   it("should NOT retry submission methods on contract error", async () => {
     mockPrepareTransaction.mockResolvedValue({ sign: jest.fn() });
     mockSendTransaction.mockResolvedValue({
       status: "ERROR",
-      error: "Error(Contract, #101)", // SDK/Contract error
+      error: "Error(Contract, #101)",
     });
 
-    await expect(client.castVote(
-      { sign: jest.fn() } as any,
-      1n,
-      VoteSupport.For
-    )).rejects.toThrow();
+    await expect(
+      client.castVote(mockSigner, 1n, VoteSupport.For),
+    ).rejects.toThrow();
 
     // Should only attempt once because it's a contract error, not a network error
     expect(mockSendTransaction).toHaveBeenCalledTimes(1);
@@ -131,11 +131,9 @@ describe("SDK Retry Logic", () => {
       error: "TransactionAlreadyInMempool",
     });
 
-    await expect(client.castVote(
-      { sign: jest.fn() } as any,
-      1n,
-      VoteSupport.For
-    )).rejects.toThrow();
+    await expect(
+      client.castVote(mockSigner, 1n, VoteSupport.For),
+    ).rejects.toThrow();
 
     expect(mockSendTransaction).toHaveBeenCalledTimes(1);
   });
@@ -148,17 +146,69 @@ describe("SDK Retry Logic", () => {
         status: "PENDING",
         hash: "tx123",
       });
-    mockGetTransaction.mockResolvedValue({
-      status: "SUCCESS",
-      returnValue: {},
-    });
 
-    await client.castVote(
-      { sign: jest.fn() } as any,
-      1n,
-      VoteSupport.For
-    );
+    await client.castVote(mockSigner, 1n, VoteSupport.For);
 
     expect(mockSendTransaction).toHaveBeenCalledTimes(2);
+  }, 10_000);
+});
+
+describe("SDK Retry Logic — TimelockClient.execute() 503 recovery", () => {
+  let timelockClient: TimelockClient;
+  const validCAddr = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+  const validGAddr = "GBFUUXATVOGXGD4KS3I423QFZSPE4ZFOQ3TCJVWFUYSIPULXIRVRE2DT";
+  const opId = "a".repeat(64);
+  const mockSigner = { sign: jest.fn(), publicKey: () => validGAddr } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const { Account } = require("@stellar/stellar-sdk");
+    mockGetAccount.mockResolvedValue(new Account(validGAddr, "1"));
+    mockIsSimulationError.mockReturnValue(false);
+    mockGetTransaction.mockResolvedValue({ status: "SUCCESS", returnValue: {} });
+
+    timelockClient = new TimelockClient({
+      governorAddress: validCAddr,
+      timelockAddress: validCAddr,
+      votesAddress: validCAddr,
+      network: "testnet",
+      maxAttempts: 3,
+      baseDelayMs: 1,
+    });
+  });
+
+  it("should retry execute() on 503 and succeed on the next attempt", async () => {
+    mockPrepareTransaction.mockResolvedValue({ sign: jest.fn() });
+    mockSendTransaction
+      .mockRejectedValueOnce(new Error("Service Unavailable 503"))
+      .mockResolvedValue({ status: "PENDING", hash: "txExec1" });
+
+    await timelockClient.execute(mockSigner, opId);
+
+    expect(mockSendTransaction).toHaveBeenCalledTimes(2);
+  }, 10_000);
+
+  it("should respect maxAttempts and stop retrying execute() after exhausting retries", async () => {
+    mockPrepareTransaction.mockResolvedValue({ sign: jest.fn() });
+    mockSendTransaction.mockRejectedValue(new Error("Service Unavailable 503"));
+
+    await expect(
+      timelockClient.execute(mockSigner, opId),
+    ).rejects.toThrow("Service Unavailable 503");
+
+    expect(mockSendTransaction).toHaveBeenCalledTimes(3);
+  });
+
+  it("should surface the final 503 error to the caller after exhausting retries", async () => {
+    mockPrepareTransaction.mockResolvedValue({ sign: jest.fn() });
+    const rpcError = new Error("Service Unavailable 503");
+    mockSendTransaction.mockRejectedValue(rpcError);
+
+    const thrown = await timelockClient
+      .execute(mockSigner, opId)
+      .catch((e) => e);
+
+    expect(thrown).toBe(rpcError);
+    expect(thrown.message).toContain("503");
   });
 });

--- a/sdk/src/governor.ts
+++ b/sdk/src/governor.ts
@@ -1322,21 +1322,20 @@ export class GovernorClient {
             topics: [["VoteCast", "vote"], [voter]],
           },
         ],
-        pagination: {
-          limit: limit * 2, // Fetch extra to filter for relevant events
-        },
+        limit: limit * 2,
       });
 
       const history: VotingHistoryEntry[] = [];
       for (const event of events.events) {
         if (!event.topic || event.topic.length < 2) continue;
-        
+
         // Check if voter matches (second topic)
         const voterTopic = scValToNative(event.topic[1]);
         if (String(voterTopic) !== voter) continue;
 
         // Parse event data
-        const data = event.value?.body?.val;
+        const rawValue = event.value as xdr.ScVal;
+        const data = rawValue ?? null;
         if (!data) continue;
 
         const native = scValToNative(data) as Record<string, unknown>;

--- a/sdk/src/utils.ts
+++ b/sdk/src/utils.ts
@@ -82,11 +82,25 @@ export async function withRetry<T>(
 }
 
 export function isNetworkError(e: unknown): boolean {
-  if (e instanceof TypeError && e.message.toLowerCase().includes("fetch")) {
-    return true;
+  if (e instanceof Error) {
+    const msg = e.message.toLowerCase();
+    if (
+      msg.includes("fetch") ||
+      msg.includes("network") ||
+      msg.includes("timeout") ||
+      msg.includes("aborted") ||
+      msg.includes("connection refused") ||
+      msg.includes("econnrefused") ||
+      msg.includes("500") ||
+      msg.includes("502") ||
+      msg.includes("503") ||
+      msg.includes("504")
+    ) {
+      return true;
+    }
   }
   const status = (e as any)?.response?.status;
-  if (status >= 500 && status < 600) {
+  if (typeof status === "number" && status >= 500 && status < 600) {
     return true;
   }
   return false;

--- a/sdk/src/votes.ts
+++ b/sdk/src/votes.ts
@@ -420,7 +420,8 @@ export class VotesClient {
     }
 
     const options = arg1 ?? {};
-    const limit = Math.max(1, Math.min(options.limit ?? 20, 100));
+    const limit = Math.max(1, Math.min(options.limit ?? 50, 100));
+    const offset = Math.max(0, options.offset ?? 0);
 
     const delegationMap =
       options.delegationMap ??
@@ -449,22 +450,34 @@ export class VotesClient {
       byDelegate.get(delegatee)!.add(delegator);
     }
 
-    // Query current voting power for each unique delegate
+    // Query current voting power in batches to avoid OOM on large delegate sets
     const delegateAddresses = Array.from(byDelegate.keys());
-    const powerEntries = await Promise.all(
-      delegateAddresses.map(async (addr) => {
-        const [votingPower, baseVotes] = await Promise.all([
-          this.getVotes(addr),
-          this.getBaseVotes(addr),
-        ]);
-        return {
-          address: addr,
-          votingPower,
-          baseVotes,
-          delegatorCount: byDelegate.get(addr)!.size,
-        };
-      }),
-    );
+    const POWER_BATCH_SIZE = 20;
+    const powerEntries: Array<{
+      address: string;
+      votingPower: bigint;
+      baseVotes: bigint;
+      delegatorCount: number;
+    }> = [];
+
+    for (let i = 0; i < delegateAddresses.length; i += POWER_BATCH_SIZE) {
+      const batch = delegateAddresses.slice(i, i + POWER_BATCH_SIZE);
+      const batchResults = await Promise.all(
+        batch.map(async (addr) => {
+          const [votingPower, baseVotes] = await Promise.all([
+            this.getVotes(addr),
+            this.getBaseVotes(addr),
+          ]);
+          return {
+            address: addr,
+            votingPower,
+            baseVotes,
+            delegatorCount: byDelegate.get(addr)!.size,
+          };
+        }),
+      );
+      powerEntries.push(...batchResults);
+    }
 
     const delegates = powerEntries
       .filter((d) => d.votingPower > 0n)
@@ -475,7 +488,7 @@ export class VotesClient {
             ? -1
             : 0,
       )
-      .slice(0, limit);
+      .slice(offset, offset + limit);
 
     const result: TopDelegatesResult = {
       delegates,
@@ -964,8 +977,10 @@ export class VotesClient {
 }
 
 export interface TopDelegatesOptions {
-  /** Maximum number of delegates to return (default 20). */
+  /** Maximum number of delegates to return (default 50). */
   limit?: number;
+  /** Number of delegates to skip before returning results (default 0). */
+  offset?: number;
   /** Earliest ledger to scan events from (default latest - DEFAULT_SCAN_WINDOW). */
   fromLedger?: number;
   /** Opaque pagination cursor returned by a prior call. */


### PR DESCRIPTION
## Summary

- **#677**: Replace unbounded `Promise.all()` in `getTopDelegates()` with a batched loop (`POWER_BATCH_SIZE = 20`) to prevent OOM on large delegate sets. Add `offset` pagination parameter and wire up a "Load More" button in the delegates page.
- **#678**: Show vote participation rate `(for + against + abstain) / totalSupply` on each proposal card. Fetches `totalSupply` once on page load via `VotesClient.getTotalSupply()`.
- **#680**: Add three `TimelockClient.execute()` 503 recovery tests in `retry.test.ts`. Extend `isNetworkError()` in `utils.ts` to detect 5xx status codes in error message strings so `sendTransaction` errors are correctly classified as retryable.
- **#681**: Add `describeIfMultiToken` integration test suite in `integration.test.ts` that validates settings, BPS-weighted combined voting power via `canPropose()`, and basic governor queries against a live MultiToken deployment. Gated on `MULTI_TOKEN_GOVERNOR_ADDRESS` env vars.

## Changes

### `sdk/src/votes.ts`
- Added `offset` to `TopDelegatesOptions` interface
- Replaced single `Promise.all()` with batched loop (batch size 20) for power queries
- Changed default limit 20 → 50; `.slice(0, limit)` → `.slice(offset, offset + limit)`

### `sdk/src/utils.ts`
- Extended `isNetworkError()` to match `"500"`, `"502"`, `"503"`, `"504"` substrings in error messages

### `sdk/src/__tests__/retry.test.ts`
- Added `TimelockClient` describe block with 3 executor-503 recovery tests
- Fixed `jest.mock` factory to use wrapper arrow functions (ts-jest hoisting fix)

### `sdk/src/__tests__/integration.test.ts`
- Added `describeIfMultiToken` suite with 4 integration tests for MultiToken strategy

### `sdk/src/governor.ts`
- Fixed pre-existing TS error: removed invalid `pagination` field from `GetEventsRequest`
- Fixed pre-existing TS error: corrected `ScVal` body access pattern

### `sdk/src/__tests__/factory.test.ts`
- Fixed pre-existing compile error: split `import type { VoteType }` → value import

### `app/src/app/page.tsx`
- Added `votesAbstain` to `ProposalSummary`, fetch `totalSupply`, render participation badge

### `app/src/app/delegates/page.tsx`
- Added offset-based pagination state and "Load More" button

## Test plan

- [ ] `pnpm --filter @nebgov/sdk exec jest src/__tests__/retry.test.ts` — all 8 tests pass
- [ ] `pnpm --filter @nebgov/sdk exec jest src/__tests__/utils.test.ts` — all pass
- [ ] `pnpm --filter @nebgov/sdk exec jest src/__tests__/timelock.test.ts` — all pass
- [ ] Set `MULTI_TOKEN_GOVERNOR_ADDRESS` etc. env vars and run `integration.test.ts` against testnet
- [ ] Load `/` — proposals show "X% participation" badge
- [ ] Load `/delegates` — "Load More" appends next 20 delegates

Closes #677 
Closes #678 
Closes #680 
Closes #681