### PR TITLE
fix: resolve #625, #629, #634, #635

### DIFF
--- a/contracts/liquidity/src/lib.rs
+++ b/contracts/liquidity/src/lib.rs
@@ -294,6 +294,15 @@ impl LiquidityContract {
         let amount_a = (lp_tokens * pool.reserve_a) / pool.total_lp_supply;
         let amount_b = (lp_tokens * pool.reserve_b) / pool.total_lp_supply;
 
+        // Ensure post-removal reserves don't drop below MIN_LIQUIDITY unless fully drained
+        let remaining_a = pool.reserve_a - amount_a;
+        let remaining_b = pool.reserve_b - amount_b;
+        if (remaining_a > 0 && remaining_a < MIN_LIQUIDITY)
+            || (remaining_b > 0 && remaining_b < MIN_LIQUIDITY)
+        {
+            panic!("below minimum liquidity");
+        }
+
         // Effects
         pool.reserve_a -= amount_a;
         pool.reserve_b -= amount_b;

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -7,6 +7,7 @@ use soroban_sdk::{
 };
 
 const DEFAULT_PENDING_EXPIRY_LEDGERS: u32 = 17_280;
+const TX_STORAGE_TTL_LEDGERS: u32 = 518_400;
 
 /// Treasury error codes.
 #[contracterror]
@@ -236,6 +237,11 @@ impl TreasuryContract {
         };
 
         env.storage().persistent().set(&DataKey::Tx(id), &tx);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Tx(id),
+            TX_STORAGE_TTL_LEDGERS,
+            TX_STORAGE_TTL_LEDGERS,
+        );
         env.storage().instance().set(&DataKey::TxCount, &id);
         env.events().publish((symbol_short!("submit"),), id);
 
@@ -359,6 +365,11 @@ impl TreasuryContract {
             // State-first: commit executed before making any external call.
             tx.executed = true;
             env.storage().persistent().set(&DataKey::Tx(tx_id), &tx);
+            env.storage().persistent().extend_ttl(
+                &DataKey::Tx(tx_id),
+                TX_STORAGE_TTL_LEDGERS,
+                TX_STORAGE_TTL_LEDGERS,
+            );
 
             // Lock execution path to reject reentrant approve/cancel/submit.
             env.storage().instance().set(&DataKey::IsExecuting, &true);
@@ -368,6 +379,11 @@ impl TreasuryContract {
             env.events().publish((symbol_short!("execute"),), tx_id);
         } else {
             env.storage().persistent().set(&DataKey::Tx(tx_id), &tx);
+            env.storage().persistent().extend_ttl(
+                &DataKey::Tx(tx_id),
+                TX_STORAGE_TTL_LEDGERS,
+                TX_STORAGE_TTL_LEDGERS,
+            );
         }
 
         env.events()
@@ -412,6 +428,11 @@ impl TreasuryContract {
 
         tx.cancelled = true;
         env.storage().persistent().set(&DataKey::Tx(tx_id), &tx);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Tx(tx_id),
+            TX_STORAGE_TTL_LEDGERS,
+            TX_STORAGE_TTL_LEDGERS,
+        );
         env.events().publish((symbol_short!("cancel"),), tx_id);
     }
 


### PR DESCRIPTION
### Summary

### Changes

**#625 — timelock: re-initialization guard**
- `initialize()` now panics if `DataKey::Admin` is already present, preventing an attacker from overwriting admin/governor after initial setup.

**#629 — liquidity: post-removal reserve floor check**
- `remove_liquidity()` now asserts that post-removal reserves remain above `MIN_LIQUIDITY` (or reach 0 for a full drain), preventing the pool from being left in a broken state.

**#634 — governor: reject zero-weight votes**
- `cast_vote()` / `cast_vote_with_reason()` use `<= 0` instead of `< 0` so voters with zero tokens cannot cast votes that waste storage, emit misleading `VoteCast` events, and permanently lock the voter out of future participation.

**#635 — treasury: TxProposal TTL extension**
- Added `extend_ttl` (518,400 ledgers ≈ 30 days) after every `TxProposal` persistent storage write in `submit`, `approve`, and `cancel` so that proposals pending multi-sig approval do not expire and become inaccessible.

---

Closes #625 
Closes #629 
Closes #634 
Closes #635