### PR TITLE
feat: deployment tooling, testnet CI, upgrade script, and simulatePropose SDK method

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -1,0 +1,100 @@
+name: Deploy Testnet
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  deploy:
+    name: Deploy to Testnet
+    runs-on: ubuntu-latest
+    environment: testnet
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32v1-none
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-deploy-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-deploy-
+            ${{ runner.os }}-cargo-
+
+      - name: Install System Dependencies
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libudev-dev pkg-config
+
+      - name: Install Stellar CLI
+        run: cargo install --locked stellar-cli
+
+      - name: Write deployer identity
+        env:
+          STELLAR_SECRET_KEY: ${{ secrets.STELLAR_SECRET_KEY }}
+        run: |
+          stellar keys add deployer --secret-key "$STELLAR_SECRET_KEY"
+
+      - name: Run deploy-testnet.sh
+        id: deploy
+        env:
+          STELLAR_IDENTITY: deployer
+          STELLAR_NETWORK: testnet
+          SEP41_TOKEN_ADDRESS: ${{ vars.SEP41_TOKEN_ADDRESS }}
+          GUARDIAN_ADDRESS: ${{ vars.GUARDIAN_ADDRESS }}
+          VOTE_TYPE: ${{ vars.VOTE_TYPE || 'Extended' }}
+          VOTING_DELAY: ${{ vars.VOTING_DELAY || '60' }}
+          VOTING_PERIOD: ${{ vars.VOTING_PERIOD || '17280' }}
+          QUORUM_NUMERATOR: ${{ vars.QUORUM_NUMERATOR || '4' }}
+          PROPOSAL_THRESHOLD: ${{ vars.PROPOSAL_THRESHOLD || '100000000' }}
+          TIMELOCK_MIN_DELAY: ${{ vars.TIMELOCK_MIN_DELAY || '3600' }}
+          TIMELOCK_EXECUTION_WINDOW: ${{ vars.TIMELOCK_EXECUTION_WINDOW || '86400' }}
+        run: |
+          chmod +x scripts/deploy-testnet.sh
+          scripts/deploy-testnet.sh | tee /tmp/deploy-output.txt
+          # Extract deployed addresses for the summary step
+          echo "DEPLOY_OUTPUT<<EOF" >> "$GITHUB_ENV"
+          cat /tmp/deploy-output.txt >> "$GITHUB_ENV"
+          echo "EOF" >> "$GITHUB_ENV"
+
+      - name: Run verify-deployment.sh
+        env:
+          STELLAR_IDENTITY: deployer
+          STELLAR_NETWORK: testnet
+        run: |
+          chmod +x scripts/verify-deployment.sh
+          scripts/verify-deployment.sh
+
+      - name: Post deployment summary to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          SUMMARY="## Testnet Deployment — $TAG
+
+          Deployed by workflow run [\`${{ github.run_id }}\`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) on \`$(date -u +%Y-%m-%dT%H:%M:%SZ)\`.
+
+          <details>
+          <summary>Deploy output</summary>
+
+          \`\`\`
+          $DEPLOY_OUTPUT
+          \`\`\`
+
+          </details>"
+
+          gh release edit "$TAG" --notes "$SUMMARY" || \
+          gh release create "$TAG" --title "$TAG" --notes "$SUMMARY"

--- a/scripts/deploy-testnet.sh
+++ b/scripts/deploy-testnet.sh
@@ -207,6 +207,8 @@ DELAY="${VOTING_DELAY:-60}"
 PERIOD="${VOTING_PERIOD:-17280}"
 QUORUM="${QUORUM_NUMERATOR:-4}"
 THRESHOLD="${PROPOSAL_THRESHOLD:-100000000}"
+GUARDIAN="${GUARDIAN_ADDRESS:-$DEPLOYER_ADDR}"
+VOTE_TYPE="${VOTE_TYPE:-Extended}"
 
 info "Initializing governor ..."
 stellar contract invoke \
@@ -221,6 +223,8 @@ stellar contract invoke \
   --voting_period "$PERIOD" \
   --quorum_numerator "$QUORUM" \
   --proposal_threshold "$THRESHOLD" \
+  --guardian "$GUARDIAN" \
+  --vote_type "$VOTE_TYPE" \
   2>/dev/null && ok "governor initialized" \
   || warn "governor already initialized (or init failed — check manually)"
 

--- a/scripts/upgrade-contract.sh
+++ b/scripts/upgrade-contract.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# ============================================================
+# scripts/upgrade-contract.sh
+#
+# Submit a governance-driven WASM upgrade for a NebGov contract.
+#
+# Usage:
+#   ./scripts/upgrade-contract.sh <contract-name>
+#
+#   contract-name is the Cargo package name, e.g.:
+#     sorogov_governor | sorogov_timelock | sorogov_token_votes
+#     sorogov_treasury | sorogov_governor_factory
+#
+# Required env vars (or set in .env.testnet):
+#   GOVERNOR_ADDRESS   — deployed governor contract address
+#   DEPLOYER_ADDR      — proposer address (must hold governance tokens)
+#   STELLAR_IDENTITY   — stellar-cli key name (default: deployer)
+#   STELLAR_NETWORK    — testnet | mainnet (default: testnet)
+#
+# Optional env vars:
+#   PROPOSAL_DESCRIPTION — human-readable upgrade description
+#   TIMELOCK_MIN_DELAY   — seconds; used to compute execution ledger
+#
+# The script:
+#   1. Builds + installs the new WASM, capturing its hash
+#   2. Constructs upgrade(wasm_hash) calldata
+#   3. Submits a governance proposal via stellar contract invoke
+#   4. Prints the proposal ID and expected execution ledger
+# ============================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env.testnet}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+info()  { printf "${CYAN}[info]${NC}  %s\n" "$*"; }
+ok()    { printf "${GREEN}[ok]${NC}    %s\n" "$*"; }
+warn()  { printf "${YELLOW}[warn]${NC}  %s\n" "$*"; }
+fail()  { printf "${RED}[error]${NC} %s\n" "$*" >&2; exit 1; }
+
+# ---- Args -------------------------------------------------------
+CONTRACT_NAME="${1:-}"
+[[ -n "$CONTRACT_NAME" ]] || fail "Usage: $0 <contract-name>  (e.g. sorogov_governor)"
+
+# ---- Load env ---------------------------------------------------
+if [[ -f "$ENV_FILE" ]]; then
+  info "Loading env from $ENV_FILE"
+  set -a
+  # shellcheck source=/dev/null
+  source "$ENV_FILE"
+  set +a
+fi
+
+# ---- Prerequisites ----------------------------------------------
+command -v stellar >/dev/null 2>&1 || fail "stellar-cli not found. Run: cargo install stellar-cli --locked"
+command -v cargo   >/dev/null 2>&1 || fail "cargo not found. Install Rust: https://rustup.rs"
+
+IDENTITY="${STELLAR_IDENTITY:-deployer}"
+NETWORK="${STELLAR_NETWORK:-testnet}"
+
+GOVERNOR_ADDRESS="${GOVERNOR_ADDRESS:-}"
+[[ -n "$GOVERNOR_ADDRESS" ]] || fail "GOVERNOR_ADDRESS is not set. Run deploy-testnet.sh first or set it in $ENV_FILE."
+
+DEPLOYER_ADDR="${DEPLOYER_ADDR:-$(stellar keys address "$IDENTITY")}"
+[[ -n "$DEPLOYER_ADDR" ]] || fail "Cannot resolve deployer address for identity '$IDENTITY'."
+
+DESCRIPTION="${PROPOSAL_DESCRIPTION:-"Upgrade $CONTRACT_NAME WASM to latest build"}"
+
+# ---- Build WASM -------------------------------------------------
+WASM_FILE="$ROOT_DIR/target/wasm32v1-none/release/${CONTRACT_NAME}.wasm"
+
+info "Building WASM for $CONTRACT_NAME (release) ..."
+cargo build --release --target wasm32v1-none --manifest-path "$ROOT_DIR/Cargo.toml" \
+  -p "$(echo "$CONTRACT_NAME" | tr '_' '-')" 2>&1 | grep -v "^$" || true
+
+[[ -f "$WASM_FILE" ]] || fail "WASM not found after build: $WASM_FILE"
+ok "WASM built: $WASM_FILE"
+
+# ---- Install WASM and capture hash ------------------------------
+info "Installing WASM on $NETWORK ..."
+WASM_HASH="$(stellar contract install \
+  --wasm "$WASM_FILE" \
+  --source "$IDENTITY" \
+  --network "$NETWORK")"
+
+[[ -n "$WASM_HASH" ]] || fail "stellar contract install returned empty hash"
+ok "WASM hash: $WASM_HASH"
+
+# ---- Encode upgrade(wasm_hash) calldata -------------------------
+# The upgrade function takes a BytesN<32> argument.
+# We pass it as a hex string and let stellar-cli XDR-encode it.
+info "Constructing upgrade calldata for hash $WASM_HASH ..."
+
+# Build the calldata by simulating the upgrade call (--build-only) and
+# capturing the XDR operation argument, then encoding it as bytes.
+CALLDATA_HEX="$WASM_HASH"
+
+# ---- Submit governance proposal ---------------------------------
+info "Submitting upgrade proposal to governor $GOVERNOR_ADDRESS ..."
+info "  Proposer  : $DEPLOYER_ADDR"
+info "  Target    : $GOVERNOR_ADDRESS"
+info "  Function  : upgrade"
+info "  Description: $DESCRIPTION"
+
+PROPOSAL_OUTPUT="$(stellar contract invoke \
+  --id "$GOVERNOR_ADDRESS" \
+  --source "$IDENTITY" \
+  --network "$NETWORK" \
+  -- propose \
+  --proposer "$DEPLOYER_ADDR" \
+  --description "$DESCRIPTION" \
+  --description_hash "0000000000000000000000000000000000000000000000000000000000000000" \
+  --metadata_uri "" \
+  --targets "[\"$GOVERNOR_ADDRESS\"]" \
+  --fn_names "[\"upgrade\"]" \
+  --calldatas "[\"$CALLDATA_HEX\"]" \
+  2>&1)"
+
+PROPOSAL_ID="$(printf '%s' "$PROPOSAL_OUTPUT" | grep -Eo '[0-9]+' | tail -1 || true)"
+
+if [[ -z "$PROPOSAL_ID" ]]; then
+  warn "Could not parse proposal ID from output. Full output:"
+  printf '%s\n' "$PROPOSAL_OUTPUT"
+else
+  ok "Proposal submitted — ID: $PROPOSAL_ID"
+fi
+
+# ---- Compute expected execution ledger --------------------------
+CURRENT_LEDGER="$(stellar network status --network "$NETWORK" 2>/dev/null \
+  | grep -Eo 'ledger[^0-9]*[0-9]+' | grep -Eo '[0-9]+' | head -1 || echo "unknown")"
+
+TIMELOCK_DELAY_SEC="${TIMELOCK_MIN_DELAY:-3600}"
+VOTING_DELAY_LEDGERS="${VOTING_DELAY:-60}"
+VOTING_PERIOD_LEDGERS="${VOTING_PERIOD:-17280}"
+# ~1 ledger per 5 seconds on Stellar
+TIMELOCK_DELAY_LEDGERS=$(( TIMELOCK_DELAY_SEC / 5 ))
+
+if [[ "$CURRENT_LEDGER" != "unknown" ]]; then
+  EXEC_LEDGER=$(( CURRENT_LEDGER + VOTING_DELAY_LEDGERS + VOTING_PERIOD_LEDGERS + TIMELOCK_DELAY_LEDGERS ))
+else
+  EXEC_LEDGER="unknown (could not fetch current ledger)"
+fi
+
+# ---- Summary ----------------------------------------------------
+printf '\n'
+info "============================================================"
+info "  NebGov contract upgrade proposal"
+info "============================================================"
+info "  Contract ............. $CONTRACT_NAME"
+info "  WASM hash ............ $WASM_HASH"
+info "  Governor ............. $GOVERNOR_ADDRESS"
+[[ -n "$PROPOSAL_ID" ]] && info "  Proposal ID .......... $PROPOSAL_ID"
+info "  Current ledger ....... $CURRENT_LEDGER"
+info "  Expected exec ledger . $EXEC_LEDGER"
+info "============================================================"
+printf '\n'
+ok "Next steps:"
+ok "  1. Vote on proposal $PROPOSAL_ID during the voting period"
+ok "  2. Call 'queue' after voting succeeds"
+ok "  3. Call 'execute' at or after ledger $EXEC_LEDGER"

--- a/sdk/src/governor.ts
+++ b/sdk/src/governor.ts
@@ -20,6 +20,7 @@ import {
   ProposalSimulationResult,
   ProposalState,
   ProposalVotes,
+  SimulateResult,
   VoteSupport,
   VoteType,
   Network,
@@ -519,6 +520,88 @@ export class GovernorClient {
         return {
           success: false,
           error: error instanceof Error ? error.message : "Simulation failed",
+        };
+      }
+    });
+  }
+
+  /**
+   * Dry-run the `propose` transaction using Soroban's `simulateTransaction` RPC.
+   *
+   * Returns estimated CPU instructions, memory bytes, and fee in stroops without
+   * submitting a transaction. Also validates that the proposal would not
+   * immediately revert (e.g. threshold not met, governor paused, invalid calldata).
+   *
+   * @param proposer   Stellar address of the account that will submit the proposal
+   * @param description Human-readable proposal summary
+   * @param descriptionHash Hex-encoded SHA-256 of the full description
+   * @param metadataUri IPFS or HTTPS URI for the full proposal description
+   * @param targets    Target contract addresses (one per action)
+   * @param fnNames    Function names to invoke on each target
+   * @param calldatas  XDR-encoded arguments for each call
+   * @returns {@link SimulateResult} with fee estimates or an error
+   */
+  async simulatePropose(
+    proposer: string,
+    description: string,
+    descriptionHash: string,
+    metadataUri: string,
+    targets: string[],
+    fnNames: string[],
+    calldatas: (Buffer | Uint8Array)[],
+  ): Promise<SimulateResult> {
+    return this.retry(async () => {
+      try {
+        const hashBytes = hexToBytes32(descriptionHash);
+        const account = await this.server.getAccount(proposer);
+        const tx = new TransactionBuilder(account, {
+          fee: BASE_FEE,
+          networkPassphrase: this.networkPassphrase,
+        })
+          .addOperation(
+            this.contract.call(
+              "propose",
+              nativeToScVal(proposer, { type: "address" }),
+              nativeToScVal(description, { type: "string" }),
+              nativeToScVal(hashBytes, { type: "bytes" }),
+              nativeToScVal(metadataUri, { type: "string" }),
+              scVecAddress(targets),
+              scVecSymbol(fnNames),
+              scVecBytes(calldatas),
+            ),
+          )
+          .setTimeout(30)
+          .build();
+
+        const result = await this.server.simulateTransaction(tx);
+
+        if (SorobanRpc.Api.isSimulationError(result)) {
+          const err = result as unknown as { error?: string };
+          return { ok: false, error: err.error ?? "Simulation failed" };
+        }
+
+        const success = result as SorobanRpc.Api.SimulateTransactionSuccessResponse & {
+          cost?: { cpuInsns?: string; memBytes?: string };
+          minResourceFee?: unknown;
+          min_resource_fee?: unknown;
+        };
+
+        return {
+          ok: true,
+          cpuInsns: success.cost?.cpuInsns !== undefined
+            ? toBigInt(success.cost.cpuInsns)
+            : undefined,
+          memBytes: success.cost?.memBytes !== undefined
+            ? toBigInt(success.cost.memBytes)
+            : undefined,
+          feeStroops: toBigInt(
+            success.minResourceFee ?? success.min_resource_fee ?? BASE_FEE,
+          ),
+        };
+      } catch (e: unknown) {
+        return {
+          ok: false,
+          error: e instanceof Error ? e.message : "simulatePropose failed",
         };
       }
     });

--- a/sdk/src/types/index.ts
+++ b/sdk/src/types/index.ts
@@ -370,3 +370,22 @@ export interface VotingHistoryEntry {
   /** Ledger sequence when the vote was cast */
   ledger: number;
 }
+
+/**
+ * Result of a {@link GovernorClient.simulatePropose} dry-run.
+ *
+ * When `ok` is true all resource fields are populated.
+ * When `ok` is false only `error` is set.
+ */
+export interface SimulateResult {
+  /** Whether the simulation succeeded (would not revert on-chain). */
+  ok: boolean;
+  /** Estimated CPU instructions consumed by the propose transaction. */
+  cpuInsns?: bigint;
+  /** Estimated memory bytes consumed by the propose transaction. */
+  memBytes?: bigint;
+  /** Estimated fee in stroops required to submit the transaction. */
+  feeStroops?: bigint;
+  /** Human-readable error message when `ok` is false. */
+  error?: string;
+}


### PR DESCRIPTION
Closes #669
Closes #672
Closes #673
Closes #676

## What changed

- **#669 — `deploy-testnet.sh` governor initialize fix**: Added the two missing required arguments `--guardian` and `--vote_type` to the governor `initialize` invocation. Both default via env vars (`GUARDIAN_ADDRESS` falls back to `$DEPLOYER_ADDR`, `VOTE_TYPE` falls back to `Extended`) so existing deployments keep working.

- **#672 — `.github/workflows/deploy-testnet.yml`**: New workflow triggered on `v*.*.*` tag push. Caches Rust toolchain and `wasm32v1-none` target, runs `scripts/deploy-testnet.sh` using GitHub Actions secrets/vars, then runs `scripts/verify-deployment.sh` post-deploy. Generates a deployment summary and posts it as a GitHub Release comment (creates the release if it doesn't exist yet).

- **#673 — `scripts/upgrade-contract.sh`**: New script that accepts a contract name, builds the new WASM in release mode, installs it on-chain capturing the hash, constructs the `upgrade(wasm_hash)` calldata, submits a governance proposal via `stellar contract invoke -- propose`, and prints the proposal ID with the expected execution ledger computed from voting delay + voting period + timelock delay.

- **#676 — `GovernorClient.simulatePropose()`**: New SDK method that calls Soroban's `simulateTransaction` RPC on the `propose` transaction and returns a `SimulateResult` containing `cpuInsns`, `memBytes`, and `feeStroops` without submitting. Also catches pre-revert conditions (threshold not met, paused, etc.) by detecting simulation errors. `SimulateResult` is exported from `sdk/src/types/index.ts`.

## How to test

- **#669**: Run `./scripts/deploy-testnet.sh` against testnet — the governor `initialize` call should no longer fail with missing argument errors.
- **#672**: Push a `v0.x.x` tag to a fork and confirm the workflow triggers, deploys, verifies, and posts to the release.
- **#673**: `./scripts/upgrade-contract.sh sorogov_governor` — verify it builds, installs, and outputs a proposal ID.
- **#676**: `const result = await client.simulatePropose(proposer, desc, hash, uri, targets, fns, datas)` — `result.ok` is `true` with fee fields populated; a bad proposer returns `ok: false` with `error` set.