### PR TITLE
fix: restore GovernorClient API surface + unblock Frontend/SDK CI

### DIFF
--- a/app/e2e/governance-lifecycle.spec.ts
+++ b/app/e2e/governance-lifecycle.spec.ts
@@ -3,9 +3,9 @@ import { ProposalState, VoteSupport, hashDescription } from "@nebgov/sdk";
 import { createSdkClients, hasE2eEnv, createSigner, createGovernorConfig } from "./helpers/sdk";
 import { mockWalletConnection } from "./helpers/wallet";
 
-const testIfConfigured = hasE2eEnv() ? test : test.skip;
+test.describe("Full Governance Lifecycle (testnet)", () => {
+  test.skip(!hasE2eEnv(), "E2E environment not configured");
 
-testIfConfigured.describe("Full Governance Lifecycle (testnet)", () => {
   let signer: ReturnType<typeof createSigner>;
   let config: ReturnType<typeof createGovernorConfig>;
   let governor: ReturnType<typeof createSdkClients>["governor"];

--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -9,11 +9,12 @@ const createJestConfig = nextJest({
 const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'jest-environment-jsdom',
-  testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/'],
+  testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/', '<rootDir>/e2e/'],
   moduleNameMapper: {
     "^@nebgov/sdk$": "<rootDir>/../sdk/src/index.ts",
     "^next/link$": "<rootDir>/src/__mocks__/next-link.tsx",
     "\\.(css|scss)$": "<rootDir>/src/__mocks__/styleMock.js",
+    "^@/(.*)$": "<rootDir>/src/$1",
   },
   collectCoverageFrom: [
     'src/**/*.{js,jsx,ts,tsx}',

--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -2,7 +2,99 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin("./src/i18n.ts");
 
+/**
+ * react-markdown and its remark/rehype/unified/mdast/hast/micromark/vfile
+ * dependency chain ship ESM-only. Listing them here lets Next.js's bundler
+ * (and, via next/jest, Jest's transform) process them instead of treating
+ * them as pre-built CJS node_modules.
+ *
+ * This is the full transitive `dependencies` closure of react-markdown +
+ * rehype-sanitize (walked and verified against the installed lockfile, not
+ * hand-guessed) — trimming it risks silently missing a package and moving
+ * the same "Unexpected token 'export'" failure one level deeper.
+ */
+const markdownEcosystemPackages = [
+  "@ungap/structured-clone",
+  "bail",
+  "ccount",
+  "character-entities",
+  "character-entities-html4",
+  "character-entities-legacy",
+  "character-reference-invalid",
+  "comma-separated-tokens",
+  "debug",
+  "decode-named-character-reference",
+  "dequal",
+  "devlop",
+  "estree-util-is-identifier-name",
+  "extend",
+  "hast-util-sanitize",
+  "hast-util-to-jsx-runtime",
+  "hast-util-whitespace",
+  "html-url-attributes",
+  "inline-style-parser",
+  "is-alphabetical",
+  "is-alphanumerical",
+  "is-decimal",
+  "is-hexadecimal",
+  "is-plain-obj",
+  "longest-streak",
+  "mdast-util-from-markdown",
+  "mdast-util-mdx-expression",
+  "mdast-util-mdx-jsx",
+  "mdast-util-mdxjs-esm",
+  "mdast-util-phrasing",
+  "mdast-util-to-hast",
+  "mdast-util-to-markdown",
+  "mdast-util-to-string",
+  "micromark",
+  "micromark-core-commonmark",
+  "micromark-factory-destination",
+  "micromark-factory-label",
+  "micromark-factory-space",
+  "micromark-factory-title",
+  "micromark-factory-whitespace",
+  "micromark-util-character",
+  "micromark-util-chunked",
+  "micromark-util-classify-character",
+  "micromark-util-combine-extensions",
+  "micromark-util-decode-numeric-character-reference",
+  "micromark-util-decode-string",
+  "micromark-util-encode",
+  "micromark-util-html-tag-name",
+  "micromark-util-normalize-identifier",
+  "micromark-util-resolve-all",
+  "micromark-util-sanitize-uri",
+  "micromark-util-subtokenize",
+  "micromark-util-symbol",
+  "micromark-util-types",
+  "ms",
+  "parse-entities",
+  "property-information",
+  "react-markdown",
+  "rehype-sanitize",
+  "remark-parse",
+  "remark-rehype",
+  "space-separated-tokens",
+  "stringify-entities",
+  "style-to-js",
+  "style-to-object",
+  "trim-lines",
+  "trough",
+  "unified",
+  "unist-util-is",
+  "unist-util-position",
+  "unist-util-stringify-position",
+  "unist-util-visit",
+  "unist-util-visit-parents",
+  "vfile",
+  "vfile-message",
+  "zwitch",
+];
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  transpilePackages: markdownEcosystemPackages,
+};
 
 export default withNextIntl(nextConfig);

--- a/app/src/__tests__/accessibility.test.tsx
+++ b/app/src/__tests__/accessibility.test.tsx
@@ -17,17 +17,18 @@ declare global {
 import { VotingModal } from '../components/VotingModal';
 import { ProposalStateBadge } from '../components/ProposalStateBadge';
 import { ProposalState, VoteSupport } from '@nebgov/sdk';
+import { useWallet } from '../lib/wallet-context';
 
 // Extend Jest matchers
 expect.extend(toHaveNoViolations);
 
 // Mock the wallet context
 jest.mock('../lib/wallet-context', () => ({
-  useWallet: () => ({
+  useWallet: jest.fn(() => ({
     isConnected: true,
     connect: jest.fn(),
     publicKey: 'GTEST123...',
-  }),
+  })),
 }));
 
 // Mock react-hot-toast
@@ -108,13 +109,23 @@ describe('Accessibility Tests', () => {
     });
 
     it('should provide context for disabled state', () => {
+      // VotingModal falls back to the connected wallet's own address when no
+      // explicit `delegatee` is passed (self-delegation implied — see
+      // `resolvedDelegatee` in VotingModal.tsx), so disabling the confirm
+      // button genuinely requires no address at all, not just a null prop.
+      (useWallet as jest.Mock).mockReturnValueOnce({
+        isConnected: true,
+        connect: jest.fn(),
+        publicKey: null,
+      });
+
       const propsWithoutDelegatee = {
         ...defaultProps,
         delegatee: null,
       };
-      
+
       const { getByRole } = render(<VotingModal {...propsWithoutDelegatee} />);
-      
+
       const confirmButton = getByRole('button', { name: /confirm & sign/i });
       expect(confirmButton).toBeDisabled();
       expect(confirmButton).toHaveAttribute('aria-describedby', 'delegation-required');

--- a/app/src/__tests__/xss-protection.test.tsx
+++ b/app/src/__tests__/xss-protection.test.tsx
@@ -17,14 +17,20 @@ jest.mock('@/hooks/useGovernorConfig', () => ({
 
 // Mock next/link to avoid router context issues
 jest.mock('next/link', () => {
-  return ({ children, href }: any) => {
+  function MockLink({ children, href }: any) {
     return <a href={href}>{children}</a>;
-  };
+  }
+  MockLink.displayName = 'Link';
+  return MockLink;
 });
 
 describe('XSS Protection', () => {
   it('should sanitize script tags in proposal description', () => {
-    const maliciousDescription = '<script>alert("XSS")</script>Legitimate proposal';
+    // A blank line separates the tag from the trailing text: per CommonMark,
+    // a <script> HTML block otherwise runs to end-of-line and would swallow
+    // any same-line trailing text as part of the (dropped) raw-HTML node,
+    // which is a markdown parsing rule, not a sanitization gap.
+    const maliciousDescription = '<script>alert("XSS")</script>\n\nLegitimate proposal';
     
     render(
       <ProposalCard

--- a/app/src/app/delegates/page.tsx
+++ b/app/src/app/delegates/page.tsx
@@ -89,9 +89,10 @@ export default function DelegatesPage() {
         setTotalSupply(supply);
 
         const result = await votesClient.getTopDelegates({ limit: PAGE_SIZE, offset: 0 });
-        const page = Array.isArray(result) ? result : result.delegates;
+        const page: TopDelegate[] = Array.isArray(result) ? result : result.delegates;
         setDelegates(page);
-        const total = page.reduce((sum, d) => sum + d.votingPower, 0n);
+        let total = 0n;
+        for (const d of page) total += d.votingPower;
         setTotalDelegated(total);
         setOffset(PAGE_SIZE);
         setHasMore(page.length === PAGE_SIZE);

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -24,6 +24,7 @@ interface ProposalSummary {
   state: ProposalState;
   votesFor: bigint;
   votesAgainst: bigint;
+  votesAbstain: bigint;
   startLedger: number;
   endLedger: number;
 }
@@ -234,6 +235,7 @@ function ProposalsPageInner() {
           state: r.state!,
           votesFor: r.votes!.votesFor,
           votesAgainst: r.votes!.votesAgainst,
+          votesAbstain: r.votes!.votesAbstain,
           startLedger: 0,
           endLedger: 0,
         }));

--- a/app/src/app/profile/[address]/page.tsx
+++ b/app/src/app/profile/[address]/page.tsx
@@ -20,7 +20,6 @@ import {
   CartesianGrid,
 } from "recharts";
 import { useGovernorConfig } from "@/hooks/useGovernorConfig";
-} from "recharts";
 import { isValidStellarAddress, formatVotingPower } from "../../../lib/utils";
 
 interface VotingRecord {

--- a/app/src/app/propose/page.tsx
+++ b/app/src/app/propose/page.tsx
@@ -18,6 +18,7 @@ import {
   Loader2,
   Link as LinkIcon,
   AlertCircle,
+  Copy,
 } from "lucide-react";
 import { Keypair } from "@stellar/stellar-sdk";
 import {

--- a/app/src/components/VotingModal.tsx
+++ b/app/src/components/VotingModal.tsx
@@ -248,16 +248,16 @@ export function VotingModal({
   }
 
   return (
-    <div 
+    <div
       className="fixed inset-0 bg-black/40 flex items-center justify-center z-50"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="voting-modal-title"
-      aria-describedby="voting-modal-description"
     >
-      <div 
+      <div
         id="voting-modal"
         className="bg-white dark:bg-gray-800 rounded-2xl p-6 w-full max-w-lg shadow-xl"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="voting-modal-title"
+        aria-describedby="voting-modal-description"
         tabIndex={-1}
       >
         <div className="flex items-start justify-between mb-3">

--- a/app/src/components/__tests__/ProposalStateBadge.test.tsx
+++ b/app/src/components/__tests__/ProposalStateBadge.test.tsx
@@ -21,11 +21,15 @@ describe("ProposalStateBadge", () => {
   });
 
   it.each(STATES)("renders a non-empty badge for state %s", (state) => {
-    const tree = renderer.create(<ProposalStateBadge state={state} />).toJSON();
+    // ProposalStateBadge always renders a single root <span>, not a
+    // fragment, so toJSON() returns one ReactTestRendererJSON node (not the
+    // array variant its return type also allows).
+    const tree = renderer.create(<ProposalStateBadge state={state} />)
+      .toJSON() as renderer.ReactTestRendererJSON;
     expect(tree).toBeTruthy();
     expect(tree).toHaveProperty("type", "span");
     expect(tree).toHaveProperty("children");
     expect(Array.isArray(tree.children)).toBe(true);
-    expect(tree.children.length).toBeGreaterThan(0);
+    expect(tree.children!.length).toBeGreaterThan(0);
   });
 });

--- a/app/src/components/__tests__/__snapshots__/DelegateModal.test.tsx.snap
+++ b/app/src/components/__tests__/__snapshots__/DelegateModal.test.tsx.snap
@@ -1,0 +1,183 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DelegateModal matches snapshot when open 1`] = `
+<div
+  className="fixed inset-0 bg-black/40 flex items-center justify-center z-50"
+>
+  <div
+    className="bg-white rounded-2xl p-6 w-full max-w-md shadow-xl"
+  >
+    <h2
+      className="text-lg font-bold text-gray-900 mb-1"
+    >
+      Delegate Voting Power
+    </h2>
+    <p
+      className="text-sm text-gray-500 mb-4"
+    >
+      Delegate to yourself to activate your voting power, or choose another address.
+    </p>
+    <form
+      className="space-y-4"
+      onSubmit={[Function]}
+    >
+      <div
+        className="flex items-center justify-between gap-3"
+      >
+        <span
+          className="text-xs text-gray-500 font-mono"
+        >
+          Not connected
+        </span>
+        <button
+          className="text-xs px-3 py-1.5 rounded-lg border border-gray-200 text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          disabled={true}
+          onClick={[Function]}
+          type="button"
+        >
+          Delegate to myself
+        </button>
+      </div>
+      <input
+        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 font-mono"
+        onChange={[Function]}
+        placeholder="Stellar address (G...)"
+        required={true}
+        type="text"
+        value=""
+      />
+      <div
+        className="flex gap-3"
+      >
+        <button
+          className="flex-1 border border-gray-200 text-gray-600 py-2 rounded-lg text-sm hover:bg-gray-50"
+          onClick={[MockFunction]}
+          type="button"
+        >
+          Cancel
+        </button>
+        <button
+          className="flex-1 bg-indigo-600 text-white py-2 rounded-lg text-sm font-medium hover:bg-indigo-700 disabled:opacity-50"
+          disabled={false}
+          type="submit"
+        >
+          Delegate
+        </button>
+      </div>
+      <div
+        className="border-t border-gray-200 pt-4 mt-4"
+      >
+        <p
+          className="text-xs text-gray-500 mb-2"
+        >
+          Or delegate without paying gas
+        </p>
+        <button
+          className="w-full bg-green-600 text-white py-2 rounded-lg text-sm font-medium hover:bg-green-700 disabled:opacity-50"
+          disabled={true}
+          onClick={[Function]}
+          type="button"
+        >
+          Delegate without paying gas
+        </button>
+        <p
+          className="text-xs text-gray-400 mt-1"
+        >
+          Sign off-chain, relayer submits transaction
+        </p>
+      </div>
+    </form>
+  </div>
+</div>
+`;
+
+exports[`DelegateModal matches snapshot when open with prefill address 1`] = `
+<div
+  className="fixed inset-0 bg-black/40 flex items-center justify-center z-50"
+>
+  <div
+    className="bg-white rounded-2xl p-6 w-full max-w-md shadow-xl"
+  >
+    <h2
+      className="text-lg font-bold text-gray-900 mb-1"
+    >
+      Delegate Voting Power
+    </h2>
+    <p
+      className="text-sm text-gray-500 mb-4"
+    >
+      Delegate to yourself to activate your voting power, or choose another address.
+    </p>
+    <form
+      className="space-y-4"
+      onSubmit={[Function]}
+    >
+      <div
+        className="flex items-center justify-between gap-3"
+      >
+        <span
+          className="text-xs text-gray-500 font-mono"
+        >
+          Not connected
+        </span>
+        <button
+          className="text-xs px-3 py-1.5 rounded-lg border border-gray-200 text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          disabled={true}
+          onClick={[Function]}
+          type="button"
+        >
+          Delegate to myself
+        </button>
+      </div>
+      <input
+        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 font-mono"
+        onChange={[Function]}
+        placeholder="Stellar address (G...)"
+        required={true}
+        type="text"
+        value="GBFUUXATVOGXGD4KS3I423QFZSPE4ZFOQ3TCJVWFUYSIPULXIRVRE2DT"
+      />
+      <div
+        className="flex gap-3"
+      >
+        <button
+          className="flex-1 border border-gray-200 text-gray-600 py-2 rounded-lg text-sm hover:bg-gray-50"
+          onClick={[MockFunction]}
+          type="button"
+        >
+          Cancel
+        </button>
+        <button
+          className="flex-1 bg-indigo-600 text-white py-2 rounded-lg text-sm font-medium hover:bg-indigo-700 disabled:opacity-50"
+          disabled={false}
+          type="submit"
+        >
+          Delegate
+        </button>
+      </div>
+      <div
+        className="border-t border-gray-200 pt-4 mt-4"
+      >
+        <p
+          className="text-xs text-gray-500 mb-2"
+        >
+          Or delegate without paying gas
+        </p>
+        <button
+          className="w-full bg-green-600 text-white py-2 rounded-lg text-sm font-medium hover:bg-green-700 disabled:opacity-50"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          Delegate without paying gas
+        </button>
+        <p
+          className="text-xs text-gray-400 mt-1"
+        >
+          Sign off-chain, relayer submits transaction
+        </p>
+      </div>
+    </form>
+  </div>
+</div>
+`;

--- a/app/src/components/__tests__/__snapshots__/ProposalCard.test.tsx.snap
+++ b/app/src/components/__tests__/__snapshots__/ProposalCard.test.tsx.snap
@@ -1,0 +1,385 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProposalCard matches snapshot for state Active 1`] = `
+<a
+  className="block bg-white border border-gray-200 rounded-xl p-6 hover:border-indigo-300 hover:shadow-sm transition-all"
+  href="/proposal/1"
+>
+  <div
+    className="flex items-start justify-between"
+  >
+    <div
+      className="flex-1 min-w-0"
+    >
+      <p
+        className="text-xs text-gray-400 mb-1"
+      >
+        Proposal #
+        1
+      </p>
+      <h2
+        className="text-lg font-semibold text-gray-900 truncate"
+      >
+        <p>
+          Transfer 1000 NEB to treasury
+        </p>
+      </h2>
+      <div
+        className="mt-3 flex items-center gap-4 text-sm text-gray-500"
+      >
+        <span>
+          For: 
+          750
+        </span>
+        <span>
+          Against: 
+          250
+        </span>
+      </div>
+    </div>
+    <span
+      className="px-3 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800 border border-blue-200"
+    >
+      ●
+       
+      Active
+    </span>
+  </div>
+</a>
+`;
+
+exports[`ProposalCard matches snapshot for state Cancelled 1`] = `
+<a
+  className="block bg-white border border-gray-200 rounded-xl p-6 hover:border-indigo-300 hover:shadow-sm transition-all"
+  href="/proposal/1"
+>
+  <div
+    className="flex items-start justify-between"
+  >
+    <div
+      className="flex-1 min-w-0"
+    >
+      <p
+        className="text-xs text-gray-400 mb-1"
+      >
+        Proposal #
+        1
+      </p>
+      <h2
+        className="text-lg font-semibold text-gray-900 truncate"
+      >
+        <p>
+          Transfer 1000 NEB to treasury
+        </p>
+      </h2>
+      <div
+        className="mt-3 flex items-center gap-4 text-sm text-gray-500"
+      >
+        <span>
+          For: 
+          750
+        </span>
+        <span>
+          Against: 
+          250
+        </span>
+      </div>
+    </div>
+    <span
+      className="px-3 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-700 border border-gray-200"
+    >
+      ⊘
+       
+      Cancelled
+    </span>
+  </div>
+</a>
+`;
+
+exports[`ProposalCard matches snapshot for state Defeated 1`] = `
+<a
+  className="block bg-white border border-gray-200 rounded-xl p-6 hover:border-indigo-300 hover:shadow-sm transition-all"
+  href="/proposal/1"
+>
+  <div
+    className="flex items-start justify-between"
+  >
+    <div
+      className="flex-1 min-w-0"
+    >
+      <p
+        className="text-xs text-gray-400 mb-1"
+      >
+        Proposal #
+        1
+      </p>
+      <h2
+        className="text-lg font-semibold text-gray-900 truncate"
+      >
+        <p>
+          Transfer 1000 NEB to treasury
+        </p>
+      </h2>
+      <div
+        className="mt-3 flex items-center gap-4 text-sm text-gray-500"
+      >
+        <span>
+          For: 
+          750
+        </span>
+        <span>
+          Against: 
+          250
+        </span>
+      </div>
+    </div>
+    <span
+      className="px-3 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800 border border-red-200"
+    >
+      ✕
+       
+      Defeated
+    </span>
+  </div>
+</a>
+`;
+
+exports[`ProposalCard matches snapshot for state Executed 1`] = `
+<a
+  className="block bg-white border border-gray-200 rounded-xl p-6 hover:border-indigo-300 hover:shadow-sm transition-all"
+  href="/proposal/1"
+>
+  <div
+    className="flex items-start justify-between"
+  >
+    <div
+      className="flex-1 min-w-0"
+    >
+      <p
+        className="text-xs text-gray-400 mb-1"
+      >
+        Proposal #
+        1
+      </p>
+      <h2
+        className="text-lg font-semibold text-gray-900 truncate"
+      >
+        <p>
+          Transfer 1000 NEB to treasury
+        </p>
+      </h2>
+      <div
+        className="mt-3 flex items-center gap-4 text-sm text-gray-500"
+      >
+        <span>
+          For: 
+          750
+        </span>
+        <span>
+          Against: 
+          250
+        </span>
+      </div>
+    </div>
+    <span
+      className="px-3 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800 border border-purple-200"
+    >
+      ✅
+       
+      Executed
+    </span>
+  </div>
+</a>
+`;
+
+exports[`ProposalCard matches snapshot for state Pending 1`] = `
+<a
+  className="block bg-white border border-gray-200 rounded-xl p-6 hover:border-indigo-300 hover:shadow-sm transition-all"
+  href="/proposal/1"
+>
+  <div
+    className="flex items-start justify-between"
+  >
+    <div
+      className="flex-1 min-w-0"
+    >
+      <p
+        className="text-xs text-gray-400 mb-1"
+      >
+        Proposal #
+        1
+      </p>
+      <h2
+        className="text-lg font-semibold text-gray-900 truncate"
+      >
+        <p>
+          Transfer 1000 NEB to treasury
+        </p>
+      </h2>
+      <div
+        className="mt-3 flex items-center gap-4 text-sm text-gray-500"
+      >
+        <span>
+          For: 
+          750
+        </span>
+        <span>
+          Against: 
+          250
+        </span>
+      </div>
+    </div>
+    <span
+      className="px-3 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800 border border-yellow-200"
+    >
+      ⏳
+       
+      Pending
+    </span>
+  </div>
+</a>
+`;
+
+exports[`ProposalCard matches snapshot for state Queued 1`] = `
+<a
+  className="block bg-white border border-gray-200 rounded-xl p-6 hover:border-indigo-300 hover:shadow-sm transition-all"
+  href="/proposal/1"
+>
+  <div
+    className="flex items-start justify-between"
+  >
+    <div
+      className="flex-1 min-w-0"
+    >
+      <p
+        className="text-xs text-gray-400 mb-1"
+      >
+        Proposal #
+        1
+      </p>
+      <h2
+        className="text-lg font-semibold text-gray-900 truncate"
+      >
+        <p>
+          Transfer 1000 NEB to treasury
+        </p>
+      </h2>
+      <div
+        className="mt-3 flex items-center gap-4 text-sm text-gray-500"
+      >
+        <span>
+          For: 
+          750
+        </span>
+        <span>
+          Against: 
+          250
+        </span>
+      </div>
+    </div>
+    <span
+      className="px-3 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800 border border-purple-200"
+    >
+      ⏳
+       
+      Queued
+    </span>
+  </div>
+</a>
+`;
+
+exports[`ProposalCard matches snapshot for state Succeeded 1`] = `
+<a
+  className="block bg-white border border-gray-200 rounded-xl p-6 hover:border-indigo-300 hover:shadow-sm transition-all"
+  href="/proposal/1"
+>
+  <div
+    className="flex items-start justify-between"
+  >
+    <div
+      className="flex-1 min-w-0"
+    >
+      <p
+        className="text-xs text-gray-400 mb-1"
+      >
+        Proposal #
+        1
+      </p>
+      <h2
+        className="text-lg font-semibold text-gray-900 truncate"
+      >
+        <p>
+          Transfer 1000 NEB to treasury
+        </p>
+      </h2>
+      <div
+        className="mt-3 flex items-center gap-4 text-sm text-gray-500"
+      >
+        <span>
+          For: 
+          750
+        </span>
+        <span>
+          Against: 
+          250
+        </span>
+      </div>
+    </div>
+    <span
+      className="px-3 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 border border-green-200"
+    >
+      ✓
+       
+      Succeeded
+    </span>
+  </div>
+</a>
+`;
+
+exports[`ProposalCard matches snapshot with long description 1`] = `
+<a
+  className="block bg-white border border-gray-200 rounded-xl p-6 hover:border-indigo-300 hover:shadow-sm transition-all"
+  href="/proposal/1"
+>
+  <div
+    className="flex items-start justify-between"
+  >
+    <div
+      className="flex-1 min-w-0"
+    >
+      <p
+        className="text-xs text-gray-400 mb-1"
+      >
+        Proposal #
+        1
+      </p>
+      <h2
+        className="text-lg font-semibold text-gray-900 truncate"
+      >
+        <p>
+          AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        </p>
+      </h2>
+      <div
+        className="mt-3 flex items-center gap-4 text-sm text-gray-500"
+      >
+        <span>
+          For: 
+          750
+        </span>
+        <span>
+          Against: 
+          250
+        </span>
+      </div>
+    </div>
+    <span
+      className="px-3 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800 border border-blue-200"
+    >
+      ●
+       
+      Active
+    </span>
+  </div>
+</a>
+`;

--- a/app/src/components/__tests__/__snapshots__/ProposalStateBadge.test.tsx.snap
+++ b/app/src/components/__tests__/__snapshots__/ProposalStateBadge.test.tsx.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProposalStateBadge matches snapshot for state Active 1`] = `
+<span
+  className="px-3 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800 border border-blue-200"
+>
+  ●
+   
+  Active
+</span>
+`;
+
+exports[`ProposalStateBadge matches snapshot for state Cancelled 1`] = `
+<span
+  className="px-3 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-700 border border-gray-200"
+>
+  ⊘
+   
+  Cancelled
+</span>
+`;
+
+exports[`ProposalStateBadge matches snapshot for state Defeated 1`] = `
+<span
+  className="px-3 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800 border border-red-200"
+>
+  ✕
+   
+  Defeated
+</span>
+`;
+
+exports[`ProposalStateBadge matches snapshot for state Executed 1`] = `
+<span
+  className="px-3 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800 border border-purple-200"
+>
+  ✅
+   
+  Executed
+</span>
+`;
+
+exports[`ProposalStateBadge matches snapshot for state Expired 1`] = `
+<span
+  className="px-3 py-1 rounded-full text-xs font-medium bg-rose-100 text-rose-800 border border-rose-200"
+>
+  ⌛
+   
+  Expired
+</span>
+`;
+
+exports[`ProposalStateBadge matches snapshot for state Pending 1`] = `
+<span
+  className="px-3 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800 border border-yellow-200"
+>
+  ⏳
+   
+  Pending
+</span>
+`;
+
+exports[`ProposalStateBadge matches snapshot for state Queued 1`] = `
+<span
+  className="px-3 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800 border border-purple-200"
+>
+  ⏳
+   
+  Queued
+</span>
+`;
+
+exports[`ProposalStateBadge matches snapshot for state Succeeded 1`] = `
+<span
+  className="px-3 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 border border-green-200"
+>
+  ✓
+   
+  Succeeded
+</span>
+`;

--- a/app/src/components/__tests__/__snapshots__/VoteBar.test.tsx.snap
+++ b/app/src/components/__tests__/__snapshots__/VoteBar.test.tsx.snap
@@ -1,0 +1,376 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VoteBar matches snapshot with abstain-heavy votes 1`] = `
+<div
+  className="space-y-2"
+>
+  <div
+    className="flex h-2 rounded-full overflow-hidden bg-gray-100"
+  >
+    <div
+      className="bg-emerald-500"
+      style={
+        {
+          "width": "10%",
+        }
+      }
+    />
+    <div
+      className="bg-rose-500"
+      style={
+        {
+          "width": "10%",
+        }
+      }
+    />
+    <div
+      className="bg-slate-400"
+      style={
+        {
+          "width": "80%",
+        }
+      }
+    />
+  </div>
+  <div
+    className="grid grid-cols-3 gap-2 text-sm"
+  >
+    <div>
+      <span
+        className="text-gray-500"
+      >
+        For: 
+      </span>
+      <span
+        className="font-medium text-emerald-600"
+      >
+        100
+      </span>
+    </div>
+    <div>
+      <span
+        className="text-gray-500"
+      >
+        Against: 
+      </span>
+      <span
+        className="font-medium text-rose-600"
+      >
+        100
+      </span>
+    </div>
+    <div>
+      <span
+        className="text-gray-500"
+      >
+        Abstain: 
+      </span>
+      <span
+        className="font-medium text-slate-500"
+      >
+        800
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`VoteBar matches snapshot with all-against votes 1`] = `
+<div
+  className="space-y-2"
+>
+  <div
+    className="flex h-2 rounded-full overflow-hidden bg-gray-100"
+  >
+    <div
+      className="bg-emerald-500"
+      style={
+        {
+          "width": "0%",
+        }
+      }
+    />
+    <div
+      className="bg-rose-500"
+      style={
+        {
+          "width": "100%",
+        }
+      }
+    />
+    <div
+      className="bg-slate-400"
+      style={
+        {
+          "width": "0%",
+        }
+      }
+    />
+  </div>
+  <div
+    className="grid grid-cols-3 gap-2 text-sm"
+  >
+    <div>
+      <span
+        className="text-gray-500"
+      >
+        For: 
+      </span>
+      <span
+        className="font-medium text-emerald-600"
+      >
+        0
+      </span>
+    </div>
+    <div>
+      <span
+        className="text-gray-500"
+      >
+        Against: 
+      </span>
+      <span
+        className="font-medium text-rose-600"
+      >
+        500
+      </span>
+    </div>
+    <div>
+      <span
+        className="text-gray-500"
+      >
+        Abstain: 
+      </span>
+      <span
+        className="font-medium text-slate-500"
+      >
+        0
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`VoteBar matches snapshot with all-for votes 1`] = `
+<div
+  className="space-y-2"
+>
+  <div
+    className="flex h-2 rounded-full overflow-hidden bg-gray-100"
+  >
+    <div
+      className="bg-emerald-500"
+      style={
+        {
+          "width": "100%",
+        }
+      }
+    />
+    <div
+      className="bg-rose-500"
+      style={
+        {
+          "width": "0%",
+        }
+      }
+    />
+    <div
+      className="bg-slate-400"
+      style={
+        {
+          "width": "0%",
+        }
+      }
+    />
+  </div>
+  <div
+    className="grid grid-cols-3 gap-2 text-sm"
+  >
+    <div>
+      <span
+        className="text-gray-500"
+      >
+        For: 
+      </span>
+      <span
+        className="font-medium text-emerald-600"
+      >
+        1,000
+      </span>
+    </div>
+    <div>
+      <span
+        className="text-gray-500"
+      >
+        Against: 
+      </span>
+      <span
+        className="font-medium text-rose-600"
+      >
+        0
+      </span>
+    </div>
+    <div>
+      <span
+        className="text-gray-500"
+      >
+        Abstain: 
+      </span>
+      <span
+        className="font-medium text-slate-500"
+      >
+        0
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`VoteBar matches snapshot with mixed votes 1`] = `
+<div
+  className="space-y-2"
+>
+  <div
+    className="flex h-2 rounded-full overflow-hidden bg-gray-100"
+  >
+    <div
+      className="bg-emerald-500"
+      style={
+        {
+          "width": "60%",
+        }
+      }
+    />
+    <div
+      className="bg-rose-500"
+      style={
+        {
+          "width": "30%",
+        }
+      }
+    />
+    <div
+      className="bg-slate-400"
+      style={
+        {
+          "width": "10%",
+        }
+      }
+    />
+  </div>
+  <div
+    className="grid grid-cols-3 gap-2 text-sm"
+  >
+    <div>
+      <span
+        className="text-gray-500"
+      >
+        For: 
+      </span>
+      <span
+        className="font-medium text-emerald-600"
+      >
+        600
+      </span>
+    </div>
+    <div>
+      <span
+        className="text-gray-500"
+      >
+        Against: 
+      </span>
+      <span
+        className="font-medium text-rose-600"
+      >
+        300
+      </span>
+    </div>
+    <div>
+      <span
+        className="text-gray-500"
+      >
+        Abstain: 
+      </span>
+      <span
+        className="font-medium text-slate-500"
+      >
+        100
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`VoteBar matches snapshot with zero votes 1`] = `
+<div
+  className="space-y-2"
+>
+  <div
+    className="flex h-2 rounded-full overflow-hidden bg-gray-100"
+  >
+    <div
+      className="bg-emerald-500"
+      style={
+        {
+          "width": "0%",
+        }
+      }
+    />
+    <div
+      className="bg-rose-500"
+      style={
+        {
+          "width": "0%",
+        }
+      }
+    />
+    <div
+      className="bg-slate-400"
+      style={
+        {
+          "width": "0%",
+        }
+      }
+    />
+  </div>
+  <div
+    className="grid grid-cols-3 gap-2 text-sm"
+  >
+    <div>
+      <span
+        className="text-gray-500"
+      >
+        For: 
+      </span>
+      <span
+        className="font-medium text-emerald-600"
+      >
+        0
+      </span>
+    </div>
+    <div>
+      <span
+        className="text-gray-500"
+      >
+        Against: 
+      </span>
+      <span
+        className="font-medium text-rose-600"
+      >
+        0
+      </span>
+    </div>
+    <div>
+      <span
+        className="text-gray-500"
+      >
+        Abstain: 
+      </span>
+      <span
+        className="font-medium text-slate-500"
+      >
+        0
+      </span>
+    </div>
+  </div>
+</div>
+`;

--- a/app/src/components/__tests__/__snapshots__/VoteReceipt.test.tsx.snap
+++ b/app/src/components/__tests__/__snapshots__/VoteReceipt.test.tsx.snap
@@ -1,0 +1,108 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VoteReceipt matches snapshot for Abstain vote 1`] = `
+<div
+  className="bg-emerald-50 border border-emerald-200 rounded-xl p-4"
+>
+  <p
+    className="text-emerald-800 font-medium"
+  >
+    Your vote (
+    <span
+      className="text-slate-500"
+    >
+      Abstain
+    </span>
+    ) has been recorded.
+  </p>
+  <p
+    className="text-sm text-emerald-700 mt-1"
+  >
+    Voting power: 
+    100
+     NEB
+  </p>
+</div>
+`;
+
+exports[`VoteReceipt matches snapshot for Against vote 1`] = `
+<div
+  className="bg-emerald-50 border border-emerald-200 rounded-xl p-4"
+>
+  <p
+    className="text-emerald-800 font-medium"
+  >
+    Your vote (
+    <span
+      className="text-rose-600"
+    >
+      Against
+    </span>
+    ) has been recorded.
+  </p>
+  <p
+    className="text-sm text-emerald-700 mt-1"
+  >
+    Voting power: 
+    300
+     NEB
+  </p>
+</div>
+`;
+
+exports[`VoteReceipt matches snapshot for For vote 1`] = `
+<div
+  className="bg-emerald-50 border border-emerald-200 rounded-xl p-4"
+>
+  <p
+    className="text-emerald-800 font-medium"
+  >
+    Your vote (
+    <span
+      className="text-emerald-600"
+    >
+      For
+    </span>
+    ) has been recorded.
+  </p>
+  <p
+    className="text-sm text-emerald-700 mt-1"
+  >
+    Voting power: 
+    500
+     NEB
+  </p>
+</div>
+`;
+
+exports[`VoteReceipt matches snapshot with reason string 1`] = `
+<div
+  className="bg-emerald-50 border border-emerald-200 rounded-xl p-4"
+>
+  <p
+    className="text-emerald-800 font-medium"
+  >
+    Your vote (
+    <span
+      className="text-emerald-600"
+    >
+      For
+    </span>
+    ) has been recorded.
+  </p>
+  <p
+    className="text-sm text-emerald-700 mt-1"
+  >
+    Voting power: 
+    500
+     NEB
+  </p>
+  <p
+    className="text-sm text-emerald-700 mt-1 italic"
+  >
+    "
+    This proposal aligns with our governance goals.
+    "
+  </p>
+</div>
+`;

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -17,6 +17,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "plugins": [
       {
         "name": "next"

--- a/sdk/src/governor/governor-client.ts
+++ b/sdk/src/governor/governor-client.ts
@@ -12,6 +12,7 @@ import {
 import {
   GovernorConfig,
   GovernorSettings,
+  GovernorSettingsValidationLimits,
   VoteSupport,
   VoteType,
   Network,
@@ -20,10 +21,22 @@ import {
   ProposalVotes,
   CanProposeResult,
   VotingHistoryEntry,
+  TimelockInfo,
+  ExecutionGasEstimate,
 } from "../types";
 
 import { GovernorError, GovernorErrorCode, parseGovernorError } from "../errors";
 import { hexToBytes32, withRetry } from "../utils";
+
+// These modules import `GovernorClient` from this file too (each free
+// function takes the client as its first argument). The cycle is safe here
+// because every usage below is inside a method body, not at module-eval
+// time, so by the time these run, both modules have finished loading.
+import * as proposalsModule from "./proposals";
+import * as votingModule from "./voting";
+import * as queriesModule from "./queries";
+import * as executionModule from "./execution";
+import * as eventsModule from "./events";
 
 const RPC_URLS: Record<Network, string> = {
   mainnet: "https://soroban-rpc.mainnet.stellar.gateway.fm",
@@ -267,4 +280,228 @@ export class GovernorClient {
     }
     return proposals;
   }
+
+  /**
+   * Queue a succeeded proposal in the Timelock, starting its execution delay.
+   *
+   * The proposal must be in the Succeeded state. After queuing, it enters
+   * the Queued state and can be executed once the delay has elapsed.
+   *
+   * @param signer     Keypair authorising the call
+   * @param proposalId The ID of the proposal to queue
+   */
+  async queue(signer: Keypair, proposalId: bigint): Promise<void> {
+    return this.retry(async () => {
+      const account = await this.server.getAccount(signer.publicKey());
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(
+          this.contract.call("queue", nativeToScVal(proposalId, { type: "u64" })),
+        )
+        .setTimeout(30)
+        .build();
+
+      const prepared = await this.server.prepareTransaction(tx);
+      prepared.sign(signer);
+
+      const result = await this.server.sendTransaction(prepared);
+      if (result.status === "ERROR") {
+        throw new GovernorError(
+          GovernorErrorCode.TransactionFailed,
+          `queue failed: ${JSON.stringify(result)}`,
+        );
+      }
+
+      await this.pollForConfirmation(result.hash);
+    }, (e) => this.isRetryableSubmissionError(e));
+  }
+
+  // ─── Delegating wrappers ────────────────────────────────────────────────
+  //
+  // The methods below restore the object-oriented call surface
+  // (`client.propose(...)`) on top of the modular free functions introduced
+  // when this class was split into governor/{proposals,voting,queries,
+  // execution,events}.ts. Each free function already takes `client` as its
+  // first argument, so these are pure 1:1 delegation — no behavior changes.
+
+  propose(...args: TailArgs<typeof proposalsModule.propose>) {
+    return proposalsModule.propose(this, ...args);
+  }
+
+  proposeWithSign(...args: TailArgs<typeof proposalsModule.proposeWithSign>) {
+    return proposalsModule.proposeWithSign(this, ...args);
+  }
+
+  simulateTargetInvocation(...args: TailArgs<typeof proposalsModule.simulateTargetInvocation>) {
+    return proposalsModule.simulateTargetInvocation(this, ...args);
+  }
+
+  simulateProposal(...args: TailArgs<typeof proposalsModule.simulateProposal>) {
+    return proposalsModule.simulateProposal(this, ...args);
+  }
+
+  estimateProposeResources(...args: TailArgs<typeof proposalsModule.estimateProposeResources>) {
+    return proposalsModule.estimateProposeResources(this, ...args);
+  }
+
+  cancel(...args: TailArgs<typeof proposalsModule.cancel>) {
+    return proposalsModule.cancel(this, ...args);
+  }
+
+  cancelByGovernance(...args: TailArgs<typeof proposalsModule.cancelByGovernance>) {
+    return proposalsModule.cancelByGovernance(this, ...args);
+  }
+
+  cancelByGovernanceWithSign(...args: TailArgs<typeof proposalsModule.cancelByGovernanceWithSign>) {
+    return proposalsModule.cancelByGovernanceWithSign(this, ...args);
+  }
+
+  waitForProposalState(...args: TailArgs<typeof proposalsModule.waitForProposalState>) {
+    return proposalsModule.waitForProposalState(this, ...args);
+  }
+
+  getProposal(...args: TailArgs<typeof proposalsModule.getProposal>) {
+    return proposalsModule.getProposal(this, ...args);
+  }
+
+  getQueueTime(...args: TailArgs<typeof proposalsModule.getQueueTime>) {
+    return proposalsModule.getQueueTime(this, ...args);
+  }
+
+  getQueuedOpIds(...args: TailArgs<typeof proposalsModule.getQueuedOpIds>) {
+    return proposalsModule.getQueuedOpIds(this, ...args);
+  }
+
+  getTimelockInfo(...args: TailArgs<typeof proposalsModule.getTimelockInfo>): Promise<TimelockInfo> {
+    return proposalsModule.getTimelockInfo(this, ...args);
+  }
+
+  getProposalsBatch(...args: TailArgs<typeof proposalsModule.getProposalsBatch>) {
+    return proposalsModule.getProposalsBatch(this, ...args);
+  }
+
+  getProposalExpiryLedger(...args: TailArgs<typeof proposalsModule.getProposalExpiryLedger>) {
+    return proposalsModule.getProposalExpiryLedger(this, ...args);
+  }
+
+  buildUpdateConfigProposal(
+    newSettings: GovernorSettings,
+    limits?: GovernorSettingsValidationLimits,
+  ) {
+    return proposalsModule.buildUpdateConfigProposal(this, newSettings, limits);
+  }
+
+  estimateVoteGas(...args: TailArgs<typeof votingModule.estimateVoteGas>) {
+    return votingModule.estimateVoteGas(this, ...args);
+  }
+
+  castVote(...args: TailArgs<typeof votingModule.castVote>) {
+    return votingModule.castVote(this, ...args);
+  }
+
+  castVoteWithSign(...args: TailArgs<typeof votingModule.castVoteWithSign>) {
+    return votingModule.castVoteWithSign(this, ...args);
+  }
+
+  castVoteWithReason(...args: TailArgs<typeof votingModule.castVoteWithReason>) {
+    return votingModule.castVoteWithReason(this, ...args);
+  }
+
+  castVoteWithReasonAndSign(...args: TailArgs<typeof votingModule.castVoteWithReasonAndSign>) {
+    return votingModule.castVoteWithReasonAndSign(this, ...args);
+  }
+
+  getProposalVotes(...args: TailArgs<typeof votingModule.getProposalVotes>): Promise<ProposalVotes> {
+    return votingModule.getProposalVotes(this, ...args);
+  }
+
+  hasVoted(...args: TailArgs<typeof votingModule.hasVoted>) {
+    return votingModule.hasVoted(this, ...args);
+  }
+
+  canPropose(...args: TailArgs<typeof votingModule.canPropose>): Promise<CanProposeResult> {
+    return votingModule.canPropose(this, ...args);
+  }
+
+  getVotingHistory(...args: TailArgs<typeof votingModule.getVotingHistory>): Promise<VotingHistoryEntry[]> {
+    return votingModule.getVotingHistory(this, ...args);
+  }
+
+  getVotesCastByAddress(...args: TailArgs<typeof votingModule.getVotesCastByAddress>) {
+    return votingModule.getVotesCastByAddress(this, ...args);
+  }
+
+  getReceipt(...args: TailArgs<typeof votingModule.getReceipt>) {
+    return votingModule.getReceipt(this, ...args);
+  }
+
+  getVoteReason(...args: TailArgs<typeof votingModule.getVoteReason>) {
+    return votingModule.getVoteReason(this, ...args);
+  }
+
+  proposalThreshold(): Promise<bigint> {
+    return queriesModule.proposalThreshold(this);
+  }
+
+  getSettings(...args: TailArgs<typeof queriesModule.getSettings>): Promise<GovernorSettings> {
+    return queriesModule.getSettings(this, ...args);
+  }
+
+  getProposalState(...args: TailArgs<typeof queriesModule.getProposalState>): Promise<ProposalState> {
+    return queriesModule.getProposalState(this, ...args);
+  }
+
+  getQuorum(...args: TailArgs<typeof queriesModule.getQuorum>): Promise<bigint> {
+    return queriesModule.getQuorum(this, ...args);
+  }
+
+  isQuorumReached(...args: TailArgs<typeof queriesModule.isQuorumReached>): Promise<boolean> {
+    return queriesModule.isQuorumReached(this, ...args);
+  }
+
+  getLatestLedger(): Promise<number> {
+    return queriesModule.getLatestLedger(this);
+  }
+
+  onProposalStateChange(...args: TailArgs<typeof queriesModule.onProposalStateChange>): () => void {
+    return queriesModule.onProposalStateChange(this, ...args);
+  }
+
+  proposalCount(): Promise<bigint> {
+    return queriesModule.proposalCount(this);
+  }
+
+  getProposalFromIndexer(...args: TailArgs<typeof queriesModule.getProposalFromIndexer>) {
+    return queriesModule.getProposalFromIndexer(this, ...args);
+  }
+
+  getLastProposalLedger(...args: TailArgs<typeof queriesModule.getLastProposalLedger>): Promise<number> {
+    return queriesModule.getLastProposalLedger(this, ...args);
+  }
+
+  getProposalsInPeriod(...args: TailArgs<typeof queriesModule.getProposalsInPeriod>): Promise<number> {
+    return queriesModule.getProposalsInPeriod(this, ...args);
+  }
+
+  getProposalsSummaryBatch(...args: TailArgs<typeof queriesModule.getProposalsSummaryBatch>) {
+    return queriesModule.getProposalsSummaryBatch(this, ...args);
+  }
+
+  estimateExecutionGas(...args: TailArgs<typeof executionModule.estimateExecutionGas>): Promise<ExecutionGasEstimate> {
+    return executionModule.estimateExecutionGas(this, ...args);
+  }
+
+  getGuardianActivity(...args: TailArgs<typeof eventsModule.getGuardianActivity>) {
+    return eventsModule.getGuardianActivity(this, ...args);
+  }
+
+  getProposalsForAddress(...args: TailArgs<typeof eventsModule.getProposalsForAddress>) {
+    return eventsModule.getProposalsForAddress(this, ...args);
+  }
 }
+
+/** Parameters of a `(client: GovernorClient, ...rest)` free function, minus `client`. */
+type TailArgs<F> = F extends (client: GovernorClient, ...rest: infer R) => unknown ? R : never;


### PR DESCRIPTION
## Summary

Split out of #778 per review feedback — this fixes pre-existing breakage on `main` that's unrelated to #772/delegate_by_sig.

The "Refactor Governor SDK into Modular Structure" merge commit (4f8e1d1) split `GovernorClient`'s ~2800-line implementation into free functions across `sdk/src/governor/{proposals,voting,queries,execution,events}.ts`, but never restored the class-method call surface most of `app/` still uses (`client.propose(...)`, `client.castVote(...)`, etc.), and dropped `queue()` entirely. This is currently invisible in CI on `main` because the Lint step fails first on a few small, unrelated pre-existing bugs, which stops the job before Type check ever gets far enough to catch it.

- `sdk/src/governor/governor-client.ts`: restore ~35 delegating wrapper methods (mechanical — each free function already takes `client: GovernorClient` as its first argument, so it's 1:1 forwarding, not a rewrite) and reconstruct `queue()` from the pre-refactor implementation.

Unblocking Lint and Type check surfaced further small, genuinely separate pre-existing issues, all fixed here (see commit message for the full list): missing `@/*` path alias in `tsconfig.json`/`jest.config.js`, Jest picking up Playwright's `e2e/*.spec.ts` as Jest tests, `react-markdown`'s ESM dependency chain not being transpiled, a couple of type bugs, a real `VotingModal` a11y bug (`role="dialog"` and `tabIndex={-1}` on two different elements), two tests asserting against behavior that had since changed, and a stray duplicate import line / missing import in two files.

## Test plan
- [x] `pnpm --filter @nebgov/sdk` build / docs / test (237/237 passing)
- [x] `pnpm --filter nebgov-backend` build
- [x] `app`: `tsc --noEmit` (clean), `eslint` (0 errors), `jest` (72/72 passing, 27/27 snapshots), full `next build` (all pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)