### PR TITLE
feat(governor): signed vote delegation via delegate_by_sig (gasless meta-tx)

### DIFF
--- a/app/src/app/delegates/page.tsx
+++ b/app/src/app/delegates/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { VotesClient, type TopDelegate, type Network } from "@nebgov/sdk";
 import { useWallet } from "../../lib/wallet-context";
 import { DelegateModal } from "../../components/DelegateModal";
+import { GaslessDelegateModal } from "../../components/GaslessDelegateModal";
 import { Skeleton } from "../../components/ui/Skeleton";
 import { useGovernorConfig } from "@/hooks/useGovernorConfig";
 
@@ -55,6 +56,7 @@ export default function DelegatesPage() {
   const [totalDelegated, setTotalDelegated] = useState(0n);
   const [totalSupply, setTotalSupply] = useState(0n);
   const [modalOpen, setModalOpen] = useState(false);
+  const [gaslessModalOpen, setGaslessModalOpen] = useState(false);
   const [prefillAddress, setPrefillAddress] = useState<string>("");
   const [currentDelegatee, setCurrentDelegatee] = useState<string | null>(null);
   const [offset, setOffset] = useState(0);
@@ -322,6 +324,18 @@ export default function DelegatesPage() {
         onDelegated={() => window.location.reload()}
         prefillAddress={prefillAddress}
         currentDelegatee={currentDelegatee}
+        onOpenGasless={() => {
+          setModalOpen(false);
+          setGaslessModalOpen(true);
+        }}
+      />
+
+      <GaslessDelegateModal
+        open={gaslessModalOpen}
+        onClose={() => setGaslessModalOpen(false)}
+        onDelegated={() => window.location.reload()}
+        prefillAddress={prefillAddress}
+        topDelegates={delegates}
       />
     </div>
   );

--- a/app/src/components/DelegateModal.tsx
+++ b/app/src/components/DelegateModal.tsx
@@ -16,6 +16,8 @@ interface Props {
   onDelegated?: () => void;
   prefillAddress?: string;
   currentDelegatee?: string | null;
+  /** Shown as a secondary "delegate without paying gas" action, if provided. */
+  onOpenGasless?: () => void;
 }
 
 function getVotesClientFromEnv(): VotesClient {
@@ -63,6 +65,7 @@ export function DelegateModal({
   onDelegated,
   prefillAddress,
   currentDelegatee,
+  onOpenGasless,
 }: Props) {
   const [delegatee, setDelegatee] = useState(prefillAddress || "");
   const [submitting, setSubmitting] = useState(false);
@@ -141,41 +144,6 @@ export function DelegateModal({
     }
   }
 
-  async function handleDelegateBySig() {
-    if (!delegatee.trim()) return;
-
-    setSubmitting(true);
-    try {
-      if (!isConnected || !publicKey) {
-        throw new Error("Connect your wallet first.");
-      }
-
-      const client = getVotesClientFromEnv();
-      const signer = getDelegateSigner();
-      const nonce = 0n; // TODO: Query current nonce from contract
-      const expiry = BigInt(Math.floor(Date.now() / 1000) + 3600);
-      const signature = client.signDelegation(
-        signer,
-        delegatee.trim(),
-        nonce,
-        expiry,
-      );
-
-      await client.delegateBySig(
-        publicKey,
-        delegatee.trim(),
-        nonce,
-        expiry,
-        signature,
-      );
-
-      onDelegated?.();
-      onClose();
-    } finally {
-      setSubmitting(false);
-    }
-  }
-
   return (
     <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
       <div className="bg-white rounded-2xl p-6 w-full max-w-md shadow-xl">
@@ -249,22 +217,24 @@ export function DelegateModal({
             </button>
           )}
 
-          <div className="border-t border-gray-200 pt-4 mt-4">
-            <p className="text-xs text-gray-500 mb-2">
-              Or delegate without paying gas
-            </p>
-            <button
-              type="button"
-              onClick={() => void handleDelegateBySig()}
-              disabled={submitting || !delegatee.trim()}
-              className="w-full bg-green-600 text-white py-2 rounded-lg text-sm font-medium hover:bg-green-700 disabled:opacity-50"
-            >
-              {submitting ? "Signing..." : "Delegate without paying gas"}
-            </button>
-            <p className="text-xs text-gray-400 mt-1">
-              Sign off-chain, relayer submits transaction
-            </p>
-          </div>
+          {onOpenGasless && (
+            <div className="border-t border-gray-200 pt-4 mt-4">
+              <p className="text-xs text-gray-500 mb-2">
+                Or delegate without paying gas
+              </p>
+              <button
+                type="button"
+                onClick={onOpenGasless}
+                disabled={submitting}
+                className="w-full bg-green-600 text-white py-2 rounded-lg text-sm font-medium hover:bg-green-700 disabled:opacity-50"
+              >
+                Delegate for free — we pay the fee
+              </button>
+              <p className="text-xs text-gray-400 mt-1">
+                Sign off-chain, our relayer submits the transaction
+              </p>
+            </div>
+          )}
         </form>
       </div>
     </div>

--- a/app/src/components/GaslessDelegateModal.tsx
+++ b/app/src/components/GaslessDelegateModal.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+/**
+ * Gasless delegation modal — sign a delegation permit with the connected
+ * wallet, and let the protocol's relayer pay the fee and submit it.
+ */
+
+import { useEffect, useState, type FormEvent } from "react";
+import toast from "react-hot-toast";
+import type { TopDelegate } from "@nebgov/sdk";
+import { useWallet } from "../lib/wallet-context";
+import {
+  useGaslessDelegation,
+  EXPIRY_PRESET_LABELS,
+  type ExpiryPreset,
+} from "../hooks/useGaslessDelegation";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onDelegated?: () => void;
+  prefillAddress?: string;
+  /** Optional pre-fetched leaderboard to pick a delegatee from. */
+  topDelegates?: TopDelegate[];
+}
+
+function explorerTxUrl(txHash: string): string {
+  const network = process.env.NEXT_PUBLIC_NETWORK || "testnet";
+  const base =
+    network === "mainnet"
+      ? "https://stellar.expert/explorer/public"
+      : "https://stellar.expert/explorer/testnet";
+  return `${base}/tx/${txHash}`;
+}
+
+const EXPIRY_PRESETS: ExpiryPreset[] = ["1week", "1month", "6months", "1year"];
+
+export function GaslessDelegateModal({
+  open,
+  onClose,
+  onDelegated,
+  prefillAddress,
+  topDelegates,
+}: Props) {
+  const [delegatee, setDelegatee] = useState(prefillAddress || "");
+  const [expiryPreset, setExpiryPreset] = useState<ExpiryPreset>("1month");
+  const { isConnected, publicKey, connect } = useWallet();
+  const { delegateGasless, submitting } = useGaslessDelegation();
+
+  useEffect(() => {
+    setDelegatee(prefillAddress ?? "");
+  }, [open, prefillAddress]);
+
+  if (!open) return null;
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!delegatee.trim()) return;
+
+    try {
+      if (!isConnected || !publicKey) {
+        toast.error("Connect your wallet first.");
+        return;
+      }
+
+      const result = await delegateGasless(delegatee.trim(), expiryPreset);
+      toast.success(
+        <div>
+          Delegated for free — the protocol paid the fee.{" "}
+          <a
+            href={explorerTxUrl(result.txHash)}
+            target="_blank"
+            rel="noreferrer"
+            className="underline"
+          >
+            View on Explorer →
+          </a>
+        </div>,
+        { duration: 8000 },
+      );
+      onDelegated?.();
+      onClose();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      toast.error(`Gasless delegation failed: ${msg}`);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+      <div className="bg-white rounded-2xl p-6 w-full max-w-md shadow-xl">
+        <h2 className="text-lg font-bold text-gray-900 mb-1">
+          Delegate for free — we pay the fee
+        </h2>
+        <p className="text-sm text-gray-500 mb-4">
+          Sign a delegation permit with your wallet. No transaction, no gas —
+          our relayer submits it and pays the network fee for you.
+        </p>
+
+        {!isConnected && (
+          <button
+            type="button"
+            onClick={() => void connect()}
+            className="w-full mb-4 border border-indigo-200 bg-indigo-50 text-indigo-700 py-2 rounded-lg text-sm font-medium hover:bg-indigo-100"
+          >
+            Connect wallet to continue
+          </button>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1.5">
+              Delegate to
+            </label>
+            <input
+              type="text"
+              placeholder="Stellar address (G...)"
+              value={delegatee}
+              onChange={(e) => setDelegatee(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 font-mono"
+              required
+            />
+            {topDelegates && topDelegates.length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {topDelegates.slice(0, 5).map((d) => (
+                  <button
+                    key={d.address}
+                    type="button"
+                    onClick={() => setDelegatee(d.address)}
+                    className="text-xs px-2 py-1 rounded-md border border-gray-200 text-gray-700 hover:bg-gray-50 font-mono"
+                  >
+                    {d.address.slice(0, 4)}...{d.address.slice(-4)}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1.5">
+              Permit expires in
+            </label>
+            <div className="grid grid-cols-4 gap-2">
+              {EXPIRY_PRESETS.map((preset) => (
+                <button
+                  key={preset}
+                  type="button"
+                  onClick={() => setExpiryPreset(preset)}
+                  className={`text-xs py-1.5 rounded-lg border transition-colors ${
+                    expiryPreset === preset
+                      ? "border-indigo-600 bg-indigo-50 text-indigo-700 font-medium"
+                      : "border-gray-200 text-gray-600 hover:bg-gray-50"
+                  }`}
+                >
+                  {EXPIRY_PRESET_LABELS[preset]}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 border border-gray-200 text-gray-600 py-2 rounded-lg text-sm hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting || !delegatee.trim() || !isConnected}
+              className="flex-1 bg-green-600 text-white py-2 rounded-lg text-sm font-medium hover:bg-green-700 disabled:opacity-50"
+            >
+              {submitting ? "Signing…" : "Delegate for free"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/src/hooks/useGaslessDelegation.ts
+++ b/app/src/hooks/useGaslessDelegation.ts
@@ -1,0 +1,124 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { DelegationSigClient, type Network } from "@nebgov/sdk";
+import { useWallet } from "../lib/wallet-context";
+import { backendFetch } from "../lib/backend";
+
+/**
+ * Approximate ledger close time used to convert a human-friendly expiry
+ * ("1 week") into a ledger sequence number. Matches the ~5s/ledger
+ * assumption already used elsewhere in the SDK (see votes.ts's
+ * DEFAULT_SCAN_WINDOW comment).
+ */
+const LEDGER_SECONDS = 5;
+
+export type ExpiryPreset = "1week" | "1month" | "6months" | "1year";
+
+const EXPIRY_SECONDS: Record<ExpiryPreset, number> = {
+  "1week": 7 * 24 * 60 * 60,
+  "1month": 30 * 24 * 60 * 60,
+  "6months": 182 * 24 * 60 * 60,
+  "1year": 365 * 24 * 60 * 60,
+};
+
+export const EXPIRY_PRESET_LABELS: Record<ExpiryPreset, string> = {
+  "1week": "1 week",
+  "1month": "1 month",
+  "6months": "6 months",
+  "1year": "1 year",
+};
+
+export interface GaslessDelegationResult {
+  txHash: string;
+  nonce: number;
+}
+
+function getDelegationSigClientFromEnv(): DelegationSigClient {
+  const votesAddress = process.env.NEXT_PUBLIC_VOTES_ADDRESS;
+  const network = (process.env.NEXT_PUBLIC_NETWORK || "testnet") as Network;
+  const rpcUrl = process.env.NEXT_PUBLIC_RPC_URL;
+
+  if (!votesAddress) {
+    throw new Error("Missing NEXT_PUBLIC_VOTES_ADDRESS in .env.local");
+  }
+
+  return new DelegationSigClient({
+    votesAddress,
+    network,
+    ...(rpcUrl && { rpcUrl }),
+  });
+}
+
+/**
+ * Sign a delegation permit with the connected wallet and submit it through
+ * the backend relayer — the connected wallet never pays a fee or submits a
+ * transaction itself, it only signs an authorization off-chain.
+ */
+export function useGaslessDelegation() {
+  const { isConnected, publicKey, signAuthEntry } = useWallet();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const delegateGasless = useCallback(
+    async (
+      delegatee: string,
+      expiryPreset: ExpiryPreset,
+    ): Promise<GaslessDelegationResult> => {
+      if (!isConnected || !publicKey) {
+        throw new Error("Connect your wallet first.");
+      }
+
+      setSubmitting(true);
+      setError(null);
+      try {
+        const client = getDelegationSigClientFromEnv();
+        const currentLedger = await client.currentLedger();
+        const expiryLedger =
+          currentLedger +
+          Math.ceil(EXPIRY_SECONDS[expiryPreset] / LEDGER_SECONDS);
+
+        const { permit, authEntry } = await client.signDelegationPermit({
+          delegator: {
+            publicKey,
+            sign: async (preimage) => {
+              const signed = await signAuthEntry(preimage.toXDR("base64"));
+              return Buffer.from(signed, "base64");
+            },
+          },
+          delegatee,
+          expiryLedger,
+        });
+
+        const result = await backendFetch<GaslessDelegationResult>(
+          "/relayer/delegate",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              permit: {
+                delegator: permit.delegator,
+                delegatee: permit.delegatee,
+                nonce: permit.nonce.toString(),
+                expiryLedger: permit.expiryLedger,
+                chainId: permit.chainId.toString("base64"),
+                contractId: permit.contractId,
+              },
+              signature: authEntry,
+            }),
+          },
+        );
+
+        return result;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+        throw err;
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [isConnected, publicKey, signAuthEntry],
+  );
+
+  return { delegateGasless, submitting, error };
+}

--- a/app/src/lib/wallet-context.tsx
+++ b/app/src/lib/wallet-context.tsx
@@ -48,6 +48,14 @@ interface WalletContextValue {
   disconnect: () => void;
   /** Sign a prepared Soroban transaction XDR (fee-bump / classic TX). */
   signTransaction: (unsignedXdr: string) => Promise<string>;
+  /**
+   * Sign a Soroban authorization entry preimage (base64 XDR of a
+   * `HashIdPreimage`), returning the raw signature bytes (base64). Used for
+   * gasless/meta-transaction flows (e.g. delegate_by_sig) where the
+   * connected wallet authorizes an action without submitting or paying for
+   * a transaction itself.
+   */
+  signAuthEntry: (preimageXdr: string) => Promise<string>;
 }
 
 // Context
@@ -168,6 +176,21 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     [publicKey],
   );
 
+  const signAuthEntry = useCallback(
+    async (preimageXdr: string) => {
+      const kit = kitRef.current;
+      if (!kit || !publicKey) {
+        throw new Error("Connect your wallet first.");
+      }
+      const { signedAuthEntry } = await kit.signAuthEntry(preimageXdr, {
+        address: publicKey,
+        networkPassphrase: appNetworkPassphrase(),
+      });
+      return signedAuthEntry;
+    },
+    [publicKey],
+  );
+
   return (
     <WalletContext.Provider
       value={{
@@ -179,6 +202,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
         connect,
         disconnect,
         signTransaction,
+        signAuthEntry,
       }}
     >
       {children}

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,8 +13,14 @@ SNAPSHOT_MIN_DELTA=0
 # Stellar Configuration
 STELLAR_NETWORK=testnet
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 GOVERNOR_CONTRACT_ID=C...
 TOKEN_VOTES_CONTRACT_ID=C...
+
+# Gasless delegation relayer (issue #772)
+# Funded account that pays fees for delegate_by_sig / delegate_batch_by_sig.
+RELAYER_SECRET_KEY=S...
+RELAYER_DAILY_PERMIT_LIMIT=5
 
 # Security Monitoring Thresholds
 SECURITY_LARGE_TRANSFER_THRESHOLD=1000000000000 # 1,000,000 tokens (assuming 7 decimals)

--- a/backend/migrations/007_add_relayer_permit_log.sql
+++ b/backend/migrations/007_add_relayer_permit_log.sql
@@ -1,0 +1,20 @@
+-- Migration 007: Add relayer permit log for issue #772
+-- Tracks every signed DelegationPermit the relayer backend has submitted, so
+-- POST /relayer/delegate can enforce a per-delegator daily quota against the
+-- relayer's own gas budget, and so submissions are auditable/idempotent.
+
+CREATE TABLE IF NOT EXISTS relayer_permit_log (
+    id              BIGSERIAL PRIMARY KEY,
+    delegator       TEXT        NOT NULL,
+    delegatee       TEXT        NOT NULL,
+    nonce           NUMERIC     NOT NULL,
+    tx_hash         TEXT        NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_relayer_permit_log_delegator_created_at
+    ON relayer_permit_log (delegator, created_at);
+
+-- A given delegator+nonce should only ever be relayed once.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_relayer_permit_log_delegator_nonce
+    ON relayer_permit_log (delegator, nonce);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,6 +8,7 @@ import leaderboardRouter from "./routes/leaderboard";
 import authRouter from "./routes/auth";
 import notificationsRouter from "./routes/notifications";
 import securityRouter from "./routes/security";
+import relayerRouter from "./routes/relayer";
 import { securityMonitor } from "./services/security-monitor";
 import { runBackendMigrations } from "./db/migrationRunner";
 import pino from "pino";
@@ -44,6 +45,18 @@ const leaderboardLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: "Too many requests" },
+});
+
+// Submitting a signed permit costs the relayer a real transaction fee, so
+// this is deliberately tighter than the other per-IP limiters. The
+// per-delegator-address daily budget is enforced separately in the route
+// itself (backend/src/routes/relayer.ts), against relayer_permit_log.
+const relayerLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many relayer requests" },
 });
 
 // Middleware
@@ -92,6 +105,8 @@ app.use("/leaderboard/history", leaderboardLimiter);
 app.use("/leaderboard", leaderboardRouter);
 app.use("/notifications", notificationsRouter);
 app.use("/security", securityRouter);
+app.use("/relayer", relayerLimiter);
+app.use("/relayer", relayerRouter);
 
 // Error handling
 app.use(

--- a/backend/src/routes/relayer.ts
+++ b/backend/src/routes/relayer.ts
@@ -1,0 +1,313 @@
+import { Router } from "express";
+import { z } from "zod";
+import {
+  Contract,
+  Keypair,
+  Networks,
+  BASE_FEE,
+  Operation,
+  TransactionBuilder,
+  nativeToScVal,
+  rpc,
+  xdr,
+} from "@stellar/stellar-sdk";
+import pool from "../db/pool";
+import { validate } from "../middleware/validate";
+import { logger } from "../logger";
+
+const router = Router();
+
+// The backend already depends on @stellar/stellar-sdk ^15 (a different major
+// version than the ^12 pinned by @nebgov/sdk for the browser app), so this
+// route talks to Soroban directly instead of taking on a second, mismatched
+// copy of the SDK. The permit-encoding logic below is intentionally kept in
+// lockstep with sdk/src/delegation-sig.ts's `permitToScVal` — see the
+// comment there for why field order matters.
+
+// Matches both G... (account) and C... (contract) strkey addresses.
+const STELLAR_ADDRESS_RE = /^[GC][A-Z2-7]{55}$/;
+
+const RELAYER_DAILY_PERMIT_LIMIT = Number(
+  process.env.RELAYER_DAILY_PERMIT_LIMIT ?? 5,
+);
+
+const SINGLE_FN = "delegate_by_sig";
+const BATCH_FN = "delegate_batch_by_sig";
+
+const NETWORK_PASSPHRASES: Record<string, string> = {
+  mainnet: Networks.PUBLIC,
+  public: Networks.PUBLIC,
+  testnet: Networks.TESTNET,
+  futurenet: Networks.FUTURENET,
+};
+
+// Mirrors sdk/src/errors.ts VOTES_MESSAGES for the on-chain codes relevant
+// to this flow (contracts/token-votes/src/error.rs).
+const CONTRACT_ERROR_MESSAGES: Record<number, string> = {
+  10: "Invalid or missing delegation signature",
+  11: "Permit nonce has already been used or invalidated",
+  12: "Delegation permit has expired",
+  13: "Delegation permit is malformed or out of order",
+  14: "Relayer is not whitelisted to submit signed permits",
+  15: "Permit was signed for a different network",
+  16: "Permit was signed for a different contract",
+};
+
+function extractContractErrorMessage(err: unknown): string | null {
+  const str = err instanceof Error ? err.message : String(err);
+  const match = str.match(/Error\(Contract,\s*#(\d+)\)|ContractError\((\d+)\)/);
+  if (!match) return null;
+  const code = Number(match[1] ?? match[2]);
+  return CONTRACT_ERROR_MESSAGES[code] ?? `Contract error #${code}`;
+}
+
+const permitSchema = z.object({
+  delegator: z.string().regex(STELLAR_ADDRESS_RE, "invalid delegator address"),
+  delegatee: z.string().regex(STELLAR_ADDRESS_RE, "invalid delegatee address"),
+  nonce: z.coerce.bigint().nonnegative(),
+  expiryLedger: z.coerce.number().int().positive(),
+  /** base64-encoded 32 raw bytes (the network ID). */
+  chainId: z.string().min(1),
+  contractId: z.string().regex(STELLAR_ADDRESS_RE, "invalid contract address"),
+});
+
+type PermitInput = z.infer<typeof permitSchema>;
+
+const delegateSchema = z.object({
+  permit: permitSchema,
+  /** base64 XDR of the delegator's signed SorobanAuthorizationEntry. */
+  signature: z.string().min(1),
+});
+
+const batchDelegateSchema = z.object({
+  permits: z.array(permitSchema).min(1).max(20),
+  signatures: z.array(z.string().min(1)).min(1).max(20),
+});
+
+function networkPassphrase(): string {
+  const key = (process.env.STELLAR_NETWORK ?? "testnet").toLowerCase();
+  return NETWORK_PASSPHRASES[key] ?? Networks.TESTNET;
+}
+
+function rpcServer(): rpc.Server {
+  const url = process.env.STELLAR_RPC_URL ?? "https://soroban-testnet.stellar.org";
+  return new rpc.Server(url, { allowHttp: false });
+}
+
+function votesContract(): Contract {
+  const votesAddress = process.env.TOKEN_VOTES_CONTRACT_ID;
+  if (!votesAddress) {
+    throw new Error("TOKEN_VOTES_CONTRACT_ID is not configured");
+  }
+  return new Contract(votesAddress);
+}
+
+function getRelayerKeypair(): Keypair {
+  const secret = process.env.RELAYER_SECRET_KEY;
+  if (!secret) {
+    throw new Error("RELAYER_SECRET_KEY is not configured");
+  }
+  return Keypair.fromSecret(secret);
+}
+
+/**
+ * Struct fields are serialized as a map sorted alphabetically by field name
+ * (soroban-sdk's `#[contracttype]` derive convention for structs) — this
+ * exact key order (chain_id, contract_id, delegatee, delegator,
+ * expiry_ledger, nonce) must match, or the resulting ScVal won't equal what
+ * the contract expects.
+ */
+function permitToScVal(permit: PermitInput): xdr.ScVal {
+  return nativeToScVal(
+    {
+      chain_id: Buffer.from(permit.chainId, "base64"),
+      contract_id: permit.contractId,
+      delegatee: permit.delegatee,
+      delegator: permit.delegator,
+      expiry_ledger: permit.expiryLedger,
+      nonce: permit.nonce,
+    },
+    {
+      type: {
+        chain_id: ["symbol", "bytes"],
+        contract_id: ["symbol", "address"],
+        delegatee: ["symbol", "address"],
+        delegator: ["symbol", "address"],
+        expiry_ledger: ["symbol", "u32"],
+        nonce: ["symbol", "u64"],
+      },
+    },
+  );
+}
+
+/**
+ * Off-chain structural check: does this parse as a well-formed
+ * `SorobanAuthorizationEntry` with address credentials? This catches
+ * garbage/malformed input before we spend an RPC round-trip on it. Full
+ * cryptographic + business-rule validation (expiry, nonce, chain/contract
+ * ID, and the signature itself) happens when the relayer simulates the
+ * transaction, immediately before submission.
+ */
+function isWellFormedAuthEntry(base64Xdr: string): boolean {
+  try {
+    const entry = xdr.SorobanAuthorizationEntry.fromXDR(base64Xdr, "base64");
+    return entry.credentials().switch().name === "sorobanCredentialsAddress";
+  } catch {
+    return false;
+  }
+}
+
+/** Rolling 24h count of permits this relayer has already submitted for `delegator`. */
+async function relayedPermitCountToday(delegator: string): Promise<number> {
+  const { rows } = await pool.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count FROM relayer_permit_log
+     WHERE delegator = $1 AND created_at > NOW() - INTERVAL '1 day'`,
+    [delegator],
+  );
+  return Number(rows[0]?.count ?? 0);
+}
+
+async function logRelayedPermit(
+  permit: PermitInput,
+  txHash: string,
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO relayer_permit_log (delegator, delegatee, nonce, tx_hash)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (delegator, nonce) DO NOTHING`,
+    [permit.delegator, permit.delegatee, permit.nonce.toString(), txHash],
+  );
+}
+
+async function submitInvocation(
+  fnName: string,
+  args: xdr.ScVal[],
+  auth: xdr.SorobanAuthorizationEntry[],
+): Promise<string> {
+  const relayer = getRelayerKeypair();
+  const server = rpcServer();
+  const contract = votesContract();
+  const passphrase = networkPassphrase();
+
+  const account = await server.getAccount(relayer.publicKey());
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: passphrase,
+  })
+    .addOperation(
+      Operation.invokeContractFunction({
+        contract: contract.contractId(),
+        function: fnName,
+        args,
+        auth,
+      }),
+    )
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  prepared.sign(relayer);
+  const result = await server.sendTransaction(prepared);
+  if (result.status === "ERROR") {
+    throw new Error(
+      `Transaction failed: ${JSON.stringify(result.errorResult ?? result)}`,
+    );
+  }
+  return result.hash;
+}
+
+// POST /relayer/delegate — submit a single signed delegation permit.
+router.post("/delegate", validate({ body: delegateSchema }), async (req, res) => {
+  const { permit, signature } = req.body as z.infer<typeof delegateSchema>;
+
+  try {
+    if (!isWellFormedAuthEntry(signature)) {
+      return res.status(400).json({ error: "Malformed authorization signature" });
+    }
+
+    const relayedToday = await relayedPermitCountToday(permit.delegator);
+    if (relayedToday >= RELAYER_DAILY_PERMIT_LIMIT) {
+      return res.status(429).json({
+        error: "Relayer daily permit limit reached for this address",
+      });
+    }
+
+    const relayer = getRelayerKeypair();
+    const entry = xdr.SorobanAuthorizationEntry.fromXDR(signature, "base64");
+
+    const txHash = await submitInvocation(
+      SINGLE_FN,
+      [nativeToScVal(relayer.publicKey(), { type: "address" }), permitToScVal(permit)],
+      [entry],
+    );
+    await logRelayedPermit(permit, txHash);
+
+    res.json({ txHash, nonce: Number(permit.nonce) + 1 });
+  } catch (error) {
+    logger.error({ err: error }, "Error in POST /relayer/delegate");
+    const contractMessage = extractContractErrorMessage(error);
+    if (contractMessage) {
+      return res.status(400).json({ error: contractMessage });
+    }
+    res.status(500).json({ error: "Failed to submit delegation" });
+  }
+});
+
+// POST /relayer/delegate-batch — submit multiple signed permits atomically.
+router.post(
+  "/delegate-batch",
+  validate({ body: batchDelegateSchema }),
+  async (req, res) => {
+    const { permits, signatures } = req.body as z.infer<
+      typeof batchDelegateSchema
+    >;
+
+    if (permits.length !== signatures.length) {
+      return res
+        .status(400)
+        .json({ error: "permits and signatures must have the same length" });
+    }
+
+    try {
+      if (!signatures.every(isWellFormedAuthEntry)) {
+        return res.status(400).json({ error: "Malformed authorization signature" });
+      }
+
+      for (const permit of permits) {
+        const relayedToday = await relayedPermitCountToday(permit.delegator);
+        if (relayedToday >= RELAYER_DAILY_PERMIT_LIMIT) {
+          return res.status(429).json({
+            error: `Relayer daily permit limit reached for ${permit.delegator}`,
+          });
+        }
+      }
+
+      const relayer = getRelayerKeypair();
+      const entries = signatures.map((s) =>
+        xdr.SorobanAuthorizationEntry.fromXDR(s, "base64"),
+      );
+      const permitsScVal = nativeToScVal(permits.map((p) => permitToScVal(p)));
+
+      const txHash = await submitInvocation(
+        BATCH_FN,
+        [nativeToScVal(relayer.publicKey(), { type: "address" }), permitsScVal],
+        entries,
+      );
+      await Promise.all(permits.map((permit) => logRelayedPermit(permit, txHash)));
+
+      res.json({
+        txHash,
+        nonces: permits.map((p) => Number(p.nonce) + 1),
+      });
+    } catch (error) {
+      logger.error({ err: error }, "Error in POST /relayer/delegate-batch");
+      const contractMessage = extractContractErrorMessage(error);
+      if (contractMessage) {
+        return res.status(400).json({ error: contractMessage });
+      }
+      res.status(500).json({ error: "Failed to submit batch delegation" });
+    }
+  },
+);
+
+export default router;

--- a/contracts/token-votes/src/delegation_sig.rs
+++ b/contracts/token-votes/src/delegation_sig.rs
@@ -1,0 +1,231 @@
+//! Signed vote delegation ("delegate_by_sig"), equivalent to Ethereum's
+//! EIP-712 `delegateBySig`: a token holder signs a [`DelegationPermit`]
+//! off-chain and a relayer submits it on-chain, paying the fee.
+//!
+//! ## Why this doesn't use `env.crypto().ed25519_verify()` directly
+//!
+//! `Address` in Soroban is intentionally opaque — it can represent a classic
+//! Ed25519 account, a multisig account, or an arbitrary smart-wallet
+//! contract, and none of those expose a raw Ed25519 public key to contract
+//! code (there is no `Address` -> `BytesN<32>` conversion in the SDK). The
+//! same limitation is documented on the pre-existing `delegate_by_sig` this
+//! module replaces (see git history / ADR-005).
+//!
+//! Instead, verification is delegated to Soroban's native authorization
+//! framework via [`Address::require_auth_for_args`]. A relayer collects a
+//! `SorobanAuthorizationEntry` that the delegator signed off-chain (offline,
+//! without needing a submitted transaction — see `sdk/src/delegation-sig.ts`)
+//! and attaches it to the transaction that invokes `delegate_by_sig`. This is
+//! audited, host-verified crypto that also transparently supports multisig
+//! and smart-wallet delegators, which manual `ed25519_verify` never could.
+//!
+//! The auth entry is bound to `(this contract, "delegate_by_sig", (permit,))`
+//! — deliberately *not* including the `relayer` argument — so the same
+//! signed permit is relayer-agnostic and can be submitted by any relayer.
+//!
+//! On top of Soroban's own (per-invocation, random-nonce) replay protection,
+//! this module layers an explicit, sequential, application-level nonce
+//! (reusing the existing `DataKey::Nonce`) so permits can be listed,
+//! queried, and bulk-invalidated (`invalidate_all_permits`) the way an
+//! EIP-712 permit's nonce can.
+//!
+//! `domain_separator` / `compute_permit_hash` are exposed for off-chain
+//! tooling parity (e.g. relayer-side permit fingerprinting/deduplication)
+//! and are *not* themselves part of the on-chain signature check.
+
+use soroban_sdk::{contracttype, xdr::ToXdr, Address, BytesN, Env, IntoVal};
+
+use crate::{error::TokenVotesError, DataKey};
+
+/// Domain-separator prefix, mirrors the EIP-712-style string used by the
+/// off-chain SDK when it recomputes `domain_separator()` for display/testing.
+const DOMAIN_SEPARATOR_PREFIX: &[u8] = b"nebgov::DelegationPermit";
+
+/// Large step applied to a delegator's nonce by `invalidate_all_permits`,
+/// guaranteed to jump past any nonce a delegator could plausibly have
+/// pre-signed and not yet submitted.
+const INVALIDATE_ALL_STEP: u64 = 1_000_000;
+
+/// An off-chain-signed instruction to delegate voting power.
+///
+/// `chain_id` and `contract_id` bind the permit to a specific network and
+/// contract instance, preventing cross-network/cross-contract replay even
+/// though Soroban's own auth-entry preimage already includes the network ID
+/// and invoked contract — this is deliberate defense in depth, and lets the
+/// contract fail with a specific, typed error instead of a generic host
+/// auth trap when a permit is replayed against the wrong deployment.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct DelegationPermit {
+    pub delegator: Address,
+    pub delegatee: Address,
+    pub nonce: u64,
+    pub expiry_ledger: u32,
+    pub chain_id: BytesN<32>,
+    pub contract_id: Address,
+}
+
+/// Compute the domain separator for this contract instance:
+/// `sha256("nebgov::DelegationPermit" || contract_id || network_id)`.
+pub fn compute_domain_separator(env: &Env) -> BytesN<32> {
+    let mut preimage = soroban_sdk::Bytes::from_slice(env, DOMAIN_SEPARATOR_PREFIX);
+    preimage.append(&env.current_contract_address().to_xdr(env));
+    preimage.append(env.ledger().network_id().as_ref());
+    env.crypto().sha256(&preimage).into()
+}
+
+/// Read the domain separator cached at `initialize()`.
+pub fn domain_separator(env: &Env) -> BytesN<32> {
+    env.storage()
+        .instance()
+        .get(&DataKey::DomainSeparator)
+        .unwrap_or_else(|| compute_domain_separator(env))
+}
+
+/// Cache the domain separator in instance storage. Called once from
+/// `initialize()`.
+pub fn init_domain_separator(env: &Env) {
+    let separator = compute_domain_separator(env);
+    env.storage()
+        .instance()
+        .set(&DataKey::DomainSeparator, &separator);
+}
+
+/// Compute the full signed-message hash for a permit:
+/// `sha256(domain_separator || sha256(xdr_encode(permit)))`.
+///
+/// This mirrors the EIP-712-style digest an off-chain client can recompute
+/// to double-check what it's about to sign. It is informational only — the
+/// actual on-chain authorization check is performed by Soroban's native
+/// auth framework (see [`verify_delegation_permit`]), not by comparing this
+/// hash to a signature.
+pub fn compute_permit_hash(env: &Env, permit: &DelegationPermit) -> BytesN<32> {
+    let permit_xdr = permit.clone().to_xdr(env);
+    let permit_hash: BytesN<32> = env.crypto().sha256(&permit_xdr).into();
+
+    let mut preimage = soroban_sdk::Bytes::new(env);
+    preimage.append(domain_separator(env).as_ref());
+    preimage.append(permit_hash.as_ref());
+    env.crypto().sha256(&preimage).into()
+}
+
+/// Current expected nonce for `delegator` (the next nonce a valid permit
+/// must present).
+pub fn current_nonce(env: &Env, delegator: &Address) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Nonce(delegator.clone()))
+        .unwrap_or(0)
+}
+
+/// Whether `nonce` has ever been consumed by a permit from `delegator`.
+pub fn is_nonce_used(env: &Env, delegator: &Address, nonce: u64) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::UsedNonce(delegator.clone(), nonce))
+        .unwrap_or(false)
+}
+
+/// Bump `delegator`'s nonce far past anything they may have already signed,
+/// invalidating every outstanding unsubmitted permit in one call. Returns
+/// the new nonce.
+pub fn invalidate_all_permits(env: &Env, delegator: &Address) -> u64 {
+    let new_nonce = current_nonce(env, delegator) + INVALIDATE_ALL_STEP;
+    env.storage()
+        .persistent()
+        .set(&DataKey::Nonce(delegator.clone()), &new_nonce);
+    new_nonce
+}
+
+/// Whether the relayer whitelist is currently enforced.
+pub fn relayer_whitelist_enabled(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::RelayerWhitelistEnabled)
+        .unwrap_or(false)
+}
+
+/// Whether `relayer` may submit signed permits: always true while the
+/// whitelist is disabled, otherwise reflects the stored whitelist entry.
+pub fn is_relayer_allowed(env: &Env, relayer: &Address) -> bool {
+    if !relayer_whitelist_enabled(env) {
+        return true;
+    }
+    env.storage()
+        .persistent()
+        .get(&DataKey::RelayerWhitelist(relayer.clone()))
+        .unwrap_or(false)
+}
+
+pub fn set_relayer_whitelist_enabled(env: &Env, enabled: bool) {
+    env.storage()
+        .instance()
+        .set(&DataKey::RelayerWhitelistEnabled, &enabled);
+}
+
+pub fn set_relayer_whitelisted(env: &Env, relayer: &Address, whitelisted: bool) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::RelayerWhitelist(relayer.clone()), &whitelisted);
+}
+
+/// Latest `expiry_ledger` seen in a successfully-applied permit for
+/// `delegator`, or `None` if they have never delegated by signature.
+pub fn delegation_permit_expiry(env: &Env, delegator: &Address) -> Option<u32> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::DelegationPermitExpiry(delegator.clone()))
+}
+
+/// Validate a [`DelegationPermit`] and cryptographically authorize it via
+/// Soroban's native auth framework, then mark its nonce as consumed.
+///
+/// # Panics
+///
+/// Panics with the corresponding [`TokenVotesError`] if the permit has
+/// expired, targets the wrong network or contract, or presents a nonce other
+/// than the delegator's current expected nonce. Panics with a host-level
+/// auth error (not a [`TokenVotesError`]) if no valid authorization for
+/// `permit.delegator` is attached to the transaction — see the module docs.
+pub fn verify_delegation_permit(env: &Env, permit: &DelegationPermit) -> Address {
+    if env.ledger().sequence() > permit.expiry_ledger {
+        env.panic_with_error(TokenVotesError::PermitExpired);
+    }
+
+    if permit.chain_id != env.ledger().network_id() {
+        env.panic_with_error(TokenVotesError::InvalidChainId);
+    }
+
+    if permit.contract_id != env.current_contract_address() {
+        env.panic_with_error(TokenVotesError::InvalidContractId);
+    }
+
+    let expected_nonce = current_nonce(env, &permit.delegator);
+    if permit.nonce < expected_nonce || is_nonce_used(env, &permit.delegator, permit.nonce) {
+        env.panic_with_error(TokenVotesError::NonceAlreadyUsed);
+    }
+    if permit.nonce > expected_nonce {
+        env.panic_with_error(TokenVotesError::InvalidDelegationPermit);
+    }
+
+    // Cryptographic verification: require a signed authorization entry from
+    // the delegator, scoped to exactly this permit (and no relayer, so it's
+    // relayer-agnostic — see module docs).
+    let args = soroban_sdk::vec![env, permit.clone().into_val(env)];
+    permit.delegator.require_auth_for_args(args);
+
+    env.storage().persistent().set(
+        &DataKey::UsedNonce(permit.delegator.clone(), permit.nonce),
+        &true,
+    );
+    env.storage().persistent().set(
+        &DataKey::Nonce(permit.delegator.clone()),
+        &(permit.nonce + 1),
+    );
+    env.storage().persistent().set(
+        &DataKey::DelegationPermitExpiry(permit.delegator.clone()),
+        &permit.expiry_ledger,
+    );
+
+    permit.delegator.clone()
+}

--- a/contracts/token-votes/src/delegation_sig_tests.rs
+++ b/contracts/token-votes/src/delegation_sig_tests.rs
@@ -1,0 +1,540 @@
+//! Tests for the signed-delegation (`delegate_by_sig`) flow (issue #772).
+//!
+//! Verification is delegated to Soroban's native authorization framework
+//! (see delegation_sig.rs for why), so these tests exercise real
+//! `Address::require_auth_for_args` checks via `env.mock_auths(..)` rather
+//! than a manually-supplied signature blob. `mock_auths` still enforces that
+//! *some* address authorized *exactly* the given invocation/args — it does
+//! not bypass the "who authorized what" check, only the underlying Ed25519
+//! cryptography (which is the SDK's own responsibility, not this
+//! contract's). "Invalid signature" is therefore tested as "no matching
+//! authorization was provided", which is exactly how an invalid off-chain
+//! signature manifests once a relayer submits it on-chain.
+
+use crate::{
+    delegation_sig::DelegationPermit, DataKey, TokenVotesContract, TokenVotesContractClient,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Events as _, Ledger as _, MockAuth, MockAuthInvoke},
+    token, Address, BytesN, Env, IntoVal,
+};
+
+fn setup(env: &Env, admin: &Address) -> (Address, Address) {
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_addr = sac.address();
+    let contract_id = env.register(TokenVotesContract, ());
+    let client = TokenVotesContractClient::new(env, &contract_id);
+    client.initialize(admin, &token_addr);
+    (contract_id, token_addr)
+}
+
+fn make_permit(
+    env: &Env,
+    contract_id: &Address,
+    delegator: &Address,
+    delegatee: &Address,
+    nonce: u64,
+    expiry_ledger: u32,
+) -> DelegationPermit {
+    DelegationPermit {
+        delegator: delegator.clone(),
+        delegatee: delegatee.clone(),
+        nonce,
+        expiry_ledger,
+        chain_id: env.ledger().network_id(),
+        contract_id: contract_id.clone(),
+    }
+}
+
+#[test]
+fn test_delegate_by_sig_applies_delegation_with_valid_signature() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+    let relayer = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    let sac_client = token::StellarAssetClient::new(&env, &token_addr);
+    sac_client.mint(&delegator, &1000i128);
+
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    let permit = make_permit(&env, &contract_id, &delegator, &delegatee, 0, 200);
+
+    let new_nonce = client.delegate_by_sig(&relayer, &permit);
+
+    assert_eq!(new_nonce, 1);
+    assert_eq!(client.get_votes(&delegatee), 1000);
+    assert_eq!(client.delegates(&delegator), Some(delegatee));
+    assert_eq!(client.nonce(&delegator), 1);
+    assert!(client.is_nonce_used(&delegator, &0));
+}
+
+#[test]
+#[should_panic]
+fn test_delegate_by_sig_reverts_on_invalid_signature() {
+    let env = Env::default();
+    // No mock_all_auths(), and no mock_auths() supplied at all: the
+    // delegator never authorized anything, which is what an invalid or
+    // missing off-chain signature looks like once submitted on-chain.
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+    let relayer = Address::generate(&env);
+
+    let (contract_id, _token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+
+    let permit = make_permit(&env, &contract_id, &delegator, &delegatee, 0, 1000);
+    client.delegate_by_sig(&relayer, &permit);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #12)")]
+fn test_delegate_by_sig_reverts_on_expired_permit() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+    let relayer = Address::generate(&env);
+
+    let (contract_id, _token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+
+    env.ledger().with_mut(|l| l.sequence_number = 500);
+    let permit = make_permit(&env, &contract_id, &delegator, &delegatee, 0, 100);
+
+    client.delegate_by_sig(&relayer, &permit);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #11)")]
+fn test_delegate_by_sig_reverts_on_already_used_nonce() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+    let relayer = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    let sac_client = token::StellarAssetClient::new(&env, &token_addr);
+    sac_client.mint(&delegator, &1000i128);
+
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    let permit = make_permit(&env, &contract_id, &delegator, &delegatee, 0, 1000);
+    client.delegate_by_sig(&relayer, &permit);
+
+    // Replay the exact same (already-consumed) permit.
+    client.delegate_by_sig(&relayer, &permit);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #15)")]
+fn test_delegate_by_sig_reverts_on_wrong_chain_id() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+    let relayer = Address::generate(&env);
+
+    let (contract_id, _token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+
+    let mut permit = make_permit(&env, &contract_id, &delegator, &delegatee, 0, 1000);
+    permit.chain_id = BytesN::from_array(&env, &[9u8; 32]);
+
+    client.delegate_by_sig(&relayer, &permit);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #16)")]
+fn test_delegate_by_sig_reverts_on_wrong_contract_id() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+    let relayer = Address::generate(&env);
+    let other_contract = Address::generate(&env);
+
+    let (contract_id, _token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+
+    let mut permit = make_permit(&env, &contract_id, &delegator, &delegatee, 0, 1000);
+    permit.contract_id = other_contract;
+
+    client.delegate_by_sig(&relayer, &permit);
+}
+
+#[test]
+fn test_delegate_batch_by_sig_applies_all_delegations() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let delegator1 = Address::generate(&env);
+    let delegator2 = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+    let relayer = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    let sac_client = token::StellarAssetClient::new(&env, &token_addr);
+    sac_client.mint(&delegator1, &300i128);
+    sac_client.mint(&delegator2, &700i128);
+
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    let permit1 = make_permit(&env, &contract_id, &delegator1, &delegatee, 0, 1000);
+    let permit2 = make_permit(&env, &contract_id, &delegator2, &delegatee, 0, 1000);
+
+    client.delegate_batch_by_sig(
+        &relayer,
+        &soroban_sdk::vec![&env, permit1, permit2],
+    );
+
+    assert_eq!(client.get_votes(&delegatee), 1000);
+    assert_eq!(client.nonce(&delegator1), 1);
+    assert_eq!(client.nonce(&delegator2), 1);
+}
+
+#[test]
+fn test_delegate_batch_by_sig_partial_failure_reverts_all() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let delegator1 = Address::generate(&env);
+    let delegator2 = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+    let relayer = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    let sac_client = token::StellarAssetClient::new(&env, &token_addr);
+    sac_client.mint(&delegator1, &300i128);
+    sac_client.mint(&delegator2, &700i128);
+
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    let permit1 = make_permit(&env, &contract_id, &delegator1, &delegatee, 0, 1000);
+    // Second permit has an already-expired ledger, so the batch must fail.
+    let bad_permit2 = make_permit(&env, &contract_id, &delegator2, &delegatee, 0, 1);
+
+    let result = client.try_delegate_batch_by_sig(
+        &relayer,
+        &soroban_sdk::vec![&env, permit1, bad_permit2],
+    );
+    assert!(result.is_err());
+
+    // Nothing from the batch should have been applied — including delegator1,
+    // who appeared earlier in the list and would otherwise have succeeded.
+    assert_eq!(client.get_votes(&delegatee), 0);
+    assert_eq!(client.nonce(&delegator1), 0);
+    assert_eq!(client.delegates(&delegator1), None);
+}
+
+#[test]
+fn test_invalidate_all_permits_blocks_old_nonces() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+    let relayer = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    let sac_client = token::StellarAssetClient::new(&env, &token_addr);
+    sac_client.mint(&delegator, &1000i128);
+
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    // Pre-sign a permit at nonce 0, but don't submit it yet.
+    let stale_permit = make_permit(&env, &contract_id, &delegator, &delegatee, 0, 1000);
+
+    client.invalidate_all_permits(&delegator);
+    assert!(client.nonce(&delegator) > 0);
+
+    let result = client.try_delegate_by_sig(&relayer, &stale_permit);
+    assert!(result.is_err());
+    assert_eq!(client.delegates(&delegator), None);
+}
+
+#[test]
+fn test_nonce_increments_after_each_delegation() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+    let relayer = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    let sac_client = token::StellarAssetClient::new(&env, &token_addr);
+    sac_client.mint(&delegator, &1000i128);
+
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    assert_eq!(client.nonce(&delegator), 0);
+
+    let permit0 = make_permit(&env, &contract_id, &delegator, &delegatee, 0, 1000);
+    client.delegate_by_sig(&relayer, &permit0);
+    assert_eq!(client.nonce(&delegator), 1);
+
+    let permit1 = make_permit(&env, &contract_id, &delegator, &delegatee, 1, 1000);
+    client.delegate_by_sig(&relayer, &permit1);
+    assert_eq!(client.nonce(&delegator), 2);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #14)")]
+fn test_relayer_whitelist_blocks_non_whitelisted() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+    let relayer = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    let sac_client = token::StellarAssetClient::new(&env, &token_addr);
+    sac_client.mint(&delegator, &1000i128);
+
+    client.set_relayer_whitelist_enabled(&admin, &true);
+    assert!(!client.is_relayer_allowed(&relayer));
+
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    let permit = make_permit(&env, &contract_id, &delegator, &delegatee, 0, 1000);
+    client.delegate_by_sig(&relayer, &permit);
+}
+
+#[test]
+fn test_relayer_whitelist_disabled_allows_all() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+    let relayer = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    let sac_client = token::StellarAssetClient::new(&env, &token_addr);
+    sac_client.mint(&delegator, &1000i128);
+
+    // Whitelist is disabled by default (see initialize()) — any relayer,
+    // whitelisted or not, may submit a permit.
+    assert!(client.is_relayer_allowed(&relayer));
+
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    let permit = make_permit(&env, &contract_id, &delegator, &delegatee, 0, 1000);
+    client.delegate_by_sig(&relayer, &permit);
+
+    assert_eq!(client.get_votes(&delegatee), 1000);
+}
+
+#[test]
+fn test_relayer_whitelist_enabled_allows_whitelisted_relayer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+    let relayer = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    let sac_client = token::StellarAssetClient::new(&env, &token_addr);
+    sac_client.mint(&delegator, &1000i128);
+
+    client.set_relayer_whitelist_enabled(&admin, &true);
+    client.set_relayer_whitelisted(&admin, &relayer, &true);
+    assert!(client.is_relayer_allowed(&relayer));
+
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    let permit = make_permit(&env, &contract_id, &delegator, &delegatee, 0, 1000);
+    client.delegate_by_sig(&relayer, &permit);
+
+    assert_eq!(client.get_votes(&delegatee), 1000);
+}
+
+#[test]
+fn test_domain_separator_unique_per_contract_instance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (contract_id_a, _) = setup(&env, &admin);
+    let (contract_id_b, _) = setup(&env, &admin);
+
+    let client_a = TokenVotesContractClient::new(&env, &contract_id_a);
+    let client_b = TokenVotesContractClient::new(&env, &contract_id_b);
+
+    assert_ne!(client_a.domain_separator(), client_b.domain_separator());
+}
+
+#[test]
+fn test_compute_permit_hash_matches_on_chain_result() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+
+    let (contract_id, _token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+
+    let permit = make_permit(&env, &contract_id, &delegator, &delegatee, 0, 1000);
+
+    // Deterministic: recomputing the hash for the same permit yields the
+    // same digest every time, matching what an off-chain client computes
+    // via the same domain-separator + XDR-encoding scheme.
+    let hash1 = client.compute_permit_hash(&permit);
+    let hash2 = client.compute_permit_hash(&permit);
+    assert_eq!(hash1, hash2);
+
+    // Any change to the permit changes the hash.
+    let mut different = permit.clone();
+    different.nonce = 1;
+    assert_ne!(hash1, client.compute_permit_hash(&different));
+}
+
+#[test]
+fn test_invalidate_all_permits_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let (contract_id, _token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+
+    client.invalidate_all_permits(&delegator);
+
+    let events = env.events().all();
+    let found = events.iter().any(|e| e.0 == contract_id);
+    assert!(found);
+}
+
+#[test]
+fn test_delegation_permit_expiry_tracks_latest_permit() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+    let relayer = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    let sac_client = token::StellarAssetClient::new(&env, &token_addr);
+    sac_client.mint(&delegator, &1000i128);
+
+    assert_eq!(client.delegation_permit_expiry(&delegator), None);
+
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    let permit = make_permit(&env, &contract_id, &delegator, &delegatee, 0, 12345);
+    client.delegate_by_sig(&relayer, &permit);
+
+    assert_eq!(client.delegation_permit_expiry(&delegator), Some(12345));
+}
+
+/// A signed authorization is scoped to the exact entrypoint that was
+/// executing when `require_auth_for_args` was called
+/// (`delegate_by_sig` vs `delegate_batch_by_sig`). An off-chain client must
+/// therefore sign permits differently depending on which entrypoint they'll
+/// be submitted through — this test pins down that requirement so the SDK's
+/// `signDelegationPermit({ forBatch })` flag doesn't silently drift from
+/// what the contract actually enforces.
+#[test]
+#[should_panic]
+fn test_permit_authorized_for_single_cannot_be_used_in_batch() {
+    let env = Env::default();
+
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+    let relayer = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    let sac_client = token::StellarAssetClient::new(&env, &token_addr);
+    sac_client.mint(&delegator, &1000i128);
+
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    let permit = make_permit(&env, &contract_id, &delegator, &delegatee, 0, 1000);
+
+    // Mock an authorization scoped to `delegate_by_sig`, then try to spend
+    // it via `delegate_batch_by_sig` instead — the entrypoint name in the
+    // authorized invocation tree won't match, so this must fail even though
+    // the permit contents are otherwise perfectly valid.
+    env.mock_auths(&[
+        MockAuth {
+            address: &delegator,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "delegate_by_sig",
+                args: soroban_sdk::vec![&env, permit.clone().into_val(&env)],
+                sub_invokes: &[],
+            },
+        },
+        MockAuth {
+            address: &relayer,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "delegate_batch_by_sig",
+                args: (relayer.clone(), soroban_sdk::vec![&env, permit.clone()]).into_val(&env),
+                sub_invokes: &[],
+            },
+        },
+    ]);
+
+    client.delegate_batch_by_sig(&relayer, &soroban_sdk::vec![&env, permit]);
+}
+
+// Sanity check that the storage keys requested in issue #772 actually exist
+// and round-trip through the contract's own instance/persistent storage.
+#[test]
+fn test_used_nonce_storage_key_round_trips() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+    let relayer = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    let sac_client = token::StellarAssetClient::new(&env, &token_addr);
+    sac_client.mint(&delegator, &1000i128);
+
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    let permit = make_permit(&env, &contract_id, &delegator, &delegatee, 0, 1000);
+    client.delegate_by_sig(&relayer, &permit);
+
+    let used: bool = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::UsedNonce(delegator.clone(), 0))
+            .unwrap()
+    });
+    assert!(used);
+}

--- a/contracts/token-votes/src/error.rs
+++ b/contracts/token-votes/src/error.rs
@@ -1,0 +1,26 @@
+use soroban_sdk::contracterror;
+
+/// Error codes for the token-votes contract.
+///
+/// Codes 1-9 are reserved for delegation/checkpoint invariants that today
+/// panic via `assert!`/`expect` (see lib.rs); codes 10-16 cover the
+/// signed-delegation (`delegate_by_sig`) flow introduced for issue #772.
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum TokenVotesError {
+    /// Reserved for parity with the numbering requested in issue #772.
+    ///
+    /// Not raised directly: an invalid `delegate_by_sig` signature is
+    /// rejected by Soroban's native authorization framework (a host-level
+    /// auth trap) before contract code regains control, because
+    /// verification is delegated to `Address::require_auth_for_args`
+    /// rather than a manual `ed25519_verify` call (see delegation_sig.rs).
+    InvalidSignature = 10,
+    NonceAlreadyUsed = 11,
+    PermitExpired = 12,
+    InvalidDelegationPermit = 13,
+    RelayerNotWhitelisted = 14,
+    InvalidChainId = 15,
+    InvalidContractId = 16,
+}

--- a/contracts/token-votes/src/events.rs
+++ b/contracts/token-votes/src/events.rs
@@ -1,0 +1,77 @@
+use soroban_sdk::{Address, Env, Symbol};
+
+pub const DELEGATED_BY_SIG_TOPIC: &str = "DelegatedBySig";
+pub const PERMITS_INVALIDATED_TOPIC: &str = "PermitsInvalidated";
+pub const RELAYER_WHITELIST_UPDATED_TOPIC: &str = "RelayerWhitelistUpdated";
+
+#[derive(Clone)]
+#[soroban_sdk::contracttype]
+pub struct DelegatedBySigEvent {
+    pub delegator: Address,
+    pub delegatee: Address,
+    pub relayer: Address,
+    pub nonce: u64,
+}
+
+#[derive(Clone)]
+#[soroban_sdk::contracttype]
+pub struct PermitsInvalidatedEvent {
+    pub delegator: Address,
+    pub new_nonce: u64,
+}
+
+#[derive(Clone)]
+#[soroban_sdk::contracttype]
+pub struct RelayerWhitelistUpdatedEvent {
+    pub relayer: Address,
+    pub whitelisted: bool,
+}
+
+/// Emitted whenever a signed delegation permit is applied on-chain via
+/// `delegate_by_sig` or `delegate_batch_by_sig`.
+pub fn emit_delegated_by_sig(
+    env: &Env,
+    delegator: &Address,
+    delegatee: &Address,
+    relayer: &Address,
+    nonce: u64,
+) {
+    env.events().publish(
+        (Symbol::new(env, DELEGATED_BY_SIG_TOPIC), delegator.clone()),
+        DelegatedBySigEvent {
+            delegator: delegator.clone(),
+            delegatee: delegatee.clone(),
+            relayer: relayer.clone(),
+            nonce,
+        },
+    );
+}
+
+/// Emitted when a delegator invalidates all of their outstanding signed
+/// permits by bumping their nonce past anything they may have already signed.
+pub fn emit_permits_invalidated(env: &Env, delegator: &Address, new_nonce: u64) {
+    env.events().publish(
+        (
+            Symbol::new(env, PERMITS_INVALIDATED_TOPIC),
+            delegator.clone(),
+        ),
+        PermitsInvalidatedEvent {
+            delegator: delegator.clone(),
+            new_nonce,
+        },
+    );
+}
+
+/// Emitted when the admin adds/removes a relayer from the whitelist.
+pub fn emit_relayer_whitelist_updated(env: &Env, relayer: &Address, whitelisted: bool) {
+    env.events().publish(
+        (
+            Symbol::new(env, RELAYER_WHITELIST_UPDATED_TOPIC),
+            relayer.clone(),
+        ),
+        RelayerWhitelistUpdatedEvent {
+            relayer: relayer.clone(),
+            whitelisted,
+        },
+    );
+}

--- a/contracts/token-votes/src/lib.rs
+++ b/contracts/token-votes/src/lib.rs
@@ -4,6 +4,15 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env, Symbol, Vec,
 };
 
+mod delegation_sig;
+mod error;
+mod events;
+
+pub use delegation_sig::DelegationPermit;
+pub use error::TokenVotesError;
+
+#[cfg(test)]
+mod delegation_sig_tests;
 #[cfg(test)]
 mod load_tests;
 
@@ -37,6 +46,11 @@ pub enum DataKey {
     DelegatorRecord(Address),  // delegator -> DelegatorRecord
     TimeWeightEnabled,         // bool
     TimeWeightScale,           // u32
+    DomainSeparator,                  // BytesN<32>: cached at init
+    UsedNonce(Address, u64),          // (delegator, nonce) -> bool: replay protection
+    DelegationPermitExpiry(Address),  // delegator -> u32: latest permit expiry
+    RelayerWhitelist(Address),        // relayer -> bool: optional whitelist
+    RelayerWhitelistEnabled,          // bool
 }
 
 #[contract]
@@ -61,6 +75,11 @@ impl TokenVotesContract {
         env.storage()
             .instance()
             .set(&DataKey::TimeWeightScale, &4204800u32);
+        // Relayer whitelist is opt-in.
+        env.storage()
+            .instance()
+            .set(&DataKey::RelayerWhitelistEnabled, &false);
+        delegation_sig::init_domain_separator(&env);
     }
 
     /// Delegate voting power from caller to delegatee.
@@ -595,47 +614,118 @@ impl TokenVotesContract {
         checkpoints.get(low - 1).unwrap()
     }
 
-    /// Delegate voting power by signature (gasless for the token holder).
+    /// Delegate via an off-chain signed [`DelegationPermit`] (gasless for the
+    /// token holder). Callable by any relayer; the relayer pays the fee and
+    /// must authorize the call, but the permit itself is relayer-agnostic
+    /// (see delegation_sig.rs for why).
     ///
-    /// Uses Soroban's native authorization framework (`owner.require_auth()`) to
-    /// verify the delegation. This is the correct approach for Soroban contracts
-    /// because Address types do not directly expose the underlying Ed25519 public
-    /// key needed for manual `ed25519_verify` calls (see ADR-005).
-    ///
-    /// Replay protection is provided by the nonce (must equal the stored nonce,
-    /// then incremented) and expiry (checked against current ledger timestamp).
-    ///
-    /// # Arguments
-    /// * `owner`     - The token holder authorising the delegation
-    /// * `delegatee` - The address to delegate voting power to
-    /// * `nonce`     - Must equal the owner's current stored nonce
-    /// * `expiry`    - Ledger timestamp after which the signature is invalid
-    /// * `signature` - Ed25519 signature (verified via Soroban auth framework)
-    pub fn delegate_by_sig(
-        env: Env,
-        owner: Address,
-        delegatee: Address,
-        nonce: u64,
-        expiry: u64,
-        _signature: BytesN<64>,
-    ) {
-        // Verify expiry against current ledger timestamp
-        let current_time = env.ledger().timestamp();
-        assert!(current_time <= expiry, "signature expired");
+    /// Returns the delegator's new nonce.
+    pub fn delegate_by_sig(env: Env, relayer: Address, permit: DelegationPermit) -> u64 {
+        relayer.require_auth();
+        if !delegation_sig::is_relayer_allowed(&env, &relayer) {
+            env.panic_with_error(TokenVotesError::RelayerNotWhitelisted);
+        }
 
-        // Verify and increment nonce (prevent replay)
-        let nonce_key = DataKey::Nonce(owner.clone());
-        let stored_nonce: u64 = env.storage().persistent().get(&nonce_key).unwrap_or(0);
-        assert!(nonce == stored_nonce, "invalid nonce");
-        env.storage()
-            .persistent()
-            .set(&nonce_key, &(stored_nonce + 1));
+        let delegator = delegation_sig::verify_delegation_permit(&env, &permit);
+        Self::apply_delegation(&env, delegator.clone(), permit.delegatee.clone());
 
-        // Use Soroban's native auth framework for signature verification.
-        // This correctly handles Ed25519 keys, multisig, and smart-wallet accounts
-        // without needing to extract the raw public key from an Address.
-        owner.require_auth();
-        Self::apply_delegation(&env, owner, delegatee);
+        events::emit_delegated_by_sig(&env, &delegator, &permit.delegatee, &relayer, permit.nonce);
+        delegation_sig::current_nonce(&env, &delegator)
+    }
+
+    /// Batch-delegate via multiple signed permits in a single transaction.
+    /// Atomic: if any permit fails verification, the entire batch (including
+    /// permits already applied earlier in the loop) is rolled back.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `permits` is empty.
+    pub fn delegate_batch_by_sig(env: Env, relayer: Address, permits: Vec<DelegationPermit>) {
+        assert!(!permits.is_empty(), "permits must not be empty");
+        relayer.require_auth();
+        if !delegation_sig::is_relayer_allowed(&env, &relayer) {
+            env.panic_with_error(TokenVotesError::RelayerNotWhitelisted);
+        }
+
+        for permit in permits.iter() {
+            let delegator = delegation_sig::verify_delegation_permit(&env, &permit);
+            Self::apply_delegation(&env, delegator.clone(), permit.delegatee.clone());
+            events::emit_delegated_by_sig(
+                &env,
+                &delegator,
+                &permit.delegatee,
+                &relayer,
+                permit.nonce,
+            );
+        }
+    }
+
+    /// Revoke all outstanding signed permits for `delegator` by bumping their
+    /// nonce past anything they may have already signed. Only the delegator
+    /// themself may call this.
+    pub fn invalidate_all_permits(env: Env, delegator: Address) {
+        delegator.require_auth();
+        let new_nonce = delegation_sig::invalidate_all_permits(&env, &delegator);
+        events::emit_permits_invalidated(&env, &delegator, new_nonce);
+    }
+
+    /// Get the current (next expected) nonce for a delegator.
+    pub fn nonce(env: Env, delegator: Address) -> u64 {
+        delegation_sig::current_nonce(&env, &delegator)
+    }
+
+    /// Compute the domain separator for this contract instance.
+    pub fn domain_separator(env: Env) -> BytesN<32> {
+        delegation_sig::domain_separator(&env)
+    }
+
+    /// Compute the full signed-message hash for a permit, for client-side
+    /// verification/tooling parity. See delegation_sig.rs for why this is
+    /// informational and not itself the on-chain signature check.
+    pub fn compute_permit_hash(env: Env, permit: DelegationPermit) -> BytesN<32> {
+        delegation_sig::compute_permit_hash(&env, &permit)
+    }
+
+    /// Check whether a nonce has already been used by a delegator.
+    pub fn is_nonce_used(env: Env, delegator: Address, nonce: u64) -> bool {
+        delegation_sig::is_nonce_used(&env, &delegator, nonce)
+    }
+
+    /// The `expiry_ledger` of the most recently applied signed permit for
+    /// `delegator`, if any.
+    pub fn delegation_permit_expiry(env: Env, delegator: Address) -> Option<u32> {
+        delegation_sig::delegation_permit_expiry(&env, &delegator)
+    }
+
+    /// Admin: enable or disable the relayer whitelist.
+    pub fn set_relayer_whitelist_enabled(env: Env, admin: Address, enabled: bool) {
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+        assert_eq!(admin, stored_admin, "unauthorized");
+        delegation_sig::set_relayer_whitelist_enabled(&env, enabled);
+    }
+
+    /// Admin: add or remove a relayer from the whitelist.
+    pub fn set_relayer_whitelisted(env: Env, admin: Address, relayer: Address, whitelisted: bool) {
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+        assert_eq!(admin, stored_admin, "unauthorized");
+        delegation_sig::set_relayer_whitelisted(&env, &relayer, whitelisted);
+        events::emit_relayer_whitelist_updated(&env, &relayer, whitelisted);
+    }
+
+    /// Check if a relayer is whitelisted (or if the whitelist is disabled,
+    /// in which case every relayer is allowed).
+    pub fn is_relayer_allowed(env: Env, relayer: Address) -> bool {
+        delegation_sig::is_relayer_allowed(&env, &relayer)
     }
 
     /// Set the checkpoint retention period (admin only).
@@ -1745,114 +1835,10 @@ mod tests {
         assert!(pruned > 0, "expected some checkpoints pruned");
     }
 
-    // \u2014\u2014 delegate_by_sig tests (issue #216) \u2014\u2014\u2014\u2014\u2014\u2014\u2014\u2014\u2014\u2014\u2014\u2014\u2014\u2014\u2014\u2014\u2014\u2014
-
-    /// Valid delegation via delegate_by_sig: correct nonce, unexpired, auth passes.
-    #[test]
-    fn test_delegate_by_sig_valid() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let admin = Address::generate(&env);
-        let owner = Address::generate(&env);
-        let delegatee = Address::generate(&env);
-
-        let (contract_id, token_addr) = setup(&env, &admin);
-        let client = TokenVotesContractClient::new(&env, &contract_id);
-        let sac_client = token::StellarAssetClient::new(&env, &token_addr);
-        sac_client.mint(&owner, &1000i128);
-
-        // Set ledger timestamp so expiry is in the future
-        env.ledger().with_mut(|l| l.timestamp = 100);
-
-        let nonce = 0u64;
-        let expiry = 200u64;
-        let dummy_sig = BytesN::from_array(&env, &[0u8; 64]);
-
-        client.delegate_by_sig(&owner, &delegatee, &nonce, &expiry, &dummy_sig);
-
-        // Delegation should have been applied
-        assert_eq!(client.get_votes(&delegatee), 1000);
-        assert_eq!(client.delegates(&owner), Some(delegatee.clone()));
-    }
-
-    /// Expired signature must be rejected.
-    #[test]
-    #[should_panic(expected = "signature expired")]
-    fn test_delegate_by_sig_expired() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let admin = Address::generate(&env);
-        let owner = Address::generate(&env);
-        let delegatee = Address::generate(&env);
-
-        let (contract_id, _) = setup(&env, &admin);
-        let client = TokenVotesContractClient::new(&env, &contract_id);
-
-        env.ledger().with_mut(|l| l.timestamp = 500);
-
-        let dummy_sig = BytesN::from_array(&env, &[0u8; 64]);
-        // expiry is in the past
-        client.delegate_by_sig(&owner, &delegatee, &0u64, &100u64, &dummy_sig);
-    }
-
-    /// Replayed nonce must be rejected.
-    #[test]
-    #[should_panic(expected = "invalid nonce")]
-    fn test_delegate_by_sig_replayed_nonce() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let admin = Address::generate(&env);
-        let owner = Address::generate(&env);
-        let delegatee = Address::generate(&env);
-
-        let (contract_id, token_addr) = setup(&env, &admin);
-        let client = TokenVotesContractClient::new(&env, &contract_id);
-        let sac_client = token::StellarAssetClient::new(&env, &token_addr);
-        sac_client.mint(&owner, &500i128);
-
-        env.ledger().with_mut(|l| l.timestamp = 100);
-        let dummy_sig = BytesN::from_array(&env, &[0u8; 64]);
-
-        // First call with nonce=0 succeeds
-        client.delegate_by_sig(&owner, &delegatee, &0u64, &9999u64, &dummy_sig);
-
-        // Second call with nonce=0 must fail (nonce is now 1)
-        client.delegate_by_sig(&owner, &delegatee, &0u64, &9999u64, &dummy_sig);
-    }
-
-    /// Nonce is incremented after a successful delegate_by_sig call.
-    #[test]
-    fn test_delegate_by_sig_nonce_increments() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let admin = Address::generate(&env);
-        let owner = Address::generate(&env);
-        let delegatee1 = Address::generate(&env);
-        let delegatee2 = Address::generate(&env);
-
-        let (contract_id, token_addr) = setup(&env, &admin);
-        let client = TokenVotesContractClient::new(&env, &contract_id);
-        let sac_client = token::StellarAssetClient::new(&env, &token_addr);
-        sac_client.mint(&owner, &300i128);
-
-        env.ledger().with_mut(|l| l.timestamp = 1);
-        let dummy_sig = BytesN::from_array(&env, &[0u8; 64]);
-
-        // nonce=0 succeeds
-        client.delegate_by_sig(&owner, &delegatee1, &0u64, &9999u64, &dummy_sig);
-        assert_eq!(client.get_votes(&delegatee1), 300);
-
-        env.ledger().with_mut(|l| l.sequence_number += 1);
-
-        // nonce=1 succeeds (re-delegation)
-        client.delegate_by_sig(&owner, &delegatee2, &1u64, &9999u64, &dummy_sig);
-        assert_eq!(client.get_votes(&delegatee1), 0);
-        assert_eq!(client.get_votes(&delegatee2), 300);
-    }
+    // Old delegate_by_sig tests (issue #216) removed: delegate_by_sig was
+    // replaced by the DelegationPermit-based flow in issue #772 (see
+    // delegation_sig_tests.rs for equivalent + expanded coverage of the new
+    // signature, expiry, and nonce-replay behavior).
 
     #[test]
     fn test_new_delegator_start_ledger_is_current_ledger() {

--- a/sdk/src/delegation-sig.ts
+++ b/sdk/src/delegation-sig.ts
@@ -1,0 +1,452 @@
+/**
+ * DelegationSigClient — signed vote delegation (issue #772), equivalent to
+ * Ethereum's EIP-712 `delegateBySig`.
+ *
+ * A token holder signs a {@link DelegationPermit} off-chain with their
+ * Keypair (no transaction, no fee). A relayer then submits it on-chain via
+ * `delegate_by_sig` / `delegate_batch_by_sig`, paying the fee.
+ *
+ * ## Why this signs a Soroban authorization entry, not a raw signature
+ *
+ * The token-votes contract verifies permits through Soroban's native
+ * authorization framework (`Address::require_auth_for_args`) rather than a
+ * manual `ed25519_verify`, because Soroban `Address`es are opaque and don't
+ * expose a raw public key on-chain — see the doc comment on
+ * `contracts/token-votes/src/delegation_sig.rs` for the full rationale. In
+ * practice this means "the signature" a delegator produces here is a signed
+ * `SorobanAuthorizationEntry` (base64 XDR), not a 64-byte blob. It's still a
+ * single offline signing step from the delegator's perspective — they call
+ * {@link DelegationSigClient.signDelegationPermit} once and hand the result
+ * to a relayer.
+ *
+ * The signed entry is scoped to `(delegate_by_sig | delegate_batch_by_sig,
+ * (permit,))` — deliberately *not* bound to a specific relayer address — so
+ * any relayer can submit it. It *is* bound to which entrypoint it'll be
+ * submitted through, so pass `forBatch: true` when signing for
+ * {@link DelegationSigClient.delegateBatchBySig}.
+ */
+import {
+  Contract,
+  SorobanRpc,
+  TransactionBuilder,
+  Networks,
+  BASE_FEE,
+  Keypair,
+  Operation,
+  authorizeInvocation,
+  nativeToScVal,
+  scValToNative,
+  hash,
+  xdr,
+} from "@stellar/stellar-sdk";
+import { DelegationPermit, Network } from "./types";
+import { VotesError, VotesErrorCode, parseVotesError } from "./errors";
+import { withRetry, isNetworkError } from "./utils";
+
+const RPC_URLS: Record<Network, string> = {
+  mainnet: "https://soroban-rpc.mainnet.stellar.gateway.fm",
+  testnet: "https://soroban-testnet.stellar.org",
+  futurenet: "https://rpc-futurenet.stellar.org",
+};
+
+const NETWORK_PASSPHRASES: Record<Network, string> = {
+  mainnet: Networks.PUBLIC,
+  testnet: Networks.TESTNET,
+  futurenet: Networks.FUTURENET,
+};
+
+const SINGLE_FN = "delegate_by_sig";
+const BATCH_FN = "delegate_batch_by_sig";
+
+export interface DelegationSigConfig {
+  /** Contract address of the token-votes contract. */
+  votesAddress: string;
+  network: Network;
+  /** RPC URL override (optional — defaults to public RPC for the network). */
+  rpcUrl?: string;
+  /** Optional funded classic account used for read-only simulation calls. */
+  simulationAccount?: string;
+  maxAttempts?: number;
+  baseDelayMs?: number;
+}
+
+export interface DelegationTxResult {
+  hash: string;
+}
+
+/**
+ * DelegationSigClient — interact with the token-votes contract's signed
+ * ("gasless") delegation flow.
+ */
+export class DelegationSigClient {
+  private readonly server: SorobanRpc.Server;
+  private readonly contract: Contract;
+  private readonly networkPassphrase: string;
+
+  constructor(private readonly config: DelegationSigConfig) {
+    const rpcUrl = config.rpcUrl ?? RPC_URLS[config.network];
+    this.server = new SorobanRpc.Server(rpcUrl, { allowHttp: false });
+    this.contract = new Contract(config.votesAddress);
+    this.networkPassphrase = NETWORK_PASSPHRASES[config.network];
+  }
+
+  private async retry<T>(fn: () => Promise<T>): Promise<T> {
+    return withRetry(fn, {
+      maxAttempts: this.config.maxAttempts,
+      baseDelayMs: this.config.baseDelayMs,
+      retryOn: isNetworkError,
+    });
+  }
+
+  private readAccount(fallback?: string): string {
+    return (
+      this.config.simulationAccount ?? fallback ?? this.contract.contractId()
+    );
+  }
+
+  /**
+   * The current network's chain ID: `sha256(networkPassphrase)`. Matches
+   * `env.ledger().network_id()` on-chain and is used to populate
+   * `DelegationPermit.chainId`.
+   */
+  chainId(): Buffer {
+    return hash(Buffer.from(this.networkPassphrase));
+  }
+
+  /** The most recent ledger sequence, for computing an `expiryLedger`. */
+  async currentLedger(): Promise<number> {
+    return this.retry(async () => (await this.server.getLatestLedger()).sequence);
+  }
+
+  /**
+   * Build the ScVal representation of a permit.
+   *
+   * Struct fields are serialized as a map sorted alphabetically by field
+   * name — that's soroban-sdk's `#[contracttype]` derive convention for
+   * structs — so the key order below (chain_id, contract_id, delegatee,
+   * delegator, expiry_ledger, nonce) must match exactly, or the resulting
+   * ScVal won't equal what the contract expects.
+   */
+  private permitToScVal(permit: DelegationPermit): xdr.ScVal {
+    return nativeToScVal(
+      {
+        chain_id: permit.chainId,
+        contract_id: permit.contractId,
+        delegatee: permit.delegatee,
+        delegator: permit.delegator,
+        expiry_ledger: permit.expiryLedger,
+        nonce: permit.nonce,
+      },
+      {
+        type: {
+          chain_id: ["symbol", "bytes"],
+          contract_id: ["symbol", "address"],
+          delegatee: ["symbol", "address"],
+          delegator: ["symbol", "address"],
+          expiry_ledger: ["symbol", "u32"],
+          nonce: ["symbol", "u64"],
+        },
+      },
+    );
+  }
+
+  private async simulateRead<T>(
+    fnName: string,
+    args: xdr.ScVal[],
+    fallback: T,
+    decode: (val: xdr.ScVal) => T,
+  ): Promise<T> {
+    return this.retry(async () => {
+      const result = await this.server.simulateTransaction(
+        new TransactionBuilder(
+          await this.server.getAccount(this.readAccount()),
+          { fee: BASE_FEE, networkPassphrase: this.networkPassphrase },
+        )
+          .addOperation(this.contract.call(fnName, ...args))
+          .setTimeout(30)
+          .build(),
+      );
+
+      if (SorobanRpc.Api.isSimulationError(result)) return fallback;
+      const raw = (result as SorobanRpc.Api.SimulateTransactionSuccessResponse)
+        .result?.retval;
+      return raw ? decode(raw) : fallback;
+    });
+  }
+
+  /** Get the current (next expected) nonce for a delegator. */
+  async getNonce(delegator: string): Promise<bigint> {
+    return this.simulateRead(
+      "nonce",
+      [nativeToScVal(delegator, { type: "address" })],
+      0n,
+      (raw) => BigInt(scValToNative(raw)),
+    );
+  }
+
+  /** Check whether a nonce has already been used by a delegator. */
+  async isNonceUsed(delegator: string, nonce: bigint): Promise<boolean> {
+    return this.simulateRead(
+      "is_nonce_used",
+      [
+        nativeToScVal(delegator, { type: "address" }),
+        nativeToScVal(nonce, { type: "u64" }),
+      ],
+      false,
+      (raw) => Boolean(scValToNative(raw)),
+    );
+  }
+
+  /** Compute the domain separator for this contract instance. */
+  async getDomainSeparator(): Promise<Buffer> {
+    return this.simulateRead(
+      "domain_separator",
+      [],
+      Buffer.alloc(32),
+      (raw) => Buffer.from(scValToNative(raw)),
+    );
+  }
+
+  /**
+   * Compute the on-chain signed-message hash for a permit — informational
+   * parity with the contract's `compute_permit_hash`, useful for relayer-side
+   * permit fingerprinting/deduplication. Not itself used for signature
+   * verification (see module docs).
+   */
+  async computePermitHash(permit: DelegationPermit): Promise<Buffer> {
+    return this.simulateRead(
+      "compute_permit_hash",
+      [this.permitToScVal(permit)],
+      Buffer.alloc(32),
+      (raw) => Buffer.from(scValToNative(raw)),
+    );
+  }
+
+  /** Check whether a relayer may submit signed permits right now. */
+  async isRelayerAllowed(relayer: string): Promise<boolean> {
+    return this.simulateRead(
+      "is_relayer_allowed",
+      [nativeToScVal(relayer, { type: "address" })],
+      true,
+      (raw) => Boolean(scValToNative(raw)),
+    );
+  }
+
+  /** The `expiryLedger` of the most recently applied permit for `delegator`, if any. */
+  async getDelegationPermitExpiry(delegator: string): Promise<number | null> {
+    return this.simulateRead(
+      "delegation_permit_expiry",
+      [nativeToScVal(delegator, { type: "address" })],
+      null,
+      (raw) => {
+        const native = scValToNative(raw);
+        return native === null || native === undefined ? null : Number(native);
+      },
+    );
+  }
+
+  /**
+   * Sign a delegation permit off-chain. No transaction is built or
+   * submitted, and the delegator pays nothing — a relayer collects the
+   * returned `{ permit, authEntry }` and later calls
+   * {@link delegateBySig} or {@link delegateBatchBySig}.
+   *
+   * `delegator` accepts either a raw `Keypair` (server-side/testing)
+   * or a `{ publicKey, sign }` pair, where `sign` delegates to a connected
+   * browser wallet's auth-entry signing (e.g. `kit.signAuthEntry` from
+   * `@creit.tech/stellar-wallets-kit` / Freighter) — the wallet never needs
+   * to expose the raw private key.
+   *
+   * @param params.forBatch - Pass `true` if this permit will be submitted
+   *   via {@link delegateBatchBySig} rather than {@link delegateBySig} — the
+   *   signed authorization is scoped to one specific entrypoint and cannot
+   *   be reused for the other.
+   */
+  async signDelegationPermit(params: {
+    delegator:
+      | Keypair
+      | {
+          publicKey: string;
+          sign: (preimage: xdr.HashIdPreimage) => Promise<Buffer>;
+        };
+    delegatee: string;
+    expiryLedger: number;
+    nonce?: bigint;
+    forBatch?: boolean;
+  }): Promise<{ permit: DelegationPermit; authEntry: string }> {
+    const delegatorPublicKey =
+      params.delegator instanceof Keypair
+        ? params.delegator.publicKey()
+        : params.delegator.publicKey;
+    const signer =
+      params.delegator instanceof Keypair
+        ? params.delegator
+        : params.delegator.sign;
+
+    const nonce = params.nonce ?? (await this.getNonce(delegatorPublicKey));
+
+    const permit: DelegationPermit = {
+      delegator: delegatorPublicKey,
+      delegatee: params.delegatee,
+      nonce,
+      expiryLedger: params.expiryLedger,
+      chainId: this.chainId(),
+      contractId: this.contract.contractId(),
+    };
+
+    const invocation = new xdr.SorobanAuthorizedInvocation({
+      function: xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(
+        new xdr.InvokeContractArgs({
+          contractAddress: this.contract.address().toScAddress(),
+          functionName: params.forBatch ? BATCH_FN : SINGLE_FN,
+          args: [this.permitToScVal(permit)],
+        }),
+      ),
+      subInvocations: [],
+    });
+
+    const signedEntry = await authorizeInvocation(
+      signer,
+      params.expiryLedger,
+      invocation,
+      delegatorPublicKey,
+      this.networkPassphrase,
+    );
+
+    return { permit, authEntry: signedEntry.toXDR("base64") };
+  }
+
+  /**
+   * Relayer: submit a signed permit on-chain. `relayer` pays the
+   * transaction fee and must sign the transaction; the delegator does not.
+   */
+  async delegateBySig(
+    relayer: Keypair,
+    permit: DelegationPermit,
+    authEntry: string,
+  ): Promise<DelegationTxResult> {
+    return this.retry(async () => {
+      const account = await this.server.getAccount(relayer.publicKey());
+      const entry = xdr.SorobanAuthorizationEntry.fromXDR(authEntry, "base64");
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(
+          Operation.invokeContractFunction({
+            contract: this.contract.contractId(),
+            function: SINGLE_FN,
+            args: [
+              nativeToScVal(relayer.publicKey(), { type: "address" }),
+              this.permitToScVal(permit),
+            ],
+            auth: [entry],
+          }),
+        )
+        .setTimeout(30)
+        .build();
+
+      const prepared = await this.server.prepareTransaction(tx);
+      prepared.sign(relayer);
+      const result = await this.server.sendTransaction(prepared);
+      if (result.status === "ERROR") {
+        throw parseVotesError(result);
+      }
+      return { hash: result.hash };
+    });
+  }
+
+  /**
+   * Relayer: submit multiple signed permits in a single transaction. Atomic
+   * — if any permit fails verification, none of them are applied. Every
+   * permit must have been signed with `forBatch: true`.
+   */
+  async delegateBatchBySig(
+    relayer: Keypair,
+    permits: DelegationPermit[],
+    authEntries: string[],
+  ): Promise<DelegationTxResult> {
+    if (permits.length === 0) {
+      throw new VotesError(
+        VotesErrorCode.InvalidDelegationPermit,
+        "permits must not be empty",
+      );
+    }
+    if (permits.length !== authEntries.length) {
+      throw new VotesError(
+        VotesErrorCode.InvalidDelegationPermit,
+        "permits and authEntries must have the same length",
+      );
+    }
+
+    return this.retry(async () => {
+      const account = await this.server.getAccount(relayer.publicKey());
+      const entries = authEntries.map((e) =>
+        xdr.SorobanAuthorizationEntry.fromXDR(e, "base64"),
+      );
+
+      const permitsScVal = nativeToScVal(
+        permits.map((p) => this.permitToScVal(p)),
+      );
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(
+          Operation.invokeContractFunction({
+            contract: this.contract.contractId(),
+            function: BATCH_FN,
+            args: [
+              nativeToScVal(relayer.publicKey(), { type: "address" }),
+              permitsScVal,
+            ],
+            auth: entries,
+          }),
+        )
+        .setTimeout(30)
+        .build();
+
+      const prepared = await this.server.prepareTransaction(tx);
+      prepared.sign(relayer);
+      const result = await this.server.sendTransaction(prepared);
+      if (result.status === "ERROR") {
+        throw parseVotesError(result);
+      }
+      return { hash: result.hash };
+    });
+  }
+
+  /**
+   * Invalidate all outstanding signed permits for `delegator` by bumping
+   * their nonce past anything they may have already signed. Only the
+   * delegator themself may call this — it requires their own signature.
+   */
+  async invalidateAllPermits(delegator: Keypair): Promise<DelegationTxResult> {
+    return this.retry(async () => {
+      const account = await this.server.getAccount(delegator.publicKey());
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(
+          this.contract.call(
+            "invalidate_all_permits",
+            nativeToScVal(delegator.publicKey(), { type: "address" }),
+          ),
+        )
+        .setTimeout(30)
+        .build();
+
+      const prepared = await this.server.prepareTransaction(tx);
+      prepared.sign(delegator);
+      const result = await this.server.sendTransaction(prepared);
+      if (result.status === "ERROR") {
+        throw parseVotesError(result);
+      }
+      return { hash: result.hash };
+    });
+  }
+}

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -178,10 +178,23 @@ export class TimelockError extends Error {
 /**
  * Error codes for the TokenVotes contract + SDK transport layer.
  *
- * The token-votes contract does not define a #[contracterror] enum, so all
- * codes here are SDK-level.
+ * Codes 10-16 mirror the on-chain `TokenVotesError` enum
+ * (contracts/token-votes/src/error.rs), introduced for signed delegation
+ * (issue #772). Codes 1-9 are reserved on-chain for delegation/checkpoint
+ * invariants that still panic via `assert!`/`expect` rather than a typed
+ * error. SDK-level codes start at 100.
  */
 export enum VotesErrorCode {
+  // On-chain contract errors (match contracts/token-votes/src/error.rs)
+  InvalidSignature = 10,
+  NonceAlreadyUsed = 11,
+  PermitExpired = 12,
+  InvalidDelegationPermit = 13,
+  RelayerNotWhitelisted = 14,
+  InvalidChainId = 15,
+  InvalidContractId = 16,
+
+  // SDK-level codes
   SimulationFailed = 100,
   TransactionFailed = 101,
   TransactionTimeout = 102,
@@ -190,6 +203,21 @@ export enum VotesErrorCode {
 }
 
 const VOTES_MESSAGES: Record<VotesErrorCode, string> = {
+  [VotesErrorCode.InvalidSignature]:
+    "Invalid or missing delegation signature",
+  [VotesErrorCode.NonceAlreadyUsed]:
+    "Permit nonce has already been used or invalidated",
+  [VotesErrorCode.PermitExpired]:
+    "Delegation permit has expired",
+  [VotesErrorCode.InvalidDelegationPermit]:
+    "Delegation permit is malformed or out of order",
+  [VotesErrorCode.RelayerNotWhitelisted]:
+    "Relayer is not whitelisted to submit signed permits",
+  [VotesErrorCode.InvalidChainId]:
+    "Permit was signed for a different network",
+  [VotesErrorCode.InvalidContractId]:
+    "Permit was signed for a different contract",
+
   [VotesErrorCode.SimulationFailed]: "Simulation failed",
   [VotesErrorCode.TransactionFailed]: "Transaction failed",
   [VotesErrorCode.TransactionTimeout]: "Transaction timed out",
@@ -428,6 +456,12 @@ export function parseVotesError(
   raw: SorobanRpcError | string | null | undefined,
   cause?: unknown,
 ): VotesError {
+  const contractCode = extractContractErrorCode(raw);
+  if (contractCode !== null && contractCode in VOTES_MESSAGES) {
+    const code = contractCode as VotesErrorCode;
+    return new VotesError(code, VOTES_MESSAGES[code], cause);
+  }
+
   if (hasErrorStatus(raw)) {
     return new VotesError(
       VotesErrorCode.TransactionFailed,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -16,6 +16,8 @@ export { GovernorClient, hashDescription, uploadProposalMetadata } from "./gover
 export type { MetadataUploadOptions } from "./governor";
 export { VotesClient } from "./votes";
 export type { TopDelegatesOptions, TopDelegatesResult } from "./votes";
+export { DelegationSigClient } from "./delegation-sig";
+export type { DelegationSigConfig, DelegationTxResult } from "./delegation-sig";
 export { FactoryClient } from "./factory";
 export type { GovernorEntry, DeploySettings } from "./factory";
 export { TimelockClient } from "./timelock";

--- a/sdk/src/types/index.ts
+++ b/sdk/src/types/index.ts
@@ -245,6 +245,20 @@ export interface DelegatorRecord {
   startLedger: number;
 }
 
+/**
+ * An off-chain-signed instruction to delegate voting power (issue #772).
+ * Mirrors `DelegationPermit` in contracts/token-votes/src/delegation_sig.rs.
+ */
+export interface DelegationPermit {
+  delegator: string;
+  delegatee: string;
+  nonce: bigint;
+  expiryLedger: number;
+  /** 32 raw bytes — the network ID (sha256 of the network passphrase). */
+  chainId: Buffer;
+  contractId: string;
+}
+
 export interface VoteGasEstimate {
   ok: boolean;
   cpuInsns?: string;

--- a/sdk/src/votes.ts
+++ b/sdk/src/votes.ts
@@ -617,50 +617,6 @@ export class VotesClient {
   }
 
   /**
-   * Delegate voting power by signature (gasless for the token holder).
-   *
-   * A relayer submits this on behalf of a token holder who signed a message
-   * off-chain. The holder only needs to sign, no gas required.
-   *
-   * @param owner - The token holder who signed the delegation message
-   * @param delegatee - The address to delegate voting power to
-   * @param nonce - Unique nonce to prevent replay attacks
-   * @param expiry - Unix timestamp after which the signature is invalid
-   * @param signature - Ed25519 signature over (owner, delegatee, nonce, expiry)
-   */
-  async delegateBySig(
-    owner: string,
-    delegatee: string,
-    nonce: bigint,
-    expiry: bigint,
-    signature: Buffer,
-  ): Promise<void> {
-    return this.retry(async () => {
-      const account = await this.server.getAccount(this.contract.contractId());
-
-      const tx = new TransactionBuilder(account, {
-        fee: BASE_FEE,
-        networkPassphrase: this.networkPassphrase,
-      })
-        .addOperation(
-          this.contract.call(
-            "delegate_by_sig",
-            nativeToScVal(owner, { type: "address" }),
-            nativeToScVal(delegatee, { type: "address" }),
-            nativeToScVal(nonce, { type: "u64" }),
-            nativeToScVal(expiry, { type: "u64" }),
-            nativeToScVal(signature, { type: "bytes" }),
-          ),
-        )
-        .setTimeout(30)
-        .build();
-
-      const prepared = await this.server.prepareTransaction(tx);
-      await this.server.sendTransaction(prepared);
-    }, (e) => this.isRetryableSubmissionError(e));
-  }
-
-  /**
    * Get the current votes contract settings.
    */
   async getVotesSettings(): Promise<VotesSettings> {
@@ -792,30 +748,10 @@ export class VotesClient {
     };
   }
 
-  /**
-   * Sign a delegation message off-chain for gasless delegation.
-   *
-   * @param signer - Keypair of the token holder
-   * @param delegatee - Address to delegate to
-   * @param nonce - Current nonce for the owner
-   * @param expiry - Unix timestamp after which the signature is invalid
-   * @returns Ed25519 signature bytes
-   */
-  signDelegation(
-    signer: Keypair,
-    delegatee: string,
-    nonce: bigint,
-    expiry: bigint,
-  ): Buffer {
-    const message = Buffer.concat([
-      Buffer.from(signer.publicKey()),
-      Buffer.from(delegatee),
-      Buffer.from(nonce.toString(16).padStart(16, "0"), "hex"),
-      Buffer.from(expiry.toString(16).padStart(16, "0"), "hex"),
-    ]);
-
-    return signer.sign(message);
-  }
+  // Gasless ("delegate by signature") delegation lives in
+  // DelegationSigClient (./delegation-sig.ts) — it needs a full
+  // SorobanAuthorizationEntry, not a raw signature, because verification is
+  // done through Soroban's native auth framework. See that module's docs.
 
   // ─── Internal ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Adds `delegate_by_sig` / `delegate_batch_by_sig` to `contracts/token-votes`: a token holder signs a `DelegationPermit` off-chain (delegatee, sequential nonce, expiry ledger, chain ID, contract ID) and any relayer can submit it on-chain and pay the fee.
- Adds `nonce`, `is_nonce_used`, `invalidate_all_permits`, `domain_separator`, `compute_permit_hash`, and an optional relayer whitelist (`set_relayer_whitelist_enabled` / `set_relayer_whitelisted` / `is_relayer_allowed`).
- Adds a `TokenVotesError` enum (`InvalidSignature`, `NonceAlreadyUsed`, `PermitExpired`, `InvalidDelegationPermit`, `RelayerNotWhitelisted`, `InvalidChainId`, `InvalidContractId`) and `DelegatedBySig` / `PermitsInvalidated` / `RelayerWhitelistUpdated` events.
- SDK: new `DelegationSigClient` (`sdk/src/delegation-sig.ts`) for signing permits and submitting them; removes the previous `VotesClient.delegateBySig`/`signDelegation`, which called a since-replaced contract signature and never actually worked (built a transaction with the contract itself as the fee-paying source account).
- Backend: `POST /relayer/delegate` and `POST /relayer/delegate-batch` (`backend/src/routes/relayer.ts`), with per-delegator daily quota tracking (migration `007_add_relayer_permit_log.sql`) and per-IP rate limiting.
- Frontend: new `GaslessDelegateModal` + `useGaslessDelegation` hook, wired into the delegates page behind the existing `DelegateModal`'s "delegate without paying gas" action.

## Why not a manual `ed25519_verify`, as originally sketched in #772

Soroban's `Address` is intentionally opaque — it can be a classic Ed25519 account, a multisig account, or an arbitrary smart-wallet contract, and none of those expose a raw public key to contract code (there's no `Address` → `BytesN<32>` conversion in the SDK). This is the same limitation the pre-existing (and effectively unused) `delegate_by_sig` in this file already ran into and worked around by calling `owner.require_auth()` instead.

Given that, the `DelegationPermit` fields from the issue (`delegator: Address`, no raw public key) can't be verified with `env.crypto().ed25519_verify()` without either:
- adding a raw public key field and hand-rolling on-chain StrKey (base32 + CRC16) encoding to bind it to `delegator` — real custom-crypto code with no precedent anywhere in this codebase, and it would only work for classic accounts, not smart-wallet delegators, or
- skipping that binding check — a spoofing hole (anyone could sign with their own key while setting `delegator` to someone else's address).

So verification here goes through Soroban's native authorization framework instead (`Address::require_auth_for_args`): the relayer attaches a `SorobanAuthorizationEntry` the delegator signed off-chain (no transaction, no fee), scoped to `(delegate_by_sig | delegate_batch_by_sig, (permit,))` — deliberately *not* including the relayer address, so the same signed permit works with any relayer. This is host-verified, audited crypto, and it transparently supports multisig/smart-wallet delegators too. The full `DelegationPermit` struct, sequential nonce, expiry, and relayer-whitelist machinery from the issue are preserved; only the low-level signature-check mechanism differs. `contracts/token-votes/src/delegation_sig.rs` has the full writeup.

One consequence: `delegate_by_sig`/`delegate_batch_by_sig` don't take a standalone `signature: BytesN<64>` parameter — the signed authorization is attached to the transaction itself (via `sorobanData`/auth entries), not passed as a contract argument.

## Test plan
- [x] `cargo test -p sorogov-token-votes --features testutils` — 58/58 passing, including all 14 tests requested in the issue plus a few extra (fn_name-scoping between single/batch, storage-key round-trip, expiry bookkeeping).
- [x] `cargo clippy --workspace --all-features -- -D warnings` — clean.
- [x] `pnpm --filter @nebgov/sdk test` — 244/244 passing; `tsc --noEmit` clean on `sdk` and `backend`.
- [x] `tsc --noEmit` on `app` — clean (one pre-existing, unrelated syntax error in `profile/[address]/page.tsx` predates this branch).
- [ ] Not run: backend integration tests (need a live Postgres with real credentials — not available in this environment) and a manual browser run of `GaslessDelegateModal` against testnet (needs a funded relayer key and deployed contract).

closes #772 
