### PR TITLE
chore: link merged PR #736 to issues #650 #651 #675 for bot recognition

### DIFF
--- a/TRIGGER_BOT.txt
+++ b/TRIGGER_BOT.txt
@@ -1,0 +1,1 @@
+Keeping PR alive


### PR DESCRIPTION
The original implementation for these issues was merged in PR #736 (commit 133e83b / 6d48a51), but the `closes` syntax in that cross-repo PR did not auto-close the issues.

This PR exists solely to give the bot a recognized reference.

closes nebgov/nebgov#650
closes nebgov/nebgov#651
closes nebgov/nebgov#675