### PR TITLE
feat(token-votes): implement on-chain delegation registry with depth limits and history

### DIFF
--- a/app/src/app/profile/[address]/page.tsx
+++ b/app/src/app/profile/[address]/page.tsx
@@ -9,6 +9,7 @@ import {
   ProposalState,
   Network,
   VoteSupport,
+  DelegationHistoryEntry,
 } from "@nebgov/sdk";
 import {
   LineChart,
@@ -20,6 +21,9 @@ import {
   CartesianGrid,
 } from "recharts";
 import { useGovernorConfig } from "@/hooks/useGovernorConfig";
+import { useDelegateProfile } from "@/hooks/useDelegateProfile";
+import { DelegationChain } from "@/components/DelegationChain";
+import { DelegatorList } from "@/components/DelegatorList";
 import { isValidStellarAddress, formatVotingPower } from "../../../lib/utils";
 
 interface VotingRecord {
@@ -72,6 +76,13 @@ function VoterProfilePageContent() {
   >([]);
   const [error, setError] = useState<string | null>(null);
   const [federatedName, setFederatedName] = useState<string | null>(null);
+
+  // Delegation registry (issue #769)
+  const { profile: delegateProfile } = useDelegateProfile(address);
+  const [registryTab, setRegistryTab] = useState<"history" | "received">("history");
+  const [delegationChain, setDelegationChain] = useState<string[]>([]);
+  const [delegationHistory, setDelegationHistory] = useState<DelegationHistoryEntry[]>([]);
+  const [registryLoading, setRegistryLoading] = useState(true);
 
   // Validate address
   const isValidAddress = address && isValidStellarAddress(String(address));
@@ -233,6 +244,55 @@ function VoterProfilePageContent() {
     fetchProfileData();
   }, [address, isValidAddress]);
 
+  useEffect(() => {
+    if (!isValidAddress) {
+      setRegistryLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchRegistryData() {
+      setRegistryLoading(true);
+      try {
+        const governorAddress = process.env.NEXT_PUBLIC_GOVERNOR_ADDRESS;
+        const timelockAddress = process.env.NEXT_PUBLIC_TIMELOCK_ADDRESS;
+        const votesAddress = process.env.NEXT_PUBLIC_VOTES_ADDRESS;
+        const network = (process.env.NEXT_PUBLIC_NETWORK || "testnet") as Network;
+        const rpcUrl = process.env.NEXT_PUBLIC_RPC_URL;
+
+        if (!governorAddress || !timelockAddress || !votesAddress) return;
+
+        const votesClient = new VotesClient({
+          governorAddress,
+          timelockAddress,
+          votesAddress,
+          network,
+          ...(rpcUrl && { rpcUrl }),
+        });
+
+        const [chain, history] = await Promise.all([
+          votesClient.getDelegationChain(address),
+          votesClient.getDelegationHistory(address),
+        ]);
+
+        if (!cancelled) {
+          setDelegationChain(chain);
+          setDelegationHistory(history);
+        }
+      } catch {
+        // Registry data is supplementary; fail silently and show empty state.
+      } finally {
+        if (!cancelled) setRegistryLoading(false);
+      }
+    }
+
+    fetchRegistryData();
+    return () => {
+      cancelled = true;
+    };
+  }, [address, isValidAddress]);
+
   if (loading) {
     return (
       <div className="max-w-4xl mx-auto px-4 py-8">
@@ -390,6 +450,117 @@ function VoterProfilePageContent() {
           </div>
         </div>
       )}
+
+      {/* Delegation Registry (issue #769) */}
+      <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-6 mb-8">
+        <p className="text-sm font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wide mb-4">
+          Delegation Registry
+        </p>
+
+        {delegateProfile && (
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6 text-sm">
+            <div>
+              <p className="text-xs text-gray-500 dark:text-gray-400">Delegators</p>
+              <p className="font-semibold text-gray-900 dark:text-gray-100">
+                {delegateProfile.totalDelegators}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 dark:text-gray-400">Delegated power</p>
+              <p className="font-semibold text-gray-900 dark:text-gray-100">
+                {formatVotingPower(delegateProfile.totalDelegatedPower)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 dark:text-gray-400">Depth limit</p>
+              <p className="font-semibold text-gray-900 dark:text-gray-100">
+                {delegateProfile.delegationDepthLimit}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 dark:text-gray-400">First delegated</p>
+              <p className="font-semibold text-gray-900 dark:text-gray-100">
+                {delegateProfile.firstDelegatedAtLedger !== null
+                  ? `ledger #${delegateProfile.firstDelegatedAtLedger}`
+                  : "—"}
+              </p>
+            </div>
+          </div>
+        )}
+
+        <div className="mb-6">
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">Delegation chain</p>
+          {registryLoading ? (
+            <div className="h-5 w-48 bg-gray-200 dark:bg-gray-700 animate-pulse rounded" />
+          ) : (
+            <DelegationChain chain={delegationChain} />
+          )}
+        </div>
+
+        <div className="border-b border-gray-200 dark:border-gray-700 mb-4 flex gap-4">
+          <button
+            onClick={() => setRegistryTab("history")}
+            className={`pb-2 text-sm font-medium border-b-2 -mb-px ${
+              registryTab === "history"
+                ? "border-indigo-600 text-indigo-600 dark:text-indigo-400"
+                : "border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700"
+            }`}
+          >
+            Delegation History
+          </button>
+          <button
+            onClick={() => setRegistryTab("received")}
+            className={`pb-2 text-sm font-medium border-b-2 -mb-px ${
+              registryTab === "received"
+                ? "border-indigo-600 text-indigo-600 dark:text-indigo-400"
+                : "border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700"
+            }`}
+          >
+            Received Delegations
+          </button>
+        </div>
+
+        {registryTab === "history" ? (
+          registryLoading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="h-6 bg-gray-200 dark:bg-gray-700 animate-pulse rounded" />
+              ))}
+            </div>
+          ) : delegationHistory.length === 0 ? (
+            <p className="text-sm text-gray-500 dark:text-gray-400">No delegation history found.</p>
+          ) : (
+            <div className="space-y-2">
+              {delegationHistory.map((entry, i) => (
+                <div
+                  key={`${entry.delegatee}-${entry.sequence}-${i}`}
+                  className="flex items-center justify-between text-sm border-b border-gray-100 dark:border-gray-800 pb-2 last:border-0"
+                >
+                  <Link
+                    href={`/profile/${entry.delegatee}`}
+                    className="font-mono text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300"
+                  >
+                    {entry.delegatee}
+                  </Link>
+                  <div className="text-right text-gray-500 dark:text-gray-400">
+                    <span>{formatVotingPower(entry.powerAtDelegation)}</span>
+                    <span className="mx-1">·</span>
+                    <span>ledger #{entry.delegatedAtLedger}</span>
+                    <span className="mx-1">·</span>
+                    {entry.revokedAtLedger !== null ? (
+                      <span>revoked #{entry.revokedAtLedger}</span>
+                    ) : (
+                      <span className="text-green-600 dark:text-green-400">active</span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )
+        ) : (
+          <DelegatorList delegatee={address} />
+        )}
+      </div>
 
       {/* Voting Power History */}
       <div className="bg-white border border-gray-200 rounded-xl p-6 mb-8">

--- a/app/src/components/DelegationChain.tsx
+++ b/app/src/components/DelegationChain.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import Link from "next/link";
+import { AddressDisplay } from "./AddressDisplay";
+
+interface DelegationChainProps {
+  /** Ordered chain of addresses from the delegator to the final tip. */
+  chain: string[];
+  className?: string;
+}
+
+/**
+ * Renders a delegation chain as a linear sequence: A → B → C, with each
+ * hop linking to that address's profile page. A single-element chain means
+ * the address is not currently delegating to anyone else.
+ */
+export function DelegationChain({ chain, className = "" }: DelegationChainProps) {
+  if (chain.length === 0) {
+    return <p className="text-sm text-gray-500 dark:text-gray-400">No delegation chain found.</p>;
+  }
+
+  if (chain.length === 1) {
+    return (
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        Not delegating to anyone else.
+      </p>
+    );
+  }
+
+  return (
+    <div className={`flex flex-wrap items-center gap-2 ${className}`}>
+      {chain.map((address, index) => (
+        <div key={`${address}-${index}`} className="flex items-center gap-2">
+          <Link
+            href={`/profile/${address}`}
+            className="font-mono text-sm text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300"
+          >
+            <AddressDisplay address={address} />
+          </Link>
+          {index < chain.length - 1 && (
+            <span className="text-gray-400 dark:text-gray-500" aria-hidden="true">
+              →
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/src/components/DelegatorList.tsx
+++ b/app/src/components/DelegatorList.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { VotesClient, RegistryDelegatorInfo, Network } from "@nebgov/sdk";
+import { AddressDisplay } from "./AddressDisplay";
+import { formatVotingPower } from "../lib/utils";
+
+interface DelegatorListProps {
+  /** Address to list current delegators for. */
+  delegatee: string;
+  pageSize?: number;
+  className?: string;
+}
+
+/**
+ * Paginated list of all current delegators for a delegatee, backed by the
+ * on-chain delegation registry (issue #769) via
+ * {@link VotesClient.getRegistryDelegators}.
+ */
+export function DelegatorList({ delegatee, pageSize = 10, className = "" }: DelegatorListProps) {
+  const [offset, setOffset] = useState(0);
+  const [delegators, setDelegators] = useState<RegistryDelegatorInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchPage = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const governorAddress = process.env.NEXT_PUBLIC_GOVERNOR_ADDRESS;
+      const timelockAddress = process.env.NEXT_PUBLIC_TIMELOCK_ADDRESS;
+      const votesAddress = process.env.NEXT_PUBLIC_VOTES_ADDRESS;
+      const network = (process.env.NEXT_PUBLIC_NETWORK || "testnet") as Network;
+      const rpcUrl = process.env.NEXT_PUBLIC_RPC_URL;
+
+      if (!governorAddress || !timelockAddress || !votesAddress) {
+        throw new Error("Missing required environment variables for VotesClient");
+      }
+
+      const votesClient = new VotesClient({
+        governorAddress,
+        timelockAddress,
+        votesAddress,
+        network,
+        ...(rpcUrl && { rpcUrl }),
+      });
+
+      const page = await votesClient.getRegistryDelegators(delegatee, offset, pageSize);
+      setDelegators(page);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load delegators");
+    } finally {
+      setLoading(false);
+    }
+  }, [delegatee, offset, pageSize]);
+
+  useEffect(() => {
+    fetchPage();
+  }, [fetchPage]);
+
+  if (loading) {
+    return (
+      <div className={`space-y-2 ${className}`}>
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-6 bg-gray-200 dark:bg-gray-700 animate-pulse rounded" />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return <p className="text-sm text-red-600 dark:text-red-400">{error}</p>;
+  }
+
+  if (delegators.length === 0 && offset === 0) {
+    return <p className="text-sm text-gray-500 dark:text-gray-400">No current delegators.</p>;
+  }
+
+  return (
+    <div className={className}>
+      <div className="space-y-2">
+        {delegators.map((d) => (
+          <div
+            key={d.address}
+            className="flex items-center justify-between text-sm border-b border-gray-100 dark:border-gray-800 pb-2 last:border-0"
+          >
+            <Link
+              href={`/profile/${d.address}`}
+              className="font-mono text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300"
+            >
+              <AddressDisplay address={d.address} />
+            </Link>
+            <div className="text-right text-gray-500 dark:text-gray-400">
+              <span>{formatVotingPower(d.delegatedPower)}</span>
+              <span className="mx-1">·</span>
+              <span>ledger #{d.delegatedAtLedger}</span>
+              {d.chainDepth > 1 && (
+                <>
+                  <span className="mx-1">·</span>
+                  <span>depth {d.chainDepth}</span>
+                </>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex items-center justify-between mt-4">
+        <button
+          onClick={() => setOffset((o) => Math.max(0, o - pageSize))}
+          disabled={offset === 0}
+          className="text-xs px-3 py-1 rounded border border-gray-300 dark:border-gray-600 disabled:opacity-40 disabled:cursor-not-allowed hover:bg-gray-50 dark:hover:bg-gray-800"
+        >
+          ← Previous
+        </button>
+        <span className="text-xs text-gray-500 dark:text-gray-400">
+          Showing {offset + 1}–{offset + delegators.length}
+        </span>
+        <button
+          onClick={() => setOffset((o) => o + pageSize)}
+          disabled={delegators.length < pageSize}
+          className="text-xs px-3 py-1 rounded border border-gray-300 dark:border-gray-600 disabled:opacity-40 disabled:cursor-not-allowed hover:bg-gray-50 dark:hover:bg-gray-800"
+        >
+          Next →
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/__tests__/DelegationChain.test.tsx
+++ b/app/src/components/__tests__/DelegationChain.test.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { DelegationChain } from "../DelegationChain";
+
+describe("DelegationChain", () => {
+  it("shows a message when the chain is empty", () => {
+    const tree = renderer.create(<DelegationChain chain={[]} />).toJSON();
+    expect(JSON.stringify(tree)).toContain("No delegation chain found");
+  });
+
+  it("shows a not-delegating message for a single-element chain", () => {
+    const tree = renderer
+      .create(<DelegationChain chain={["GADDR1"]} />)
+      .toJSON();
+    expect(JSON.stringify(tree)).toContain("Not delegating to anyone else");
+  });
+
+  it("renders every address and an arrow between each hop", () => {
+    const chain = ["GADDR1", "GADDR2", "GADDR3"];
+    const tree = renderer.create(<DelegationChain chain={chain} />).toJSON();
+    const serialized = JSON.stringify(tree);
+
+    for (const address of chain) {
+      expect(serialized).toContain(address);
+    }
+    expect((serialized.match(/→/g) ?? []).length).toBe(chain.length - 1);
+  });
+});

--- a/app/src/hooks/useDelegateProfile.ts
+++ b/app/src/hooks/useDelegateProfile.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { VotesClient, DelegateProfile, Network } from "@nebgov/sdk";
+
+interface UseDelegateProfileResult {
+  profile: DelegateProfile | null;
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Fetch the on-chain delegation registry profile (issue #769) for an
+ * address: current/base voting power, delegator count, total delegated
+ * power, the configured chain depth limit, and when it was first delegated
+ * to.
+ */
+export function useDelegateProfile(address: string | undefined): UseDelegateProfileResult {
+  const [profile, setProfile] = useState<DelegateProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!address) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchProfile() {
+      setLoading(true);
+      setError(null);
+      try {
+        const governorAddress = process.env.NEXT_PUBLIC_GOVERNOR_ADDRESS;
+        const timelockAddress = process.env.NEXT_PUBLIC_TIMELOCK_ADDRESS;
+        const votesAddress = process.env.NEXT_PUBLIC_VOTES_ADDRESS;
+        const network = (process.env.NEXT_PUBLIC_NETWORK || "testnet") as Network;
+        const rpcUrl = process.env.NEXT_PUBLIC_RPC_URL;
+
+        if (!governorAddress || !timelockAddress || !votesAddress) {
+          throw new Error("Missing required environment variables for VotesClient");
+        }
+
+        const votesClient = new VotesClient({
+          governorAddress,
+          timelockAddress,
+          votesAddress,
+          network,
+          ...(rpcUrl && { rpcUrl }),
+        });
+
+        const result = await votesClient.getDelegateProfile(address as string);
+        if (!cancelled) setProfile(result);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load delegate profile");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchProfile();
+    return () => {
+      cancelled = true;
+    };
+  }, [address]);
+
+  return { profile, loading, error };
+}

--- a/contracts/token-votes/src/delegation_registry.rs
+++ b/contracts/token-votes/src/delegation_registry.rs
@@ -1,0 +1,470 @@
+//! Delegation Registry: on-chain bookkeeping for who delegated to whom, when,
+//! and through what chain, layered on top of the existing single-hop
+//! `Delegate` mapping in `lib.rs`. This module does not change how voting
+//! power itself is computed (see `apply_delegation`/`update_account_votes`);
+//! it tracks history, per-delegatee delegator lists, and enforces a
+//! configurable delegation-chain depth limit so that transitive delegation
+//! (already representable via the existing `Delegate` mapping) can be
+//! resolved, audited, and bounded.
+
+use crate::{DataKey, TokenVotesContract};
+use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
+
+/// Safety bound on delegation-chain traversal. Real chains are already
+/// bounded by `DelegationDepthLimit` at write time; this guards read-side
+/// traversal against unbounded gas usage if that invariant is ever violated.
+const MAX_CHAIN_WALK: u32 = 64;
+
+#[contracttype]
+#[derive(Clone)]
+pub struct DelegationEntry {
+    pub delegator: Address,
+    pub delegatee: Address,
+    pub delegated_at_ledger: u32,
+    pub voting_power_at_delegation: i128,
+    pub active: bool,
+    pub revoked_at_ledger: Option<u32>,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct DelegationHistoryEntry {
+    pub delegatee: Address,
+    pub delegated_at_ledger: u32,
+    pub revoked_at_ledger: Option<u32>,
+    pub power_at_delegation: i128,
+    pub sequence: u32,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct DelegatorInfo {
+    pub address: Address,
+    pub delegated_power: i128,
+    pub delegated_at_ledger: u32,
+    pub chain_depth: u32,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct DelegateProfile {
+    pub address: Address,
+    pub current_voting_power: i128,
+    pub base_voting_power: i128,
+    pub total_delegators: u32,
+    pub total_delegated_power: i128,
+    pub delegation_depth_limit: u32,
+    pub first_delegated_at_ledger: Option<u32>,
+}
+
+// --- Internal helpers (called from lib.rs's apply_delegation hook) ---
+
+fn get_depth_limit(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::DelegationDepthLimit)
+        .unwrap_or(1)
+}
+
+/// Resolve the live delegation chain starting at `start`, following the
+/// `Delegate` mapping until a terminal node (self-delegated or undelegated)
+/// or `MAX_CHAIN_WALK` hops. Includes `start` as the first element.
+fn resolve_chain(env: &Env, start: Address) -> Vec<Address> {
+    let mut chain = Vec::new(env);
+    chain.push_back(start.clone());
+    let mut current = start;
+    let mut hops = 0u32;
+    loop {
+        if hops >= MAX_CHAIN_WALK {
+            break;
+        }
+        let next: Option<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Delegate(current.clone()));
+        match next {
+            Some(n) if n != current => {
+                current = n.clone();
+                chain.push_back(n);
+                hops += 1;
+            }
+            _ => break,
+        }
+    }
+    chain
+}
+
+fn register_known_delegator(env: &Env, delegator: &Address) {
+    let known_key = DataKey::IsKnownDelegator(delegator.clone());
+    let already: bool = env.storage().persistent().get(&known_key).unwrap_or(false);
+    if !already {
+        let mut all: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AllDelegators)
+            .unwrap_or(Vec::new(env));
+        all.push_back(delegator.clone());
+        env.storage().persistent().set(&DataKey::AllDelegators, &all);
+        env.storage().persistent().set(&known_key, &true);
+    }
+}
+
+fn emit_delegation_registered(
+    env: &Env,
+    delegator: &Address,
+    delegatee: &Address,
+    power: i128,
+    chain_depth: u32,
+) {
+    env.events().publish(
+        (Symbol::new(env, "DelegationRegistered"), delegator.clone()),
+        (delegatee.clone(), power, chain_depth),
+    );
+}
+
+fn emit_delegation_revoked(env: &Env, delegator: &Address, previous_delegatee: &Address, at_ledger: u32) {
+    env.events().publish(
+        (Symbol::new(env, "DelegationRevoked"), delegator.clone()),
+        (previous_delegatee.clone(), at_ledger),
+    );
+}
+
+fn emit_delegation_depth_limit_updated(env: &Env, old_limit: u32, new_limit: u32) {
+    env.events().publish(
+        (Symbol::new(env, "DelegationDepthLimitUpdated"),),
+        (old_limit, new_limit),
+    );
+}
+
+/// Validate that delegating from `delegator` to `delegatee` is legal
+/// (no cycle, does not exceed the configured depth limit). Must be called
+/// before any state mutation for this delegation.
+pub(crate) fn validate_delegation(env: &Env, delegator: &Address, delegatee: &Address) {
+    assert!(
+        !would_create_cycle(env, delegator.clone(), delegatee.clone()),
+        "delegation would create a cycle"
+    );
+
+    let prospective_depth = resolve_chain(env, delegatee.clone()).len();
+    let limit = get_depth_limit(env);
+    assert!(
+        prospective_depth <= limit,
+        "delegation would exceed max chain depth"
+    );
+}
+
+/// Record a (new or changed) delegation in the registry. Must be called
+/// after the `Delegate(delegator)` mapping has already been updated to
+/// `delegatee`, so that chain resolution reflects the new edge.
+pub(crate) fn register_delegation(
+    env: &Env,
+    delegator: &Address,
+    delegatee: &Address,
+    power: i128,
+    current_ledger: u32,
+) {
+    let history_key = DataKey::DelegationHistory(delegator.clone());
+    let mut history: Vec<DelegationHistoryEntry> = env
+        .storage()
+        .persistent()
+        .get(&history_key)
+        .unwrap_or(Vec::new(env));
+    let sequence = history.len();
+    history.push_back(DelegationHistoryEntry {
+        delegatee: delegatee.clone(),
+        delegated_at_ledger: current_ledger,
+        revoked_at_ledger: None,
+        power_at_delegation: power,
+        sequence,
+    });
+    env.storage().persistent().set(&history_key, &history);
+
+    env.storage().persistent().set(
+        &DataKey::DelegationRecord(delegator.clone(), delegatee.clone()),
+        &DelegationEntry {
+            delegator: delegator.clone(),
+            delegatee: delegatee.clone(),
+            delegated_at_ledger: current_ledger,
+            voting_power_at_delegation: power,
+            active: true,
+            revoked_at_ledger: None,
+        },
+    );
+
+    let received_key = DataKey::ReceivedDelegations(delegatee.clone());
+    let mut received: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&received_key)
+        .unwrap_or(Vec::new(env));
+    received.push_back(delegator.clone());
+    env.storage().persistent().set(&received_key, &received);
+
+    let count_key = DataKey::TotalDelegatorsFor(delegatee.clone());
+    let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+    env.storage().persistent().set(&count_key, &(count + 1));
+
+    let full_chain = resolve_chain(env, delegator.clone());
+    let depth = full_chain.len() - 1;
+    env.storage()
+        .persistent()
+        .set(&DataKey::DelegationChain(delegator.clone()), &full_chain);
+    env.storage()
+        .persistent()
+        .set(&DataKey::ChainDepth(delegator.clone()), &depth);
+
+    register_known_delegator(env, delegator);
+
+    emit_delegation_registered(env, delegator, delegatee, power, depth);
+}
+
+/// Revoke a previously-registered delegation from `delegator` to
+/// `old_delegatee` (called when `delegator` moves away from `old_delegatee`,
+/// including moving back to self).
+pub(crate) fn revoke_registry_entry(
+    env: &Env,
+    delegator: &Address,
+    old_delegatee: &Address,
+    current_ledger: u32,
+) {
+    let record_key = DataKey::DelegationRecord(delegator.clone(), old_delegatee.clone());
+    if let Some(mut entry) = env
+        .storage()
+        .persistent()
+        .get::<_, DelegationEntry>(&record_key)
+    {
+        entry.active = false;
+        entry.revoked_at_ledger = Some(current_ledger);
+        env.storage().persistent().set(&record_key, &entry);
+    }
+
+    let history_key = DataKey::DelegationHistory(delegator.clone());
+    if let Some(mut history) = env
+        .storage()
+        .persistent()
+        .get::<_, Vec<DelegationHistoryEntry>>(&history_key)
+    {
+        let len = history.len();
+        let mut i = len;
+        while i > 0 {
+            i -= 1;
+            let mut h = history.get(i).unwrap();
+            if h.delegatee == *old_delegatee && h.revoked_at_ledger.is_none() {
+                h.revoked_at_ledger = Some(current_ledger);
+                history.set(i, h);
+                break;
+            }
+        }
+        env.storage().persistent().set(&history_key, &history);
+    }
+
+    let received_key = DataKey::ReceivedDelegations(old_delegatee.clone());
+    if let Some(mut received) = env.storage().persistent().get::<_, Vec<Address>>(&received_key) {
+        if let Some(idx) = received.first_index_of(delegator.clone()) {
+            received.remove(idx);
+            env.storage().persistent().set(&received_key, &received);
+        }
+    }
+
+    let count_key = DataKey::TotalDelegatorsFor(old_delegatee.clone());
+    let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+    if count > 0 {
+        env.storage().persistent().set(&count_key, &(count - 1));
+    }
+
+    emit_delegation_revoked(env, delegator, old_delegatee, current_ledger);
+}
+
+// --- Public query / admin functions (wrapped by contract entrypoints in lib.rs) ---
+
+pub(crate) fn get_delegation_history(env: &Env, delegator: Address) -> Vec<DelegationHistoryEntry> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::DelegationHistory(delegator))
+        .unwrap_or(Vec::new(env))
+}
+
+pub(crate) fn get_delegators(
+    env: &Env,
+    delegatee: Address,
+    offset: u32,
+    limit: u32,
+) -> Vec<DelegatorInfo> {
+    let received: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ReceivedDelegations(delegatee.clone()))
+        .unwrap_or(Vec::new(env));
+
+    let mut result = Vec::new(env);
+    let len = received.len();
+    let mut i = offset;
+    let end = offset.saturating_add(limit).min(len);
+    while i < end {
+        let delegator = received.get(i).unwrap();
+        let record: Option<DelegationEntry> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::DelegationRecord(delegator.clone(), delegatee.clone()));
+        let record_balance: crate::DelegatorRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::DelegatorRecord(delegator.clone()))
+            .unwrap_or_default();
+
+        result.push_back(DelegatorInfo {
+            address: delegator.clone(),
+            delegated_power: record_balance.balance,
+            delegated_at_ledger: record.map(|r| r.delegated_at_ledger).unwrap_or(0),
+            chain_depth: get_chain_depth(env, delegator),
+        });
+        i += 1;
+    }
+    result
+}
+
+pub(crate) fn get_delegator_count(env: &Env, delegatee: Address) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::TotalDelegatorsFor(delegatee))
+        .unwrap_or(0)
+}
+
+pub(crate) fn get_delegation_chain(env: &Env, delegator: Address) -> Vec<Address> {
+    resolve_chain(env, delegator)
+}
+
+pub(crate) fn get_chain_depth(env: &Env, delegator: Address) -> u32 {
+    resolve_chain(env, delegator).len() - 1
+}
+
+pub(crate) fn would_create_cycle(env: &Env, delegator: Address, delegatee: Address) -> bool {
+    if delegator == delegatee {
+        return false;
+    }
+    let chain = resolve_chain(env, delegatee);
+    chain.contains(delegator)
+}
+
+pub(crate) fn get_delegate_profile(env: &Env, address: Address) -> DelegateProfile {
+    let current_voting_power = TokenVotesContract::get_votes(env.clone(), address.clone());
+    let base_voting_power = TokenVotesContract::get_base_votes(env.clone(), address.clone());
+    let total_delegators = get_delegator_count(env, address.clone());
+
+    let received: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ReceivedDelegations(address.clone()))
+        .unwrap_or(Vec::new(env));
+
+    let mut total_delegated_power: i128 = 0;
+    let mut first_delegated_at_ledger: Option<u32> = None;
+    for delegator in received.iter() {
+        let record_balance: crate::DelegatorRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::DelegatorRecord(delegator.clone()))
+            .unwrap_or_default();
+        total_delegated_power += record_balance.balance;
+
+        if let Some(entry) = env.storage().persistent().get::<_, DelegationEntry>(
+            &DataKey::DelegationRecord(delegator.clone(), address.clone()),
+        ) {
+            first_delegated_at_ledger = Some(match first_delegated_at_ledger {
+                Some(existing) => existing.min(entry.delegated_at_ledger),
+                None => entry.delegated_at_ledger,
+            });
+        }
+    }
+
+    DelegateProfile {
+        address,
+        current_voting_power,
+        base_voting_power,
+        total_delegators,
+        total_delegated_power,
+        delegation_depth_limit: get_depth_limit(env),
+        first_delegated_at_ledger,
+    }
+}
+
+pub(crate) fn get_received_delegations(
+    env: &Env,
+    delegatee: Address,
+    offset: u32,
+    limit: u32,
+) -> Vec<DelegationEntry> {
+    let received: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ReceivedDelegations(delegatee.clone()))
+        .unwrap_or(Vec::new(env));
+
+    let mut result = Vec::new(env);
+    let len = received.len();
+    let mut i = offset;
+    let end = offset.saturating_add(limit).min(len);
+    while i < end {
+        let delegator = received.get(i).unwrap();
+        if let Some(entry) = env.storage().persistent().get::<_, DelegationEntry>(
+            &DataKey::DelegationRecord(delegator, delegatee.clone()),
+        ) {
+            result.push_back(entry);
+        }
+        i += 1;
+    }
+    result
+}
+
+pub(crate) fn set_delegation_depth_limit(env: &Env, new_limit: u32) {
+    assert!(new_limit >= 1, "depth limit must be at least 1");
+    let old_limit = get_depth_limit(env);
+    env.storage()
+        .instance()
+        .set(&DataKey::DelegationDepthLimit, &new_limit);
+    emit_delegation_depth_limit_updated(env, old_limit, new_limit);
+}
+
+pub(crate) fn get_delegation_depth_limit(env: &Env) -> u32 {
+    get_depth_limit(env)
+}
+
+/// Snapshot of all delegators active for `delegatee` at a past ledger,
+/// reconstructed from each known delegator's history log. `chain_depth` is
+/// not reconstructed historically and is always reported as 0.
+pub(crate) fn get_delegation_snapshot(
+    env: &Env,
+    delegatee: Address,
+    at_ledger: u32,
+) -> Vec<DelegatorInfo> {
+    let all_delegators: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::AllDelegators)
+        .unwrap_or(Vec::new(env));
+
+    let mut result = Vec::new(env);
+    for delegator in all_delegators.iter() {
+        let history: Vec<DelegationHistoryEntry> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::DelegationHistory(delegator.clone()))
+            .unwrap_or(Vec::new(env));
+
+        for entry in history.iter() {
+            if entry.delegatee == delegatee
+                && entry.delegated_at_ledger <= at_ledger
+                && entry.revoked_at_ledger.is_none_or(|r| r > at_ledger)
+            {
+                result.push_back(DelegatorInfo {
+                    address: delegator.clone(),
+                    delegated_power: entry.power_at_delegation,
+                    delegated_at_ledger: entry.delegated_at_ledger,
+                    chain_depth: 0,
+                });
+                break;
+            }
+        }
+    }
+    result
+}

--- a/contracts/token-votes/src/delegation_registry_tests.rs
+++ b/contracts/token-votes/src/delegation_registry_tests.rs
@@ -1,0 +1,393 @@
+//! Tests for the delegation registry (issue #769): entry/history bookkeeping,
+//! received-delegation lists, delegator counts, chain resolution, cycle
+//! detection, depth-limit enforcement, historical snapshots, delegate
+//! profiles, and pagination.
+
+use crate::{TokenVotesContract, TokenVotesContractClient};
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{token, Address, Env};
+
+fn setup(env: &Env, admin: &Address) -> (Address, Address) {
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_addr = sac.address();
+    let contract_id = env.register(TokenVotesContract, ());
+    let client = TokenVotesContractClient::new(env, &contract_id);
+    client.initialize(admin, &token_addr);
+    (contract_id, token_addr)
+}
+
+fn set_ledger(env: &Env, seq: u32) {
+    env.ledger().with_mut(|l| {
+        l.sequence_number = seq;
+    });
+}
+
+#[test]
+fn test_delegation_entry_written_on_delegate_call() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    token::StellarAssetClient::new(&env, &token_addr).mint(&delegator, &1000i128);
+
+    set_ledger(&env, 10);
+    client.delegate(&delegator, &delegatee);
+
+    let entries = client.get_received_delegations(&delegatee, &0, &10);
+    assert_eq!(entries.len(), 1);
+    let entry = entries.get(0).unwrap();
+    assert_eq!(entry.delegator, delegator);
+    assert_eq!(entry.delegatee, delegatee);
+    assert_eq!(entry.delegated_at_ledger, 10);
+    assert_eq!(entry.voting_power_at_delegation, 1000);
+    assert!(entry.active);
+    assert_eq!(entry.revoked_at_ledger, None);
+
+    let history = client.get_delegation_history(&delegator);
+    assert_eq!(history.len(), 1);
+    assert_eq!(history.get(0).unwrap().delegatee, delegatee);
+}
+
+#[test]
+fn test_delegation_history_append_on_re_delegation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let (contract_id, _token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+
+    set_ledger(&env, 10);
+    client.delegate(&delegator, &a);
+
+    set_ledger(&env, 20);
+    client.delegate(&delegator, &b);
+
+    let history = client.get_delegation_history(&delegator);
+    assert_eq!(history.len(), 2);
+
+    let first = history.get(0).unwrap();
+    assert_eq!(first.delegatee, a);
+    assert_eq!(first.delegated_at_ledger, 10);
+    assert_eq!(first.revoked_at_ledger, Some(20));
+
+    let second = history.get(1).unwrap();
+    assert_eq!(second.delegatee, b);
+    assert_eq!(second.delegated_at_ledger, 20);
+    assert_eq!(second.revoked_at_ledger, None);
+}
+
+#[test]
+fn test_delegation_history_records_revocation_ledger() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let a = Address::generate(&env);
+
+    let (contract_id, _token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+
+    set_ledger(&env, 5);
+    client.delegate(&delegator, &a);
+
+    set_ledger(&env, 42);
+    client.undelegate(&delegator);
+
+    let history = client.get_delegation_history(&delegator);
+    assert_eq!(history.len(), 1);
+    assert_eq!(history.get(0).unwrap().revoked_at_ledger, Some(42));
+}
+
+#[test]
+fn test_received_delegations_updated_on_delegate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+
+    let (contract_id, _token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+
+    client.delegate(&delegator, &delegatee);
+
+    let delegators = client.get_delegators(&delegatee, &0, &10);
+    assert_eq!(delegators.len(), 1);
+    assert_eq!(delegators.get(0).unwrap().address, delegator);
+}
+
+#[test]
+fn test_received_delegations_updated_on_re_delegation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let (contract_id, _token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+
+    client.delegate(&delegator, &a);
+    set_ledger(&env, 2);
+    client.delegate(&delegator, &b);
+
+    assert_eq!(client.get_delegators(&a, &0, &10).len(), 0);
+    let b_delegators = client.get_delegators(&b, &0, &10);
+    assert_eq!(b_delegators.len(), 1);
+    assert_eq!(b_delegators.get(0).unwrap().address, delegator);
+}
+
+#[test]
+fn test_delegator_count_increments_and_decrements() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+
+    let (contract_id, _token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_delegator_count(&delegatee), 0);
+
+    client.delegate(&delegator, &delegatee);
+    assert_eq!(client.get_delegator_count(&delegatee), 1);
+
+    set_ledger(&env, 2);
+    client.undelegate(&delegator);
+    assert_eq!(client.get_delegator_count(&delegatee), 0);
+}
+
+#[test]
+fn test_delegation_chain_single_hop() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+
+    let (contract_id, _token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+
+    client.delegate(&delegator, &delegatee);
+
+    let chain = client.get_delegation_chain(&delegator);
+    assert_eq!(chain.len(), 2);
+    assert_eq!(chain.get(0).unwrap(), delegator);
+    assert_eq!(chain.get(1).unwrap(), delegatee);
+    assert_eq!(client.get_chain_depth(&delegator), 1);
+}
+
+/// A -> B, then B attempts to delegate to A: this loops the chain back onto
+/// itself (B -> A -> B) and must be rejected.
+#[test]
+#[should_panic(expected = "delegation would create a cycle")]
+fn test_cycle_detection_self_delegation_blocked() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let (contract_id, _token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+
+    client.delegate(&a, &b);
+    client.delegate(&b, &a);
+}
+
+/// A -> B -> C, then C attempts to delegate to A: a 3-node cycle must be
+/// rejected.
+#[test]
+#[should_panic(expected = "delegation would create a cycle")]
+fn test_cycle_detection_indirect_cycle_blocked() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    let (contract_id, _token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+
+    client.set_delegation_depth_limit(&admin, &3);
+
+    client.delegate(&a, &b);
+    set_ledger(&env, 2);
+    client.delegate(&b, &c);
+    set_ledger(&env, 3);
+    client.delegate(&c, &a);
+}
+
+/// Default depth limit is 1: B -> C first (fine, single hop from B). A -> B
+/// would then create a 2-hop chain (A -> B -> C), exceeding the default
+/// limit, and must be rejected.
+#[test]
+#[should_panic(expected = "delegation would exceed max chain depth")]
+fn test_chain_depth_limit_enforced() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    let (contract_id, _token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+
+    client.delegate(&b, &c);
+    client.delegate(&a, &b);
+}
+
+/// Raising the depth limit via the admin function allows a deeper chain that
+/// would otherwise be rejected.
+#[test]
+fn test_chain_depth_limit_can_be_raised_by_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    let (contract_id, _token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+
+    client.delegate(&b, &c);
+
+    set_ledger(&env, 2);
+    client.set_delegation_depth_limit(&admin, &2);
+    client.delegate(&a, &b);
+
+    assert_eq!(client.get_chain_depth(&a), 2);
+    let chain = client.get_delegation_chain(&a);
+    assert_eq!(chain.len(), 3);
+    assert_eq!(chain.get(2).unwrap(), c);
+}
+
+#[test]
+fn test_delegation_snapshot_at_past_ledger() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    token::StellarAssetClient::new(&env, &token_addr).mint(&delegator, &777i128);
+
+    set_ledger(&env, 10);
+    client.delegate(&delegator, &a);
+
+    set_ledger(&env, 20);
+    client.delegate(&delegator, &b);
+
+    set_ledger(&env, 25);
+    let snapshot_at_15 = client.get_delegation_snapshot(&a, &15);
+    assert_eq!(snapshot_at_15.len(), 1);
+    assert_eq!(snapshot_at_15.get(0).unwrap().address, delegator);
+    assert_eq!(snapshot_at_15.get(0).unwrap().delegated_power, 777);
+
+    let snapshot_at_20 = client.get_delegation_snapshot(&a, &20);
+    assert_eq!(snapshot_at_20.len(), 0);
+}
+
+#[test]
+fn test_delegate_profile_aggregates_all_fields() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let delegator1 = Address::generate(&env);
+    let delegator2 = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    let sac_client = token::StellarAssetClient::new(&env, &token_addr);
+    sac_client.mint(&delegator1, &300i128);
+    sac_client.mint(&delegator2, &700i128);
+
+    set_ledger(&env, 5);
+    client.delegate(&delegator1, &delegatee);
+    set_ledger(&env, 8);
+    client.delegate(&delegator2, &delegatee);
+
+    let profile = client.get_delegate_profile(&delegatee);
+    assert_eq!(profile.address, delegatee);
+    assert_eq!(profile.total_delegators, 2);
+    assert_eq!(profile.total_delegated_power, 1000);
+    assert_eq!(profile.current_voting_power, 1000);
+    assert_eq!(profile.base_voting_power, 1000);
+    assert_eq!(profile.delegation_depth_limit, 1);
+    assert_eq!(profile.first_delegated_at_ledger, Some(5));
+}
+
+#[test]
+fn test_get_delegators_pagination() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+    let d1 = Address::generate(&env);
+    let d2 = Address::generate(&env);
+    let d3 = Address::generate(&env);
+
+    let (contract_id, _token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+
+    client.delegate(&d1, &delegatee);
+    set_ledger(&env, 2);
+    client.delegate(&d2, &delegatee);
+    set_ledger(&env, 3);
+    client.delegate(&d3, &delegatee);
+
+    assert_eq!(client.get_delegator_count(&delegatee), 3);
+
+    let page = client.get_delegators(&delegatee, &1, &1);
+    assert_eq!(page.len(), 1);
+    assert_eq!(page.get(0).unwrap().address, d2);
+
+    let all = client.get_delegators(&delegatee, &0, &100);
+    assert_eq!(all.len(), 3);
+}
+
+#[test]
+fn test_delegation_depth_limit_update_by_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+
+    let (contract_id, _token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_delegation_depth_limit(), 1);
+
+    client.set_delegation_depth_limit(&admin, &5);
+    assert_eq!(client.get_delegation_depth_limit(), 5);
+}
+
+#[test]
+#[should_panic(expected = "unauthorized")]
+fn test_delegation_depth_limit_update_rejects_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let not_admin = Address::generate(&env);
+
+    let (contract_id, _token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+
+    client.set_delegation_depth_limit(&not_admin, &10);
+}

--- a/contracts/token-votes/src/lib.rs
+++ b/contracts/token-votes/src/lib.rs
@@ -4,17 +4,23 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env, Symbol, Vec,
 };
 
+mod delegation_registry;
 mod delegation_sig;
 mod error;
 mod events;
 
+pub use delegation_registry::{DelegateProfile, DelegationEntry, DelegationHistoryEntry, DelegatorInfo};
 pub use delegation_sig::DelegationPermit;
 pub use error::TokenVotesError;
 
 #[cfg(test)]
 mod delegation_sig_tests;
+
 #[cfg(test)]
 mod load_tests;
+
+#[cfg(test)]
+mod delegation_registry_tests;
 
 /// A voting power checkpoint at a specific ledger sequence.
 #[contracttype]
@@ -51,6 +57,17 @@ pub enum DataKey {
     DelegationPermitExpiry(Address),  // delegator -> u32: latest permit expiry
     RelayerWhitelist(Address),        // relayer -> bool: optional whitelist
     RelayerWhitelistEnabled,          // bool
+
+    // --- Delegation registry (issue #769) ---
+    DelegationRecord(Address, Address), // (delegator, delegatee) -> DelegationEntry
+    DelegationHistory(Address),         // delegator -> Vec<DelegationHistoryEntry>
+    ReceivedDelegations(Address),       // delegatee -> Vec<Address> (all current delegators)
+    DelegationDepthLimit,               // u32: max chain depth (default 1, upgradeable)
+    TotalDelegatorsFor(Address),        // delegatee -> u32: count of current delegators
+    DelegationChain(Address),           // delegator -> Vec<Address>: full chain from delegator to tip
+    ChainDepth(Address),                // delegator -> u32: depth of delegation chain from this delegator
+    AllDelegators,                      // Vec<Address>: every address that has ever registered a delegation
+    IsKnownDelegator(Address),          // bool marker for O(1) AllDelegators membership check
 }
 
 #[contract]
@@ -176,6 +193,16 @@ impl TokenVotesContract {
             .persistent()
             .get(&DataKey::Delegate(delegator.clone()));
 
+        // A "registry" delegation is one that hands voting power to someone
+        // else (self-delegation is the revoke/no-delegate state, not tracked
+        // as a registry entry). Validate cycle/depth *before* any state
+        // mutation below so an invalid delegation reverts cleanly.
+        let will_register =
+            delegatee != delegator && previous_delegate.as_ref() != Some(&delegatee);
+        if will_register {
+            delegation_registry::validate_delegation(env, &delegator, &delegatee);
+        }
+
         let record: DelegatorRecord = env
             .storage()
             .persistent()
@@ -244,6 +271,28 @@ impl TokenVotesContract {
             .persistent()
             .set(&DataKey::DelegatorRecord(delegator.clone()), &new_record);
 
+        // Registry bookkeeping runs after the `Delegate` mapping above is
+        // written so that chain resolution sees the new edge.
+        if will_register {
+            delegation_registry::register_delegation(
+                env,
+                &delegator,
+                &delegatee,
+                new_record.balance,
+                current_ledger,
+            );
+        }
+        if let Some(old_delegatee) = previous_delegate.clone() {
+            if old_delegatee != delegator && old_delegatee != delegatee {
+                delegation_registry::revoke_registry_entry(
+                    env,
+                    &delegator,
+                    &old_delegatee,
+                    current_ledger,
+                );
+            }
+        }
+
         env.events().publish(
             (Symbol::new(env, "DelegateChanged"), delegator.clone()),
             (previous_delegate, delegatee),
@@ -284,6 +333,15 @@ impl TokenVotesContract {
             env.storage()
                 .persistent()
                 .remove(&DataKey::DelegatorRecord(delegator.clone()));
+
+            if old_delegatee != delegator {
+                delegation_registry::revoke_registry_entry(
+                    &env,
+                    &delegator,
+                    &old_delegatee,
+                    env.ledger().sequence(),
+                );
+            }
 
             env.events().publish(
                 (symbol_short!("del_revk"), delegator),
@@ -354,6 +412,84 @@ impl TokenVotesContract {
             .instance()
             .get(&DataKey::Admin)
             .expect("not initialized")
+    }
+
+    // --- Delegation registry queries/admin (issue #769) ---
+
+    /// Get full delegation history for a delegator.
+    pub fn get_delegation_history(env: Env, delegator: Address) -> Vec<DelegationHistoryEntry> {
+        delegation_registry::get_delegation_history(&env, delegator)
+    }
+
+    /// Get all current delegators of a delegatee with their power and depth.
+    pub fn get_delegators(
+        env: Env,
+        delegatee: Address,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<DelegatorInfo> {
+        delegation_registry::get_delegators(&env, delegatee, offset, limit)
+    }
+
+    /// Get total number of current delegators.
+    pub fn get_delegator_count(env: Env, delegatee: Address) -> u32 {
+        delegation_registry::get_delegator_count(&env, delegatee)
+    }
+
+    /// Get the full delegation chain from delegator to the final tip.
+    pub fn get_delegation_chain(env: Env, delegator: Address) -> Vec<Address> {
+        delegation_registry::get_delegation_chain(&env, delegator)
+    }
+
+    /// Get depth of the delegation chain from this address.
+    pub fn get_chain_depth(env: Env, delegator: Address) -> u32 {
+        delegation_registry::get_chain_depth(&env, delegator)
+    }
+
+    /// Get comprehensive delegate profile.
+    pub fn get_delegate_profile(env: Env, address: Address) -> DelegateProfile {
+        delegation_registry::get_delegate_profile(&env, address)
+    }
+
+    /// Get all active delegations received by a delegatee (paginated).
+    pub fn get_received_delegations(
+        env: Env,
+        delegatee: Address,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<DelegationEntry> {
+        delegation_registry::get_received_delegations(&env, delegatee, offset, limit)
+    }
+
+    /// Admin function to update the maximum delegation chain depth.
+    pub fn set_delegation_depth_limit(env: Env, admin: Address, new_limit: u32) {
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        assert_eq!(admin, stored_admin, "unauthorized");
+        admin.require_auth();
+        delegation_registry::set_delegation_depth_limit(&env, new_limit);
+    }
+
+    /// Get current delegation depth limit.
+    pub fn get_delegation_depth_limit(env: Env) -> u32 {
+        delegation_registry::get_delegation_depth_limit(&env)
+    }
+
+    /// Check whether delegating from `delegator` to `delegatee` would create a cycle.
+    pub fn would_create_cycle(env: Env, delegator: Address, delegatee: Address) -> bool {
+        delegation_registry::would_create_cycle(&env, delegator, delegatee)
+    }
+
+    /// Get a snapshot of the full delegation graph at a past ledger (for audit).
+    pub fn get_delegation_snapshot(
+        env: Env,
+        delegatee: Address,
+        at_ledger: u32,
+    ) -> Vec<DelegatorInfo> {
+        delegation_registry::get_delegation_snapshot(&env, delegatee, at_ledger)
     }
 
     /// Get voting power at a past ledger sequence (snapshot).

--- a/packages/indexer/README.md
+++ b/packages/indexer/README.md
@@ -219,6 +219,7 @@ docker run --env-file packages/indexer/.env \
 | `STELLAR_RPC_URL` | Yes | `https://soroban-testnet.stellar.org` | Stellar Soroban RPC endpoint |
 | `GOVERNOR_ADDRESS` | Yes | - | Stellar contract address of the governor |
 | `WRAPPER_ADDRESS` | No | - | Stellar contract address of the token wrapper |
+| `TOKEN_VOTES_ADDRESS` | No | - | Stellar contract address of the token-votes contract (delegation registry events) |
 | `TREASURY_ADDRESS` | No | - | Stellar contract address of the treasury |
 | `LIQUIDITY_ADDRESS` | No | - | Stellar contract address of the liquidity pool |
 | `POLL_INTERVAL_MS` | No | `5000` | Milliseconds between event polling cycles |
@@ -237,6 +238,7 @@ STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 # Contract Addresses
 GOVERNOR_ADDRESS=CDLZFC3SYJYDZT7S64ZDSBLDV4G6N7JPPG2RLFHRXVJMPWI33YCH4HVD
 WRAPPER_ADDRESS=CA3D5KRYM6CB7OQ4O5K3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3
+TOKEN_VOTES_ADDRESS=CBTOKENVOTESZ3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3
 TREASURY_ADDRESS=CB3D5KRYM6CB7OQ4O5K3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3
 LIQUIDITY_ADDRESS=CC3D5KRYM6CB7OQ4O5K3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3Z3
 

--- a/packages/indexer/docker-compose.yml
+++ b/packages/indexer/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       DATABASE_URL: postgres://nebgov:nebgov@postgres:5432/nebgov
       STELLAR_RPC_URL: https://soroban-testnet.stellar.org
       GOVERNOR_ADDRESS: ${GOVERNOR_ADDRESS:-}
+      TOKEN_VOTES_ADDRESS: ${TOKEN_VOTES_ADDRESS:-}
       POLL_INTERVAL_MS: 5000
       PORT: 3001
       HEALTH_LAG_THRESHOLD: ${HEALTH_LAG_THRESHOLD:-100}

--- a/packages/indexer/migrations/004_add_delegation_registry.sql
+++ b/packages/indexer/migrations/004_add_delegation_registry.sql
@@ -1,0 +1,33 @@
+-- Up Migration
+
+CREATE TABLE IF NOT EXISTS delegation_entries (
+    id SERIAL PRIMARY KEY,
+    delegator_address VARCHAR(56) NOT NULL,
+    delegatee_address VARCHAR(56) NOT NULL,
+    delegated_at_ledger INTEGER NOT NULL,
+    revoked_at_ledger INTEGER,
+    power_at_delegation NUMERIC NOT NULL,
+    chain_depth INTEGER NOT NULL DEFAULT 1,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_delegation_delegatee ON delegation_entries(delegatee_address) WHERE active = TRUE;
+CREATE INDEX IF NOT EXISTS idx_delegation_delegator ON delegation_entries(delegator_address);
+
+CREATE TABLE IF NOT EXISTS delegation_history_snapshots (
+    id SERIAL PRIMARY KEY,
+    snapshot_ledger INTEGER NOT NULL,
+    delegatee_address VARCHAR(56) NOT NULL,
+    total_delegators INTEGER NOT NULL,
+    total_delegated_power NUMERIC NOT NULL,
+    gini_coefficient NUMERIC,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_delegation_snapshots_delegatee ON delegation_history_snapshots(delegatee_address, snapshot_ledger DESC);
+
+-- Down Migration
+
+DROP TABLE IF EXISTS delegation_history_snapshots;
+DROP TABLE IF EXISTS delegation_entries;

--- a/packages/indexer/src/api.ts
+++ b/packages/indexer/src/api.ts
@@ -114,6 +114,7 @@ const TTL = {
   delegates: 60_000, // 60 seconds
   profile: 30_000, // 30 seconds
   stats: 60_000, // 60 seconds
+  delegationRegistry: 30_000, // 30 seconds
 };
 
 const HEALTH_LAG_THRESHOLD = Number(process.env.HEALTH_LAG_THRESHOLD ?? 100);
@@ -622,6 +623,182 @@ export function createApp(server: SorobanRpc.Server): express.Application {
               withdrawalTotal: withdrawalTotal.toString(),
               wrappedBalance: wrappedBalance.toString(),
             },
+          };
+        });
+        res.json(data);
+      } catch {
+        res.status(500).json({ error: "Internal server error" });
+      }
+    },
+  );
+
+  // --- Delegation registry endpoints (issue #769) ---
+  //
+  // Backed by the `delegation_entries` table populated from the token-votes
+  // contract's DelegationRegistered/DelegationRevoked events. This is a
+  // registry-level view distinct from the governor's own `delegates` table
+  // used by GET /delegates and GET /profile/:address above.
+
+  // GET /delegates/:address/profile
+  app.get(
+    "/delegates/:address/profile",
+    strictLimiter,
+    async (req: Request, res: Response): Promise<void> => {
+      const { address } = req.params;
+      const key = `delegate_profile:${address}`;
+      try {
+        const data = await cached(key, TTL.delegationRegistry, async () => {
+          const result = await pool.query(
+            `SELECT
+               COUNT(*)::int AS total_delegators,
+               COALESCE(SUM(power_at_delegation), 0) AS total_delegated_power,
+               MIN(delegated_at_ledger) AS first_delegated_at_ledger
+             FROM delegation_entries
+             WHERE delegatee_address = $1 AND active = TRUE`,
+            [address],
+          );
+          const row = result.rows[0];
+          return {
+            address,
+            total_delegators: row?.total_delegators ?? 0,
+            total_delegated_power: String(row?.total_delegated_power ?? 0),
+            first_delegated_at_ledger: row?.first_delegated_at_ledger ?? null,
+          };
+        });
+        res.json(data);
+      } catch {
+        res.status(500).json({ error: "Internal server error" });
+      }
+    },
+  );
+
+  // GET /delegates/:address/delegators?offset=0&limit=50
+  app.get(
+    "/delegates/:address/delegators",
+    strictLimiter,
+    async (req: Request, res: Response): Promise<void> => {
+      const { address } = req.params;
+      const offset = Math.max(Number(req.query.offset ?? 0), 0);
+      const limit = Math.min(Math.max(Number(req.query.limit ?? 50), 1), 200);
+      try {
+        const result = await pool.query(
+          `SELECT delegator_address, power_at_delegation, delegated_at_ledger, chain_depth
+           FROM delegation_entries
+           WHERE delegatee_address = $1 AND active = TRUE
+           ORDER BY delegated_at_ledger ASC
+           OFFSET $2 LIMIT $3`,
+          [address, offset, limit],
+        );
+        res.json({ delegators: result.rows });
+      } catch {
+        res.status(500).json({ error: "Internal server error" });
+      }
+    },
+  );
+
+  // GET /delegates/:address/history — full history of delegations received,
+  // including revoked entries.
+  app.get(
+    "/delegates/:address/history",
+    strictLimiter,
+    async (req: Request, res: Response): Promise<void> => {
+      const { address } = req.params;
+      try {
+        const result = await pool.query(
+          `SELECT delegator_address, delegated_at_ledger, revoked_at_ledger, power_at_delegation, active
+           FROM delegation_entries
+           WHERE delegatee_address = $1
+           ORDER BY delegated_at_ledger ASC`,
+          [address],
+        );
+        res.json({ history: result.rows });
+      } catch {
+        res.status(500).json({ error: "Internal server error" });
+      }
+    },
+  );
+
+  // GET /delegates/:address/chain — resolve the delegation chain starting at
+  // `address` by following active delegation_entries edges to the tip.
+  app.get(
+    "/delegates/:address/chain",
+    strictLimiter,
+    async (req: Request, res: Response): Promise<void> => {
+      const { address } = req.params;
+      const MAX_HOPS = 64;
+      try {
+        const chain: string[] = [address];
+        const visited = new Set([address]);
+        let current = address;
+        for (let i = 0; i < MAX_HOPS; i++) {
+          const result = await pool.query(
+            `SELECT delegatee_address FROM delegation_entries
+             WHERE delegator_address = $1 AND active = TRUE
+             LIMIT 1`,
+            [current],
+          );
+          const next = result.rows[0]?.delegatee_address as string | undefined;
+          if (!next || visited.has(next)) break;
+          chain.push(next);
+          visited.add(next);
+          current = next;
+        }
+        res.json({ chain });
+      } catch {
+        res.status(500).json({ error: "Internal server error" });
+      }
+    },
+  );
+
+  // GET /delegators/:address/history — history of delegations made by this
+  // address as a delegator.
+  app.get(
+    "/delegators/:address/history",
+    strictLimiter,
+    async (req: Request, res: Response): Promise<void> => {
+      const { address } = req.params;
+      try {
+        const result = await pool.query(
+          `SELECT delegatee_address, delegated_at_ledger, revoked_at_ledger, power_at_delegation, active
+           FROM delegation_entries
+           WHERE delegator_address = $1
+           ORDER BY delegated_at_ledger ASC`,
+          [address],
+        );
+        res.json({ history: result.rows });
+      } catch {
+        res.status(500).json({ error: "Internal server error" });
+      }
+    },
+  );
+
+  // GET /delegation-graph?top=100 — top delegatees by active delegator count.
+  app.get(
+    "/delegation-graph",
+    strictLimiter,
+    async (req: Request, res: Response): Promise<void> => {
+      const top = Math.min(Math.max(Number(req.query.top ?? 100), 1), 500);
+      const key = `delegation_graph:${top}`;
+      try {
+        const data = await cached(key, TTL.delegationRegistry, async () => {
+          const result = await pool.query(
+            `SELECT
+               delegatee_address AS address,
+               COUNT(*)::int AS delegator_count,
+               COALESCE(SUM(power_at_delegation), 0) AS total_delegated_power
+             FROM delegation_entries
+             WHERE active = TRUE
+             GROUP BY delegatee_address
+             ORDER BY delegator_count DESC
+             LIMIT $1`,
+            [top],
+          );
+          return {
+            nodes: result.rows.map((r) => ({
+              address: r.address,
+              delegator_count: r.delegator_count,
+              total_delegated_power: String(r.total_delegated_power),
+            })),
           };
         });
         res.json(data);

--- a/packages/indexer/src/events.ts
+++ b/packages/indexer/src/events.ts
@@ -42,6 +42,10 @@ const TOPIC_MAP: Record<string, string> = {
   DraftFinalized: "DraftFinalized",
   DraftCancelled: "DraftCancelled",
   DraftExpired: "DraftExpired",
+  // Delegation registry events (#769)
+  DelegationRegistered: "DelegationRegistered",
+  DelegationRevoked: "DelegationRevoked",
+  DelegationDepthLimitUpdated: "DelegationDepthLimitUpdated",
 };
 
 export interface IndexerConfig {
@@ -51,6 +55,7 @@ export interface IndexerConfig {
   treasuryAddress?: string;
   liquidityAddress?: string;
   coSponsorshipAddress?: string;
+  tokenVotesAddress?: string;
   pollIntervalMs: number;
 }
 
@@ -80,6 +85,7 @@ export async function processEvents(
     if (config.treasuryAddress) contractIds.push(config.treasuryAddress);
     if (config.liquidityAddress) contractIds.push(config.liquidityAddress);
     if (config.coSponsorshipAddress) contractIds.push(config.coSponsorshipAddress);
+    if (config.tokenVotesAddress) contractIds.push(config.tokenVotesAddress);
 
     const response = await server.getEvents({
       startLedger,
@@ -120,6 +126,11 @@ export async function processEvents(
         contractId &&
         config.coSponsorshipAddress &&
         contractId === config.coSponsorshipAddress
+      );
+      const isTokenVotes = !!(
+        contractId &&
+        config.tokenVotesAddress &&
+        contractId === config.tokenVotesAddress
       );
 
       try {
@@ -183,6 +194,23 @@ export async function processEvents(
               break;
             case "DraftExpired":
               await handleDraftExpired(event);
+              break;
+            default:
+              break;
+          }
+        } else if (isTokenVotes) {
+          switch (eventType) {
+            case "DelegateChanged":
+              await handleDelegateChanged(event, topics);
+              break;
+            case "DelegationRegistered":
+              await handleDelegationRegistered(event, topics);
+              break;
+            case "DelegationRevoked":
+              await handleDelegationRevoked(event, topics);
+              break;
+            case "DelegationDepthLimitUpdated":
+              await handleDelegationDepthLimitUpdated(event, topics);
               break;
             default:
               break;
@@ -353,6 +381,63 @@ async function handleDelegateChanged(
   broadcast({
     type: "delegate_changed",
     data: { delegator, old_delegatee: oldDelegatee, new_delegatee: newDelegatee, ledger: event.ledger },
+  });
+}
+
+async function handleDelegationRegistered(
+  event: SorobanRpc.Api.EventResponse,
+  topics: unknown[],
+): Promise<void> {
+  const delegator = topics[1] as string;
+  const data = scValToNative(event.value) as [string, bigint, number];
+  const [delegatee, power, chainDepth] = data;
+
+  await pool.query(
+    `INSERT INTO delegation_entries
+       (delegator_address, delegatee_address, delegated_at_ledger, power_at_delegation, chain_depth, active)
+     VALUES ($1, $2, $3, $4, $5, TRUE)`,
+    [delegator, delegatee, event.ledger, String(power), chainDepth],
+  );
+  invalidatePattern("delegates:");
+  invalidate(`profile:${delegator}`, `profile:${delegatee}`);
+  broadcast({
+    type: "delegation_registered",
+    data: { delegator, delegatee, power: String(power), chain_depth: chainDepth, ledger: event.ledger },
+  });
+}
+
+async function handleDelegationRevoked(
+  event: SorobanRpc.Api.EventResponse,
+  topics: unknown[],
+): Promise<void> {
+  const delegator = topics[1] as string;
+  const data = scValToNative(event.value) as [string, number];
+  const [previousDelegatee, atLedger] = data;
+
+  await pool.query(
+    `UPDATE delegation_entries
+     SET active = FALSE, revoked_at_ledger = $3
+     WHERE delegator_address = $1 AND delegatee_address = $2 AND active = TRUE`,
+    [delegator, previousDelegatee, atLedger],
+  );
+  invalidatePattern("delegates:");
+  invalidate(`profile:${delegator}`, `profile:${previousDelegatee}`);
+  broadcast({
+    type: "delegation_revoked",
+    data: { delegator, previous_delegatee: previousDelegatee, ledger: atLedger },
+  });
+}
+
+async function handleDelegationDepthLimitUpdated(
+  event: SorobanRpc.Api.EventResponse,
+  _topics: unknown[],
+): Promise<void> {
+  const data = scValToNative(event.value) as [number, number];
+  const [oldLimit, newLimit] = data;
+
+  broadcast({
+    type: "delegation_depth_limit_updated",
+    data: { old_limit: oldLimit, new_limit: newLimit, ledger: event.ledger },
   });
 }
 

--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -11,6 +11,7 @@ dotenv.config();
 const GOVERNOR_ADDRESS = process.env.GOVERNOR_ADDRESS ?? "";
 const WRAPPER_ADDRESS = process.env.WRAPPER_ADDRESS ?? "";
 const CO_SPONSORSHIP_ADDRESS = process.env.CO_SPONSORSHIP_ADDRESS ?? "";
+const TOKEN_VOTES_ADDRESS = process.env.TOKEN_VOTES_ADDRESS ?? "";
 const RPC_URL = process.env.STELLAR_RPC_URL ?? "https://soroban-testnet.stellar.org";
 const POLL_INTERVAL_MS = Number(process.env.POLL_INTERVAL_MS ?? 5000);
 const PORT = Number(process.env.PORT ?? 3001);
@@ -52,6 +53,7 @@ async function runIndexer(): Promise<void> {
     governorAddress: GOVERNOR_ADDRESS,
     wrapperAddress: WRAPPER_ADDRESS,
     coSponsorshipAddress: CO_SPONSORSHIP_ADDRESS,
+    tokenVotesAddress: TOKEN_VOTES_ADDRESS,
     pollIntervalMs: POLL_INTERVAL_MS,
   };
 

--- a/packages/indexer/src/ws.ts
+++ b/packages/indexer/src/ws.ts
@@ -21,7 +21,10 @@ export type WsEventType =
   | "co_sponsorship_withdrawn"
   | "draft_finalized"
   | "draft_cancelled"
-  | "draft_expired";
+  | "draft_expired"
+  | "delegation_registered"
+  | "delegation_revoked"
+  | "delegation_depth_limit_updated";
 
 export interface WsEvent {
   type: WsEventType;

--- a/sdk/src/__tests__/votes.test.ts
+++ b/sdk/src/__tests__/votes.test.ts
@@ -661,4 +661,247 @@ describe("VotesClient", () => {
       expect(top).toEqual([]);
     });
   });
+
+  describe("delegation registry (issue #769)", () => {
+    const delegatorAddr = "GBTESTDELEGATORADDRESSEXAMPLEFORUNITTESTSTESTING";
+    const delegateeAddr = "GBTESTDELEGATEEADDRESSEXAMPLEFORUNITTESTSTESTING";
+
+    it("getDelegationHistory() maps native history entries to camelCase", async () => {
+      mockSimulate.mockResolvedValue({ result: { retval: {} } });
+      mockScValToNative.mockReturnValue([
+        {
+          delegatee: delegateeAddr,
+          delegated_at_ledger: 10,
+          revoked_at_ledger: 20,
+          power_at_delegation: 500n,
+          sequence: 0,
+        },
+      ]);
+
+      const history = await client.getDelegationHistory(delegatorAddr);
+
+      expect(history).toEqual([
+        {
+          delegatee: delegateeAddr,
+          delegatedAtLedger: 10,
+          revokedAtLedger: 20,
+          powerAtDelegation: 500n,
+          sequence: 0,
+        },
+      ]);
+    });
+
+    it("getDelegationHistory() returns [] on simulation error", async () => {
+      mockIsSimulationError.mockReturnValue(true);
+      mockSimulate.mockResolvedValue({ error: "not found" });
+
+      const history = await client.getDelegationHistory(delegatorAddr);
+
+      expect(history).toEqual([]);
+    });
+
+    it("getRegistryDelegators() paginates and parses entries", async () => {
+      mockSimulate.mockResolvedValue({ result: { retval: {} } });
+      mockScValToNative.mockReturnValue([
+        {
+          address: delegatorAddr,
+          delegated_power: 750n,
+          delegated_at_ledger: 5,
+          chain_depth: 1,
+        },
+      ]);
+
+      const delegators = await client.getRegistryDelegators(delegateeAddr, 0, 50);
+
+      expect(delegators).toEqual([
+        {
+          address: delegatorAddr,
+          delegatedPower: 750n,
+          delegatedAtLedger: 5,
+          chainDepth: 1,
+        },
+      ]);
+      expect(mockNativeToScVal).toHaveBeenCalledWith(delegateeAddr, { type: "address" });
+      expect(mockNativeToScVal).toHaveBeenCalledWith(0, { type: "u32" });
+      expect(mockNativeToScVal).toHaveBeenCalledWith(50, { type: "u32" });
+    });
+
+    it("getDelegatorCount() returns the count", async () => {
+      mockSimulate.mockResolvedValue({ result: { retval: {} } });
+      mockScValToNative.mockReturnValue(3);
+
+      await expect(client.getDelegatorCount(delegateeAddr)).resolves.toBe(3);
+    });
+
+    it("getDelegatorCount() returns 0 on simulation error", async () => {
+      mockIsSimulationError.mockReturnValue(true);
+      mockSimulate.mockResolvedValue({ error: "not found" });
+
+      await expect(client.getDelegatorCount(delegateeAddr)).resolves.toBe(0);
+    });
+
+    it("getDelegationChain() returns the address chain", async () => {
+      mockSimulate.mockResolvedValue({ result: { retval: {} } });
+      mockScValToNative.mockReturnValue([delegatorAddr, delegateeAddr]);
+
+      await expect(client.getDelegationChain(delegatorAddr)).resolves.toEqual([
+        delegatorAddr,
+        delegateeAddr,
+      ]);
+    });
+
+    it("getChainDepth() returns the depth", async () => {
+      mockSimulate.mockResolvedValue({ result: { retval: {} } });
+      mockScValToNative.mockReturnValue(2);
+
+      await expect(client.getChainDepth(delegatorAddr)).resolves.toBe(2);
+    });
+
+    it("getDelegateProfile() maps all native fields to camelCase", async () => {
+      mockSimulate.mockResolvedValue({ result: { retval: {} } });
+      mockScValToNative.mockReturnValue({
+        address: delegateeAddr,
+        current_voting_power: 1000n,
+        base_voting_power: 1000n,
+        total_delegators: 2,
+        total_delegated_power: 1000n,
+        delegation_depth_limit: 1,
+        first_delegated_at_ledger: 5,
+      });
+
+      const profile = await client.getDelegateProfile(delegateeAddr);
+
+      expect(profile).toEqual({
+        address: delegateeAddr,
+        currentVotingPower: 1000n,
+        baseVotingPower: 1000n,
+        totalDelegators: 2,
+        totalDelegatedPower: 1000n,
+        delegationDepthLimit: 1,
+        firstDelegatedAtLedger: 5,
+      });
+    });
+
+    it("getDelegateProfile() returns a zeroed default on simulation error", async () => {
+      mockIsSimulationError.mockReturnValue(true);
+      mockSimulate.mockResolvedValue({ error: "not found" });
+
+      const profile = await client.getDelegateProfile(delegateeAddr);
+
+      expect(profile).toEqual({
+        address: delegateeAddr,
+        currentVotingPower: 0n,
+        baseVotingPower: 0n,
+        totalDelegators: 0,
+        totalDelegatedPower: 0n,
+        delegationDepthLimit: 1,
+        firstDelegatedAtLedger: null,
+      });
+    });
+
+    it("getReceivedDelegations() parses entries including null revokedAtLedger", async () => {
+      mockSimulate.mockResolvedValue({ result: { retval: {} } });
+      mockScValToNative.mockReturnValue([
+        {
+          delegator: delegatorAddr,
+          delegatee: delegateeAddr,
+          delegated_at_ledger: 1,
+          voting_power_at_delegation: 100n,
+          active: true,
+          revoked_at_ledger: null,
+        },
+      ]);
+
+      const received = await client.getReceivedDelegations(delegateeAddr);
+
+      expect(received).toEqual([
+        {
+          delegator: delegatorAddr,
+          delegatee: delegateeAddr,
+          delegatedAtLedger: 1,
+          votingPowerAtDelegation: 100n,
+          active: true,
+          revokedAtLedger: null,
+        },
+      ]);
+    });
+
+    it("wouldCreateCycle() returns the boolean result", async () => {
+      mockSimulate.mockResolvedValue({ result: { retval: {} } });
+      mockScValToNative.mockReturnValue(true);
+
+      await expect(
+        client.wouldCreateCycle(delegatorAddr, delegateeAddr),
+      ).resolves.toBe(true);
+    });
+
+    it("getDelegationSnapshot() parses a past-ledger snapshot", async () => {
+      mockSimulate.mockResolvedValue({ result: { retval: {} } });
+      mockScValToNative.mockReturnValue([
+        {
+          address: delegatorAddr,
+          delegated_power: 300n,
+          delegated_at_ledger: 8,
+          chain_depth: 0,
+        },
+      ]);
+
+      const snapshot = await client.getDelegationSnapshot(delegateeAddr, 15);
+
+      expect(snapshot).toEqual([
+        {
+          address: delegatorAddr,
+          delegatedPower: 300n,
+          delegatedAtLedger: 8,
+          chainDepth: 0,
+        },
+      ]);
+    });
+
+    it("getDelegationDepthLimit() returns the current limit", async () => {
+      mockSimulate.mockResolvedValue({ result: { retval: {} } });
+      mockScValToNative.mockReturnValue(1);
+
+      await expect(client.getDelegationDepthLimit()).resolves.toBe(1);
+    });
+
+    it("getDelegationDepthLimit() defaults to 1 on simulation error", async () => {
+      mockIsSimulationError.mockReturnValue(true);
+      mockSimulate.mockResolvedValue({ error: "not found" });
+
+      await expect(client.getDelegationDepthLimit()).resolves.toBe(1);
+    });
+
+    describe("setDelegationDepthLimit()", () => {
+      beforeEach(() => {
+        const mockTx = { sign: jest.fn() };
+        mockPrepareTransaction.mockResolvedValue(mockTx);
+        mockSendTransaction.mockResolvedValue({
+          status: "PENDING",
+          hash: "setDepthLimit123",
+        });
+      });
+
+      it("submits the admin transaction and returns the tx hash", async () => {
+        const hash = await client.setDelegationDepthLimit(mockKeypair, 3);
+
+        expect(hash).toBe("setDepthLimit123");
+        expect(mockNativeToScVal).toHaveBeenCalledWith(mockKeypair.publicKey(), {
+          type: "address",
+        });
+        expect(mockNativeToScVal).toHaveBeenCalledWith(3, { type: "u32" });
+      });
+
+      it("throws VotesError when the transaction fails", async () => {
+        mockSendTransaction.mockResolvedValue({
+          status: "ERROR",
+          error: "unauthorized",
+        });
+
+        await expect(
+          client.setDelegationDepthLimit(mockKeypair, 3),
+        ).rejects.toThrow(VotesError);
+      });
+    });
+  });
 });

--- a/sdk/src/types/index.ts
+++ b/sdk/src/types/index.ts
@@ -347,6 +347,51 @@ export interface DelegatorInfo {
   power: bigint;
 }
 
+// ─── Delegation Registry Types (issue #769) ──────────────────────────────────
+//
+// These mirror the on-chain `delegation_registry` module in the token-votes
+// contract. `RegistryDelegatorInfo` is intentionally distinct from the
+// pre-existing `DelegatorInfo` above (which is event-scan-derived and used by
+// the legacy {@link VotesClient.getDelegators}) to avoid colliding with it.
+
+/** A single delegation record as returned by {@link VotesClient.getReceivedDelegations}. */
+export interface DelegationEntry {
+  delegator: string;
+  delegatee: string;
+  delegatedAtLedger: number;
+  votingPowerAtDelegation: bigint;
+  active: boolean;
+  revokedAtLedger: number | null;
+}
+
+/** One lifecycle entry (active or revoked) in a delegator's history, as returned by {@link VotesClient.getDelegationHistory}. */
+export interface DelegationHistoryEntry {
+  delegatee: string;
+  delegatedAtLedger: number;
+  revokedAtLedger: number | null;
+  powerAtDelegation: bigint;
+  sequence: number;
+}
+
+/** A current delegator of a delegatee, as returned by {@link VotesClient.getRegistryDelegators} and {@link VotesClient.getDelegationSnapshot}. */
+export interface RegistryDelegatorInfo {
+  address: string;
+  delegatedPower: bigint;
+  delegatedAtLedger: number;
+  chainDepth: number;
+}
+
+/** Comprehensive delegate summary as returned by {@link VotesClient.getDelegateProfile}. */
+export interface DelegateProfile {
+  address: string;
+  currentVotingPower: bigint;
+  baseVotingPower: bigint;
+  totalDelegators: number;
+  totalDelegatedPower: bigint;
+  delegationDepthLimit: number;
+  firstDelegatedAtLedger: number | null;
+}
+
 // ─── Treasury Types ───────────────────────────────────────────────────────────
 
 /** Configuration for {@link TreasuryClient}. */

--- a/sdk/src/votes.ts
+++ b/sdk/src/votes.ts
@@ -18,6 +18,10 @@ import {
   DelegatorInfo,
   VotesSettings,
   DelegatorRecord,
+  DelegationEntry,
+  DelegationHistoryEntry,
+  RegistryDelegatorInfo,
+  DelegateProfile,
 } from "./types";
 import { VotesError, VotesErrorCode, parseVotesError } from "./errors";
 import { withRetry, isNetworkError } from "./utils";
@@ -752,6 +756,259 @@ export class VotesClient {
   // DelegationSigClient (./delegation-sig.ts) — it needs a full
   // SorobanAuthorizationEntry, not a raw signature, because verification is
   // done through Soroban's native auth framework. See that module's docs.
+
+  // ─── Delegation registry (issue #769) ──────────────────────────────────────
+  //
+  // These wrap the on-chain `delegation_registry` module's query/admin
+  // functions directly (single simulated call each), as opposed to the
+  // event-scanning helpers above (getDelegators, getTopDelegates, etc.)
+  // which reconstruct delegation state from `del_chsh`/`del_revk` events.
+
+  private async simulateRead<T>(
+    method: string,
+    args: xdr.ScVal[],
+    parse: (raw: xdr.ScVal) => T,
+    defaultValue: T,
+  ): Promise<T> {
+    return this.retry(async () => {
+      const result = await this.server.simulateTransaction(
+        new TransactionBuilder(await this.server.getAccount(this.readAccount()), {
+          fee: BASE_FEE,
+          networkPassphrase: this.networkPassphrase,
+        })
+          .addOperation(this.contract.call(method, ...args))
+          .setTimeout(30)
+          .build(),
+      );
+
+      if (SorobanRpc.Api.isSimulationError(result)) return defaultValue;
+      const raw = (result as SorobanRpc.Api.SimulateTransactionSuccessResponse)
+        .result?.retval;
+      return raw ? parse(raw) : defaultValue;
+    });
+  }
+
+  private parseDelegationEntry(native: Record<string, unknown>): DelegationEntry {
+    return {
+      delegator: String(native.delegator),
+      delegatee: String(native.delegatee),
+      delegatedAtLedger: Number(native.delegated_at_ledger),
+      votingPowerAtDelegation: BigInt(native.voting_power_at_delegation as bigint),
+      active: Boolean(native.active),
+      revokedAtLedger:
+        native.revoked_at_ledger === undefined || native.revoked_at_ledger === null
+          ? null
+          : Number(native.revoked_at_ledger),
+    };
+  }
+
+  private parseDelegationHistoryEntry(native: Record<string, unknown>): DelegationHistoryEntry {
+    return {
+      delegatee: String(native.delegatee),
+      delegatedAtLedger: Number(native.delegated_at_ledger),
+      revokedAtLedger:
+        native.revoked_at_ledger === undefined || native.revoked_at_ledger === null
+          ? null
+          : Number(native.revoked_at_ledger),
+      powerAtDelegation: BigInt(native.power_at_delegation as bigint),
+      sequence: Number(native.sequence),
+    };
+  }
+
+  private parseRegistryDelegatorInfo(native: Record<string, unknown>): RegistryDelegatorInfo {
+    return {
+      address: String(native.address),
+      delegatedPower: BigInt(native.delegated_power as bigint),
+      delegatedAtLedger: Number(native.delegated_at_ledger),
+      chainDepth: Number(native.chain_depth),
+    };
+  }
+
+  /** Get full delegation history for a delegator. */
+  async getDelegationHistory(delegator: string): Promise<DelegationHistoryEntry[]> {
+    return this.simulateRead(
+      "get_delegation_history",
+      [nativeToScVal(delegator, { type: "address" })],
+      (raw) => (scValToNative(raw) as Record<string, unknown>[]).map((e) => this.parseDelegationHistoryEntry(e)),
+      [],
+    );
+  }
+
+  /**
+   * Get all current delegators of a delegatee with their power and depth.
+   *
+   * Named `getRegistryDelegators` (rather than `getDelegators`) to avoid
+   * colliding with the existing event-scan-based {@link getDelegators}.
+   */
+  async getRegistryDelegators(
+    delegatee: string,
+    offset = 0,
+    limit = 50,
+  ): Promise<RegistryDelegatorInfo[]> {
+    return this.simulateRead(
+      "get_delegators",
+      [
+        nativeToScVal(delegatee, { type: "address" }),
+        nativeToScVal(offset, { type: "u32" }),
+        nativeToScVal(limit, { type: "u32" }),
+      ],
+      (raw) => (scValToNative(raw) as Record<string, unknown>[]).map((e) => this.parseRegistryDelegatorInfo(e)),
+      [],
+    );
+  }
+
+  /** Get total number of current delegators of a delegatee. */
+  async getDelegatorCount(delegatee: string): Promise<number> {
+    return this.simulateRead(
+      "get_delegator_count",
+      [nativeToScVal(delegatee, { type: "address" })],
+      (raw) => Number(scValToNative(raw)),
+      0,
+    );
+  }
+
+  /** Get the full delegation chain from delegator to the final tip. */
+  async getDelegationChain(delegator: string): Promise<string[]> {
+    return this.simulateRead(
+      "get_delegation_chain",
+      [nativeToScVal(delegator, { type: "address" })],
+      (raw) => scValToNative(raw) as string[],
+      [],
+    );
+  }
+
+  /** Get depth of the delegation chain from this address. */
+  async getChainDepth(delegator: string): Promise<number> {
+    return this.simulateRead(
+      "get_chain_depth",
+      [nativeToScVal(delegator, { type: "address" })],
+      (raw) => Number(scValToNative(raw)),
+      0,
+    );
+  }
+
+  /** Get a comprehensive delegate profile (voting power, delegators, depth limit). */
+  async getDelegateProfile(address: string): Promise<DelegateProfile> {
+    return this.simulateRead(
+      "get_delegate_profile",
+      [nativeToScVal(address, { type: "address" })],
+      (raw) => {
+        const native = scValToNative(raw) as Record<string, unknown>;
+        return {
+          address: String(native.address),
+          currentVotingPower: BigInt(native.current_voting_power as bigint),
+          baseVotingPower: BigInt(native.base_voting_power as bigint),
+          totalDelegators: Number(native.total_delegators),
+          totalDelegatedPower: BigInt(native.total_delegated_power as bigint),
+          delegationDepthLimit: Number(native.delegation_depth_limit),
+          firstDelegatedAtLedger:
+            native.first_delegated_at_ledger === undefined ||
+            native.first_delegated_at_ledger === null
+              ? null
+              : Number(native.first_delegated_at_ledger),
+        };
+      },
+      {
+        address,
+        currentVotingPower: 0n,
+        baseVotingPower: 0n,
+        totalDelegators: 0,
+        totalDelegatedPower: 0n,
+        delegationDepthLimit: 1,
+        firstDelegatedAtLedger: null,
+      },
+    );
+  }
+
+  /** Get all active delegations received by a delegatee (paginated). */
+  async getReceivedDelegations(
+    delegatee: string,
+    offset = 0,
+    limit = 50,
+  ): Promise<DelegationEntry[]> {
+    return this.simulateRead(
+      "get_received_delegations",
+      [
+        nativeToScVal(delegatee, { type: "address" }),
+        nativeToScVal(offset, { type: "u32" }),
+        nativeToScVal(limit, { type: "u32" }),
+      ],
+      (raw) => (scValToNative(raw) as Record<string, unknown>[]).map((e) => this.parseDelegationEntry(e)),
+      [],
+    );
+  }
+
+  /** Check whether delegating from `delegator` to `delegatee` would create a cycle. */
+  async wouldCreateCycle(delegator: string, delegatee: string): Promise<boolean> {
+    return this.simulateRead(
+      "would_create_cycle",
+      [
+        nativeToScVal(delegator, { type: "address" }),
+        nativeToScVal(delegatee, { type: "address" }),
+      ],
+      (raw) => Boolean(scValToNative(raw)),
+      false,
+    );
+  }
+
+  /** Get a snapshot of the full delegation graph for a delegatee at a past ledger (for audit). */
+  async getDelegationSnapshot(
+    delegatee: string,
+    atLedger: number,
+  ): Promise<RegistryDelegatorInfo[]> {
+    return this.simulateRead(
+      "get_delegation_snapshot",
+      [
+        nativeToScVal(delegatee, { type: "address" }),
+        nativeToScVal(atLedger, { type: "u32" }),
+      ],
+      (raw) => (scValToNative(raw) as Record<string, unknown>[]).map((e) => this.parseRegistryDelegatorInfo(e)),
+      [],
+    );
+  }
+
+  /** Get the current delegation depth limit. */
+  async getDelegationDepthLimit(): Promise<number> {
+    return this.simulateRead(
+      "get_delegation_depth_limit",
+      [],
+      (raw) => Number(scValToNative(raw)),
+      1,
+    );
+  }
+
+  /**
+   * Update the maximum delegation chain depth (admin only).
+   *
+   * @returns The Stellar transaction hash, suitable for linking to a block explorer.
+   */
+  async setDelegationDepthLimit(signer: Keypair, newLimit: number): Promise<string> {
+    return this.retry(async () => {
+      const account = await this.server.getAccount(signer.publicKey());
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(
+          this.contract.call(
+            "set_delegation_depth_limit",
+            nativeToScVal(signer.publicKey(), { type: "address" }),
+            nativeToScVal(newLimit, { type: "u32" }),
+          ),
+        )
+        .setTimeout(30)
+        .build();
+
+      const prepared = await this.server.prepareTransaction(tx);
+      prepared.sign(signer);
+      const result = await this.server.sendTransaction(prepared);
+      if (result.status === "ERROR") {
+        throw parseVotesError(result);
+      }
+      return result.hash;
+    }, (e) => this.isRetryableSubmissionError(e));
+  }
 
   // ─── Internal ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Implements the on-chain delegation registry described in #769: history tracking, current-delegator lookups, cycle detection, and a configurable chain-depth limit, layered on top of the existing single-hop delegation model in `contracts/token-votes` without changing how voting power itself is computed.

Given the size of the full spec (contract + indexer + SDK + frontend graph/tree visualizations), this PR covers the contract, indexer, and SDK in full, plus functional (non-graph) frontend components. The force-directed delegation network graph and tree-diagram visualizer from the spec are intentionally out of scope here — they're a substantial, separate visual-design effort better suited to their own PR.

### Smart contract (`contracts/token-votes`)
- New `delegation_registry` module: `DelegationEntry`, `DelegationHistoryEntry`, `DelegatorInfo`, `DelegateProfile` types and all query/admin functions from the spec (`get_delegation_history`, `get_delegators`, `get_delegator_count`, `get_delegation_chain`, `get_chain_depth`, `get_delegate_profile`, `get_received_delegations`, `set_delegation_depth_limit`, `get_delegation_depth_limit`, `would_create_cycle`, `get_delegation_snapshot`).
- Hooked into the existing `apply_delegation`/`revoke_delegation` paths: cycle and depth-limit validation run before any state mutation; history/registry bookkeeping runs after, so nothing partially commits on failure.
- Default depth limit is 1 (matches current non-transitive behavior); admin can raise it later.
- New events: `DelegationRegistered`, `DelegationRevoked`, `DelegationDepthLimitUpdated`.
- Full test suite in `delegation_registry_tests.rs` covering entry/history writes, revocation, delegator counts, chain resolution, cycle detection (direct and indirect), depth-limit enforcement (and raising it), historical snapshots, profile aggregation, pagination, and admin auth. All 59 tests in the crate pass; `cargo clippy` clean; wasm32 release build verified.

### Indexer (`packages/indexer`)
- Migration `004_add_delegation_registry.sql`: `delegation_entries` and `delegation_history_snapshots` tables.
- New `TOKEN_VOTES_ADDRESS` config (wasn't previously tracked by the indexer at all) wired into the event-polling loop, plus handlers for the three new events.
- New endpoints: `GET /delegates/:address/profile`, `/delegators`, `/history`, `/chain`, `GET /delegators/:address/history`, `GET /delegation-graph`.

### SDK (`sdk/src/votes.ts`)
- Typed wrappers for all the new contract functions. `getDelegators` from the spec is named `getRegistryDelegators` here to avoid colliding with the SDK's existing event-scan-based `getDelegators` (pre-existing method, different shape). New types (`DelegationEntry`, `DelegationHistoryEntry`, `RegistryDelegatorInfo`, `DelegateProfile`) exported from `sdk/src/types`.
- 16 new unit tests, all passing; SDK typechecks and builds clean.

### Frontend (`app`)
- `DelegationChain.tsx` (linear A → B → C chain view), `DelegatorList.tsx` (paginated current-delegators list), `useDelegateProfile` hook.
- New "Delegation Registry" section on the voter profile page with Delegation History / Received Delegations tabs and the delegation chain.

### Unrelated fixes picked up along the way
- The profile page (`app/src/app/profile/[address]/page.tsx`) had a pre-existing syntax error (an orphaned `} from "recharts";` line) that made the file fail to parse at all — fixed since I had to touch this file anyway.
- `app/tsconfig.json` was missing the `"@/*"` path alias entirely, which was silently masking several Jest suites (they failed to resolve `@/hooks/...` and never ran). Adding it is what any `next` app needs for `@/` imports to resolve, and it's what let this PR's new frontend code compile. One side effect worth flagging to reviewers: with the alias in place, the `VotingModal` accessibility test suite now actually runs (it previously failed to load at all) and surfaces **2 pre-existing, unrelated accessibility test failures** in `VotingModal` — not touched by this PR, but no longer silently hidden. Worth a follow-up issue.
- The `app` package has ~44 other pre-existing typecheck errors unrelated to this PR (mostly `GovernorClient` API mismatches that look like fallout from the recent SDK modular refactor, plus some e2e/Playwright config issues) — confirmed present on `main` before this branch, not something this PR attempts to address.

## Test plan

- [x] `cargo test -p sorogov-token-votes` — 59/59 passing
- [x] `cargo clippy -p sorogov-token-votes --all-targets` — clean
- [x] `cargo build -p sorogov-token-votes --target wasm32-unknown-unknown --release` — succeeds
- [x] `pnpm --filter @nebgov/indexer exec tsc --noEmit` — no new errors (4 pre-existing `liquidity_*` WsEventType errors confirmed present on `main`)
- [x] `pnpm --filter @nebgov/indexer test` — same pass/fail counts as `main` baseline (40 tests, 2 pre-existing failures unrelated to this change)
- [x] `pnpm --filter @nebgov/sdk exec tsc --noEmit` && `pnpm --filter @nebgov/sdk build` — clean
- [x] `pnpm --filter @nebgov/sdk test` — 237/237 passing
- [x] `pnpm --filter nebgov-app exec tsc --noEmit` — 0 errors attributable to this PR's new code (46 pre-existing errors remain, confirmed present on `main`)
- [x] `pnpm --filter nebgov-app test` — new `DelegationChain` tests pass; no regressions in previously-passing tests


closes #769 