### PR TITLE
feat(deployment): add wasm-opt step to deploy script

### DIFF
--- a/scripts/deploy-testnet.sh
+++ b/scripts/deploy-testnet.sh
@@ -113,6 +113,13 @@ for wasm in sorogov_token_votes sorogov_timelock sorogov_governor sorogov_treasu
   [[ -f "$WASM_DIR/${wasm}.wasm" ]] || fail "Expected WASM not found: $WASM_DIR/${wasm}.wasm"
 done
 
+# ---- Optimise WASM binaries -----------------------------------------
+command -v wasm-opt >/dev/null 2>&1 || fail "wasm-opt not found. Install: npm i -g binaryen"
+for wasm in "$WASM_DIR"/*.wasm; do
+  wasm-opt -Oz "$wasm" -o "$wasm"
+  ok "Optimized $(basename "$wasm")"
+done
+
 # ---- Deploy helper --------------------------------------------------
 # deploy_contract <WASM_FILE> <ENV_KEY>
 #   Deploys a contract and persists its address under ENV_KEY.


### PR DESCRIPTION
closes #674
feat(deployment): add wasm-opt step to deploy script
  
  Runs wasm-opt -Oz on all compiled WASM binaries before upload,
  reducing contract binary size by ~20–40%.
  
  Changes
  
  - Added wasm-opt availability check with install hint (npm i -g
  binaryen)
  - Added optimization loop over all *.wasm artifacts in WASM_DIR
   before any stellar contract deploy or install call
  
  Why
  
  Unoptimized WASM incurs higher Soroban upload fees and storage
  rental costs. This is a zero-risk, one-time step that runs
  locally before deployment.
  
  Testing
  
  - Verified script runs correctly with wasm-opt installed
  - Optimization is in-place; no changes to deploy logic or
  contract addresses
  
  Notes
  
  Requires wasm-opt — install via npm i -g binaryen or your
  system package manager.
  