### PR TITLE
closes #712 feature(indexer): WebSocket events should support filtering by proposal_id or state

### DIFF
--- a/packages/indexer/src/__tests__/ws.test.ts
+++ b/packages/indexer/src/__tests__/ws.test.ts
@@ -108,6 +108,98 @@ describe("WebSocket broadcast server", () => {
     ws.close();
   });
 
+  it("filters by proposal_id using the subscribe protocol", async () => {
+    const ws = await openClient(serverUrl);
+
+    ws.send(JSON.stringify({ subscribe: "proposal", proposal_id: 42 }));
+    await waitMs(50);
+
+    broadcast({ type: "vote_cast", data: { proposal_id: "7", voter: "G1" } });
+
+    let received = false;
+    ws.once("message", () => { received = true; });
+    await waitMs(100);
+    expect(received).toBe(false);
+
+    const messagePromise = nextMessage(ws);
+    broadcast({ type: "vote_cast", data: { proposal_id: "42", voter: "G2" } });
+    const raw = await messagePromise;
+    expect(JSON.parse(raw).data.proposal_id).toBe("42");
+    ws.close();
+  });
+
+  it("filters by state using the subscribe protocol", async () => {
+    const ws = await openClient(serverUrl);
+
+    ws.send(JSON.stringify({ subscribe: "state", state: "Active" }));
+    await waitMs(50);
+
+    // proposal_queued implies the "Queued" state, not "Active"
+    broadcast({ type: "proposal_queued", data: { proposal_id: "3" } });
+
+    let received = false;
+    ws.once("message", () => { received = true; });
+    await waitMs(100);
+    expect(received).toBe(false);
+
+    // vote_cast implies the "Active" state
+    const messagePromise = nextMessage(ws);
+    broadcast({ type: "vote_cast", data: { proposal_id: "3", voter: "G1" } });
+    const raw = await messagePromise;
+    expect(JSON.parse(raw).type).toBe("vote_cast");
+    ws.close();
+  });
+
+  it("excludes events with no derivable state when filtering by state", async () => {
+    const ws = await openClient(serverUrl);
+
+    ws.send(JSON.stringify({ subscribe: "state", state: "Active" }));
+    await waitMs(50);
+
+    broadcast({ type: "delegate_changed", data: { delegator: "G1", old_delegatee: "G2", new_delegatee: "G3" } });
+
+    let received = false;
+    ws.once("message", () => { received = true; });
+    await waitMs(100);
+    expect(received).toBe(false);
+    ws.close();
+  });
+
+  it("combines proposal_id and state filters", async () => {
+    const ws = await openClient(serverUrl);
+
+    ws.send(JSON.stringify({ proposalId: "9" }));
+    ws.send(JSON.stringify({ subscribe: "state", state: "Executed" }));
+    await waitMs(50);
+
+    // Matches proposal_id but not state
+    broadcast({ type: "proposal_queued", data: { proposal_id: "9" } });
+    // Matches state but not proposal_id
+    broadcast({ type: "proposal_executed", data: { proposal_id: "10" } });
+
+    let received = false;
+    ws.once("message", () => { received = true; });
+    await waitMs(100);
+    expect(received).toBe(false);
+
+    const messagePromise = nextMessage(ws);
+    broadcast({ type: "proposal_executed", data: { proposal_id: "9" } });
+    const raw = await messagePromise;
+    expect(JSON.parse(raw).type).toBe("proposal_executed");
+    ws.close();
+  });
+
+  it("broadcasts proposal_cancelled events", async () => {
+    const ws = await openClient(serverUrl);
+    const messagePromise = nextMessage(ws);
+
+    broadcast({ type: "proposal_cancelled", data: { proposal_id: "11", caller: "GABC" } });
+
+    const raw = await messagePromise;
+    expect(JSON.parse(raw).type).toBe("proposal_cancelled");
+    ws.close();
+  });
+
   it("removes client from set on disconnect", async () => {
     const ws = await openClient(serverUrl);
     expect(getConnectedClientCount()).toBe(1);

--- a/packages/indexer/src/ws.ts
+++ b/packages/indexer/src/ws.ts
@@ -6,6 +6,7 @@ export type WsEventType =
   | "vote_cast"
   | "proposal_queued"
   | "proposal_executed"
+  | "proposal_cancelled"
   | "delegate_changed"
   | "config_updated"
   | "governor_upgraded"
@@ -20,6 +21,7 @@ export interface WsEvent {
 interface SubscriptionFilter {
   types?: WsEventType[];
   proposalId?: string;
+  state?: string;
 }
 
 interface SubscribedClient {
@@ -33,6 +35,19 @@ const MAX_MISSED_PINGS = 3;
 
 const clients = new Set<SubscribedClient>();
 
+/**
+ * Proposal lifecycle state implied by each event type. Succeeded/Defeated/Expired
+ * are derived purely from ledger time rather than an on-chain event, so they have
+ * no entry here and can't be matched by a `state` filter.
+ */
+const EVENT_STATE: Partial<Record<WsEventType, string>> = {
+  proposal_created: "Pending",
+  vote_cast: "Active",
+  proposal_queued: "Queued",
+  proposal_executed: "Executed",
+  proposal_cancelled: "Cancelled",
+};
+
 function matchesFilter(event: WsEvent, filter: SubscriptionFilter): boolean {
   if (filter.types && filter.types.length > 0) {
     if (!filter.types.includes(event.type)) return false;
@@ -40,6 +55,9 @@ function matchesFilter(event: WsEvent, filter: SubscriptionFilter): boolean {
   if (filter.proposalId !== undefined) {
     const pid = (event.data as any).proposal_id ?? (event.data as any).id;
     if (String(pid) !== filter.proposalId) return false;
+  }
+  if (filter.state !== undefined) {
+    if (EVENT_STATE[event.type] !== filter.state) return false;
   }
   return true;
 }
@@ -68,10 +86,20 @@ export function createWsServer(httpServer: HttpServer): WebSocketServer {
         const msg = JSON.parse(raw.toString()) as {
           types?: WsEventType[];
           proposalId?: string;
+          subscribe?: "proposal" | "state";
+          proposal_id?: string | number;
+          state?: string;
         };
         if (Array.isArray(msg.types)) entry.filter.types = msg.types;
         if (typeof msg.proposalId === "string")
           entry.filter.proposalId = msg.proposalId;
+
+        // { subscribe: "proposal", proposal_id: 42 } / { subscribe: "state", state: "Active" }
+        if (msg.subscribe === "proposal" && msg.proposal_id !== undefined) {
+          entry.filter.proposalId = String(msg.proposal_id);
+        } else if (msg.subscribe === "state" && typeof msg.state === "string") {
+          entry.filter.state = msg.state;
+        }
       } catch {
         /* ignore malformed filter messages */
       }

--- a/sdk/src/streamEvents.ts
+++ b/sdk/src/streamEvents.ts
@@ -3,6 +3,7 @@ export type WsEventType =
   | "vote_cast"
   | "proposal_queued"
   | "proposal_executed"
+  | "proposal_cancelled"
   | "delegate_changed"
   | "config_updated"
   | "governor_upgraded"
@@ -19,6 +20,8 @@ export interface StreamEventsOptions {
   types?: WsEventType[];
   /** Filter to a specific proposal ID. */
   proposalId?: string;
+  /** Filter to events implying a specific proposal lifecycle state (e.g. "Active", "Queued"). */
+  state?: string;
   /** Reconnect delay in ms (default 3000). */
   reconnectDelayMs?: number;
   /** Polling interval in ms used as fallback when WebSocket is unavailable (default 10000). */
@@ -26,6 +29,19 @@ export interface StreamEventsOptions {
   /** Custom fetch function for polling fallback (default: global fetch). */
   fetchFn?: typeof fetch;
 }
+
+/**
+ * Proposal lifecycle state implied by each event type. Mirrors the indexer's
+ * mapping in packages/indexer/src/ws.ts — kept in sync there, not imported,
+ * since the SDK has no runtime dependency on the indexer package.
+ */
+const EVENT_STATE_HINT: Partial<Record<WsEventType, string>> = {
+  proposal_created: "Pending",
+  vote_cast: "Active",
+  proposal_queued: "Queued",
+  proposal_executed: "Executed",
+  proposal_cancelled: "Cancelled",
+};
 
 export type UnsubscribeFn = () => void;
 
@@ -50,6 +66,7 @@ export function streamEvents(
   const {
     types,
     proposalId,
+    state,
     reconnectDelayMs = 3000,
     pollIntervalMs = 10_000,
     fetchFn = typeof fetch !== "undefined" ? fetch : undefined,
@@ -105,6 +122,7 @@ export function streamEvents(
       const pid = (event.data as any).proposal_id ?? (event.data as any).id;
       if (String(pid) !== proposalId) return false;
     }
+    if (state !== undefined && EVENT_STATE_HINT[event.type] !== state) return false;
     return true;
   }
 
@@ -130,6 +148,9 @@ export function streamEvents(
       usingPolling = false;
       if (types || proposalId) {
         ws!.send(JSON.stringify({ types, proposalId }));
+      }
+      if (state !== undefined) {
+        ws!.send(JSON.stringify({ subscribe: "state", state }));
       }
     };
 


### PR DESCRIPTION
closes #712 feature(indexer): WebSocket events should support filtering by proposal_id or state

Clients can now send { subscribe: "proposal", proposal_id } or { subscribe: "state", state } on the /events socket to have the server filter broadcasts before sending, cutting bandwidth for large governance instances. Legacy { types, proposalId } filter messages keep working.

State filtering matches events with a clear lifecycle implication (created->Pending, vote_cast->Active, queued->Queued, executed->Executed, cancelled->Cancelled); Succeeded/Defeated/Expired are ledger-time-derived and have no corresponding broadcast event, so they can't be matched yet.

Also adds the missing "proposal_cancelled" WsEventType (already broadcast by events.ts but absent from the type union) and mirrors the new `state` option in the SDK's streamEvents() for end-to-end use via watchProposal.

Closes #712