### PR TITLE
fix: wasm32v1-none check, liquidity deploy, competition end-date, ver…

### DIFF
--- a/backend/src/__tests__/competitions.test.ts
+++ b/backend/src/__tests__/competitions.test.ts
@@ -83,6 +83,34 @@ describe("Competition Endpoints", () => {
 
       expect(response.body.error).toBe("Competition not found");
     });
+
+    it("should fail when competition has ended", async () => {
+      const expiredResult = await pool.query(
+        `INSERT INTO competitions (name, description, entry_fee, start_date, end_date, is_active, created_by)
+         VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id`,
+        [
+          "Expired Competition",
+          null,
+          0,
+          new Date(Date.now() - 172800000),
+          new Date(Date.now() - 86400000),
+          true,
+          userId,
+        ],
+      );
+      const expiredId = expiredResult.rows[0].id;
+
+      try {
+        const response = await request(app)
+          .post(`/competitions/${expiredId}/join`)
+          .set("Authorization", `Bearer ${authToken}`)
+          .expect(400);
+
+        expect(response.body.error).toBe("Competition has ended");
+      } finally {
+        await pool.query("DELETE FROM competitions WHERE id = $1", [expiredId]);
+      }
+    });
   });
 
   describe("DELETE /competitions/:id/leave", () => {

--- a/backend/src/routes/competitions.ts
+++ b/backend/src/routes/competitions.ts
@@ -276,6 +276,11 @@ router.post(
         return res.status(400).json({ error: "Competition is not active" });
       }
 
+      if (new Date() > new Date(competition.end_date)) {
+        await client.query("ROLLBACK");
+        return res.status(400).json({ error: "Competition has ended" });
+      }
+
       if (new Date() >= new Date(competition.start_date)) {
         await client.query("ROLLBACK");
         return res

--- a/scripts/deploy-testnet.sh
+++ b/scripts/deploy-testnet.sh
@@ -98,12 +98,18 @@ fi
 # ---- Build WASM contracts -------------------------------------------
 WASM_DIR="$ROOT_DIR/target/wasm32v1-none/release"
 
+# Ensure the target is installed so the build doesn't fail with a cryptic error
+if ! rustup target list --installed | grep -q 'wasm32v1-none'; then
+  info "Installing wasm32v1-none target..."
+  rustup target add wasm32v1-none
+fi
+
 info "Building WASM contracts (release) ..."
 cargo build --release --target wasm32v1-none --manifest-path "$ROOT_DIR/Cargo.toml" --workspace
 ok "WASM build complete"
 
 # Verify expected artefacts exist
-for wasm in sorogov_token_votes sorogov_timelock sorogov_governor sorogov_treasury sorogov_governor_factory; do
+for wasm in sorogov_token_votes sorogov_timelock sorogov_governor sorogov_treasury sorogov_governor_factory sorogov_liquidity; do
   [[ -f "$WASM_DIR/${wasm}.wasm" ]] || fail "Expected WASM not found: $WASM_DIR/${wasm}.wasm"
 done
 
@@ -160,6 +166,9 @@ deploy_contract "$WASM_DIR/sorogov_treasury.wasm" "TREASURY_ADDRESS"
 
 # 5. Factory
 deploy_contract "$WASM_DIR/sorogov_governor_factory.wasm" "FACTORY_ADDRESS"
+
+# 6. Liquidity
+deploy_contract "$WASM_DIR/sorogov_liquidity.wasm" "LIQUIDITY_ADDRESS"
 
 # ====================================================================
 # Initialize contracts (idempotent — each checks storage internally)
@@ -270,6 +279,17 @@ stellar contract invoke \
   2>/dev/null && ok "factory initialized" \
   || warn "factory already initialized (or init failed — check manually)"
 
+# -- Initialize liquidity ----------------------------------------------
+info "Initializing liquidity ..."
+stellar contract invoke \
+  --id "$LIQUIDITY_ADDRESS" \
+  --source "$IDENTITY" \
+  --network "$NETWORK" \
+  -- initialize \
+  --governor "$DEPLOYER_ADDR" \
+  2>/dev/null && ok "liquidity initialized" \
+  || warn "liquidity already initialized (or init failed — check manually)"
+
 # ====================================================================
 # Summary
 # ====================================================================
@@ -285,6 +305,7 @@ info "  Timelock Exec Window . $TIMELOCK_WINDOW seconds"
 info "  Governor ............. $GOVERNOR_ADDRESS"
 info "  Treasury ............. $TREASURY_ADDRESS"
 info "  Factory .............. $FACTORY_ADDRESS"
+info "  Liquidity ............ $LIQUIDITY_ADDRESS"
 info "  Env file ............. $ENV_FILE"
 info "============================================================"
 printf '\n'

--- a/scripts/verify-deployment.sh
+++ b/scripts/verify-deployment.sh
@@ -2,14 +2,15 @@
 # ============================================================
 # scripts/verify-deployment.sh
 #
-# Verify that all NebGov contracts are deployed and initialized
-# correctly on the configured Stellar network.
+# Post-deploy validation: queries each contract's on-chain
+# settings and compares them against expected values from
+# the env file. Exits non-zero if any check fails (CI-safe).
 #
 # Usage:
 #   ./scripts/verify-deployment.sh              # uses .env.testnet
 #   ENV_FILE=.env.custom ./scripts/verify-deployment.sh
 # ============================================================
-set -euo pipefail
+set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -17,62 +18,97 @@ ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env.testnet}"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
 NC='\033[0m'
 
-info()  { printf "${CYAN}[info]${NC}  %s\n" "$*"; }
-ok()    { printf "${GREEN}[ok]${NC}    %s\n" "$*"; }
-warn()  { printf "${YELLOW}[warn]${NC}  %s\n" "$*"; }
-fail()  { printf "${RED}[error]${NC} %s\n" "$*" >&2; exit 1; }
+FAILURES=0
 
-if [[ ! -f "$ENV_FILE" ]]; then
-  fail "Env file not found: $ENV_FILE"
-fi
+pass()  { printf "${GREEN}[✓]${NC} %s\n" "$*"; }
+fail()  { printf "${RED}[✗]${NC} %s\n" "$*" >&2; FAILURES=$((FAILURES + 1)); }
+info()  { printf "${CYAN}[info]${NC}  %s\n" "$*"; }
+
+[[ -f "$ENV_FILE" ]] || { printf "${RED}[error]${NC} Env file not found: %s\n" "$ENV_FILE" >&2; exit 1; }
 
 set -a
+# shellcheck source=/dev/null
 source "$ENV_FILE"
 set +a
 
-command -v stellar >/dev/null 2>&1 || fail "stellar-cli not found"
+command -v stellar >/dev/null 2>&1 || { printf "${RED}[error]${NC} stellar-cli not found\n" >&2; exit 1; }
 
-IDENTITY="${STELLAR_IDENTITY:-deployer}"
 NETWORK="${STELLAR_NETWORK:-testnet}"
+IDENTITY="${STELLAR_IDENTITY:-deployer}"
 
-CONTRACTS=(
-  "TOKEN_VOTES_ADDRESS:Token-Votes"
-  "TIMELOCK_ADDRESS:Timelock"
-  "GOVERNOR_ADDRESS:Governor"
-  "TREASURY_ADDRESS:Treasury"
-  "FACTORY_ADDRESS:Factory"
-)
+# Call a contract getter; returns "ERROR" if the invocation fails.
+query() {
+  stellar contract invoke \
+    --id "$1" \
+    --source "$IDENTITY" \
+    --network "$NETWORK" \
+    -- "$2" 2>/dev/null || echo "ERROR"
+}
 
-all_ok=true
-
-for entry in "${CONTRACTS[@]}"; do
-  var="${entry%%:*}"
-  name="${entry##*:}"
-  addr="${!var:-}"
-
-  if [[ -z "$addr" ]]; then
-    warn "$name: $var not set in env"
-    all_ok=false
-    continue
-  fi
-
-  result=$(stellar contract id --id "$addr" --network "$NETWORK" 2>/dev/null || true)
-  if [[ -n "$result" ]]; then
-    ok "$name: $addr"
+# Assert got == expected and print a labelled result.
+check() {
+  local label="$1" got="$2" expected="$3"
+  if [[ "$got" == "$expected" ]]; then
+    pass "$label: $got"
   else
-    fail "$name: $addr not found on $NETWORK"
-    all_ok=false
+    fail "$label: got '$got', expected '$expected'"
   fi
-done
+}
 
-info "Identity: $(stellar keys address "$IDENTITY" 2>/dev/null || echo 'not found')"
+DEPLOYER_ADDR="${DEPLOYER_ADDR:-$(stellar keys address "${IDENTITY}" 2>/dev/null || echo '')}"
 
-if $all_ok; then
-  ok "All contracts verified successfully."
+info "Verifying NebGov deployment against $ENV_FILE"
+printf '\n'
+
+# ---- TokenVotes --------------------------------------------------------
+info "TokenVotes (${TOKEN_VOTES_ADDRESS:-<not set>})"
+check "  token_votes.admin" \
+  "$(query "${TOKEN_VOTES_ADDRESS:-}" admin)" \
+  "\"${DEPLOYER_ADDR}\""
+
+# ---- Timelock ----------------------------------------------------------
+info "Timelock (${TIMELOCK_ADDRESS:-<not set>})"
+check "  timelock.min_delay" \
+  "$(query "${TIMELOCK_ADDRESS:-}" min_delay)" \
+  "${TIMELOCK_MIN_DELAY:-3600}"
+check "  timelock.execution_window" \
+  "$(query "${TIMELOCK_ADDRESS:-}" execution_window)" \
+  "${TIMELOCK_EXECUTION_WINDOW:-86400}"
+
+# ---- Governor ----------------------------------------------------------
+info "Governor (${GOVERNOR_ADDRESS:-<not set>})"
+check "  governor.voting_delay" \
+  "$(query "${GOVERNOR_ADDRESS:-}" voting_delay)" \
+  "${VOTING_DELAY:-60}"
+check "  governor.voting_period" \
+  "$(query "${GOVERNOR_ADDRESS:-}" voting_period)" \
+  "${VOTING_PERIOD:-17280}"
+check "  governor.quorum_numerator" \
+  "$(query "${GOVERNOR_ADDRESS:-}" quorum_numerator)" \
+  "${QUORUM_NUMERATOR:-4}"
+check "  governor.proposal_threshold" \
+  "$(query "${GOVERNOR_ADDRESS:-}" proposal_threshold)" \
+  "${PROPOSAL_THRESHOLD:-100000000}"
+
+# ---- Treasury ----------------------------------------------------------
+info "Treasury (${TREASURY_ADDRESS:-<not set>})"
+check "  treasury.threshold" \
+  "$(query "${TREASURY_ADDRESS:-}" threshold)" \
+  "${TREASURY_THRESHOLD:-1}"
+
+# ---- Liquidity ---------------------------------------------------------
+info "Liquidity (${LIQUIDITY_ADDRESS:-<not set>})"
+check "  liquidity.governor" \
+  "$(query "${LIQUIDITY_ADDRESS:-}" governor)" \
+  "\"${DEPLOYER_ADDR}\""
+
+printf '\n'
+if [[ "$FAILURES" -gt 0 ]]; then
+  printf "${RED}%d check(s) failed.${NC}\n" "$FAILURES" >&2
+  exit 1
 else
-  fail "Some contracts failed verification."
+  printf "${GREEN}All checks passed.${NC}\n"
 fi


### PR DESCRIPTION
…ify script

- Closes #670 : check and auto-install wasm32v1-none target before cargo build
- Closes #667 : deploy and initialize sorogov_liquidity in deploy-testnet.sh; add LIQUIDITY_ADDRESS to summary
- Closes #668 : reject join if end_date has passed; add expired-competition test
- Closes #671 : replace stub verify-deployment.sh with full settings validation; exits 1 on failure