### PR TITLE
feat(simulation): add governance lifecycle simulation harness

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -4,13 +4,38 @@ on:
   push:
     paths:
       - 'sdk/**'
+      - 'contracts/**'
+      - 'tools/simulation/**'
   pull_request:
     paths:
       - 'sdk/**'
+      - 'contracts/**'
+      - 'tools/simulation/**'
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      sdk: ${{ steps.filter.outputs.sdk }}
+      simulation: ${{ steps.filter.outputs.simulation }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            sdk:
+              - 'sdk/**'
+            simulation:
+              - 'contracts/**'
+              - 'sdk/**'
+              - 'tools/simulation/**'
+
   js-security-audit:
     name: JavaScript Security Audit
+    needs: changes
+    if: needs.changes.outputs.sdk == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,6 +64,8 @@ jobs:
 
   test:
     name: SDK Test & Build
+    needs: changes
+    if: needs.changes.outputs.sdk == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -110,3 +137,34 @@ jobs:
         with:
           name: sdk-docs
           path: sdk/docs/
+
+  simulation-test:
+    name: Simulation Tests
+    needs: changes
+    if: needs.changes.outputs.simulation == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build SDK
+        run: pnpm --filter @nebgov/sdk run build
+
+      - name: Type check simulation harness
+        run: pnpm --filter @nebgov/simulation exec tsc --noEmit
+
+      - name: Run governance simulation tests (mock runtime, no network)
+        run: pnpm --filter @nebgov/simulation test

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "app",
     "packages/cli",
     "packages/indexer",
-    "backend"
+    "backend",
+    "tools/simulation"
   ],
   "scripts": {
     "build:sdk": "pnpm --filter @nebgov/sdk build",
@@ -15,7 +16,8 @@
     "dev": "pnpm --filter nebgov-app dev",
     "test:sdk": "pnpm --filter @nebgov/sdk test",
     "test:app": "pnpm --filter nebgov-app test",
-    "simulate": "tsx scripts/simulate.ts"
+    "simulate": "tsx scripts/simulate.ts",
+    "simulation:test": "pnpm --filter @nebgov/simulation test"
   },
   "devDependencies": {
     "@stellar/stellar-sdk": "^12.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,6 +349,31 @@ importers:
         specifier: ^5.0.0
         version: 5.9.3
 
+  tools/simulation:
+    dependencies:
+      '@nebgov/sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+      '@stellar/stellar-sdk':
+        specifier: ^12.0.0
+        version: 12.3.0
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.0.0
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.37
+      jest:
+        specifier: ^29.0.0
+        version: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@swc/core@1.15.30(@swc/helpers@0.5.19))(@types/node@20.19.37)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.0.0
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@swc/core@1.15.30(@swc/helpers@0.5.19))(@types/node@20.19.37)(typescript@5.9.3)))(typescript@5.9.3)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
 packages:
 
   '@adobe/css-tools@4.4.4':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,4 @@ packages:
   - 'packages/cli'
   - 'packages/indexer'
   - 'backend'
+  - 'tools/simulation'

--- a/tools/simulation/jest.config.js
+++ b/tools/simulation/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/tests/**/*.sim.ts"],
+  setupFiles: ["<rootDir>/tests/jest.setup.ts"],
+  testTimeout: 120_000,
+  maxWorkers: 1,
+};

--- a/tools/simulation/package.json
+++ b/tools/simulation/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@nebgov/simulation",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Deterministic governance lifecycle simulation harness for NebGov (propose -> vote -> queue -> execute) against a mock Soroban RPC runtime",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@nebgov/sdk": "workspace:*",
+    "@stellar/stellar-sdk": "^12.0.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.0.0",
+    "@types/node": "^20.0.0",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/tools/simulation/src/actors.ts
+++ b/tools/simulation/src/actors.ts
@@ -1,0 +1,76 @@
+import { createHash } from "node:crypto";
+import { GovernorClient, VoteSupport, VotesClient } from "@nebgov/sdk";
+import { Keypair } from "@stellar/stellar-sdk";
+
+export interface ActorRole {
+  isProposer?: boolean;
+  isVoter?: boolean;
+  isGuardian?: boolean;
+}
+
+/** A simulated governance participant with a deterministic keypair. */
+export class Actor {
+  constructor(
+    readonly name: string,
+    readonly keypair: Keypair,
+    readonly role: ActorRole = {},
+  ) {}
+
+  get publicKey(): string {
+    return this.keypair.publicKey();
+  }
+
+  /** Cast a vote on `proposalId` using this actor's keypair. */
+  async vote(client: GovernorClient, proposalId: bigint, support: VoteSupport): Promise<string> {
+    return client.castVote(this.keypair, proposalId, support);
+  }
+
+  /** Delegate this actor's voting power to `delegatee` (or itself). */
+  async delegateTo(votesClient: VotesClient, delegatee: Actor | string): Promise<string> {
+    const target = typeof delegatee === "string" ? delegatee : delegatee.publicKey;
+    return votesClient.delegate(this.keypair, target);
+  }
+}
+
+export interface ActorSet {
+  proposers: Actor[];
+  voters: Actor[];
+  guardian?: Actor;
+  /** All actors keyed by name (e.g. "proposer-0", "voter-3", "guardian"). */
+  all: Map<string, Actor>;
+}
+
+/** Deterministic 32-byte Ed25519 seed so simulation runs are reproducible without a faucet. */
+function deterministicSeed(label: string): Buffer {
+  return createHash("sha256").update(`nebgov-simulation-actor:${label}`).digest();
+}
+
+function makeActor(name: string, role: ActorRole): Actor {
+  const keypair = Keypair.fromRawEd25519Seed(deterministicSeed(name));
+  return new Actor(name, keypair, role);
+}
+
+/** Build a deterministic set of proposer/voter/guardian actors for a simulation run. */
+export function createActors(config: { proposers: number; voters: number; hasGuardian?: boolean }): ActorSet {
+  const all = new Map<string, Actor>();
+
+  const proposers = Array.from({ length: config.proposers }, (_, i) => {
+    const actor = makeActor(`proposer-${i}`, { isProposer: true });
+    all.set(actor.name, actor);
+    return actor;
+  });
+
+  const voters = Array.from({ length: config.voters }, (_, i) => {
+    const actor = makeActor(`voter-${i}`, { isVoter: true });
+    all.set(actor.name, actor);
+    return actor;
+  });
+
+  let guardian: Actor | undefined;
+  if (config.hasGuardian) {
+    guardian = makeActor("guardian", { isGuardian: true });
+    all.set(guardian.name, guardian);
+  }
+
+  return { proposers, voters, guardian, all };
+}

--- a/tools/simulation/src/assertions/balances.ts
+++ b/tools/simulation/src/assertions/balances.ts
@@ -1,0 +1,17 @@
+import { VotesClient } from "@nebgov/sdk";
+import { AssertionError } from "./errors";
+
+/** Asserts an account's raw seeded balance (`SimulationConfig.tokenBalances`), not its delegated voting power. */
+export async function assertTokenBalance(client: VotesClient, address: string, expected: bigint): Promise<void> {
+  const actual = await client.getBaseVotes(address);
+  if (actual !== expected) {
+    throw new AssertionError(`${address}: expected base balance ${expected}, got ${actual}`);
+  }
+}
+
+export async function assertDelegatedVotes(client: VotesClient, address: string, expected: bigint): Promise<void> {
+  const actual = await client.getVotes(address);
+  if (actual !== expected) {
+    throw new AssertionError(`${address}: expected delegated votes ${expected}, got ${actual}`);
+  }
+}

--- a/tools/simulation/src/assertions/errors.ts
+++ b/tools/simulation/src/assertions/errors.ts
@@ -1,0 +1,6 @@
+export class AssertionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AssertionError";
+  }
+}

--- a/tools/simulation/src/assertions/proposal.ts
+++ b/tools/simulation/src/assertions/proposal.ts
@@ -1,0 +1,36 @@
+import { GovernorClient, ProposalState } from "@nebgov/sdk";
+import { AssertionError } from "./errors";
+
+export async function assertProposalState(client: GovernorClient, proposalId: bigint, expected: ProposalState): Promise<void> {
+  const actual = await client.getProposalState(proposalId);
+  if (actual !== expected) {
+    throw new AssertionError(`Proposal ${proposalId}: expected state ${expected}, got ${actual}`);
+  }
+}
+
+export async function assertVoteCounts(
+  client: GovernorClient,
+  proposalId: bigint,
+  expected: { votesFor?: bigint; votesAgainst?: bigint; votesAbstain?: bigint },
+): Promise<void> {
+  const votes = await client.getProposalVotes(proposalId);
+  if (expected.votesFor !== undefined && votes.votesFor !== expected.votesFor) {
+    throw new AssertionError(`Proposal ${proposalId}: expected votesFor ${expected.votesFor}, got ${votes.votesFor}`);
+  }
+  if (expected.votesAgainst !== undefined && votes.votesAgainst !== expected.votesAgainst) {
+    throw new AssertionError(`Proposal ${proposalId}: expected votesAgainst ${expected.votesAgainst}, got ${votes.votesAgainst}`);
+  }
+  if (expected.votesAbstain !== undefined && votes.votesAbstain !== expected.votesAbstain) {
+    throw new AssertionError(`Proposal ${proposalId}: expected votesAbstain ${expected.votesAbstain}, got ${votes.votesAbstain}`);
+  }
+}
+
+export async function assertQuorumReached(client: GovernorClient, proposalId: bigint): Promise<void> {
+  const reached = await client.isQuorumReached(proposalId);
+  if (!reached) throw new AssertionError(`Proposal ${proposalId}: expected quorum to be reached`);
+}
+
+export async function assertQuorumNotReached(client: GovernorClient, proposalId: bigint): Promise<void> {
+  const reached = await client.isQuorumReached(proposalId);
+  if (reached) throw new AssertionError(`Proposal ${proposalId}: expected quorum to NOT be reached`);
+}

--- a/tools/simulation/src/assertions/timelock.ts
+++ b/tools/simulation/src/assertions/timelock.ts
@@ -1,0 +1,21 @@
+import { TimelockClient } from "@nebgov/sdk";
+import { AssertionError } from "./errors";
+
+export async function assertOperationReady(client: TimelockClient, opId: string): Promise<void> {
+  const ready = await client.isReady(opId);
+  if (!ready) throw new AssertionError(`Operation ${opId}: expected to be ready for execution`);
+}
+
+/**
+ * Best-effort: the real Timelock contract does not expose a direct
+ * `is_executed` reader, only `is_ready`/`is_pending`. An operation that is
+ * neither ready nor pending has either been executed or cancelled — callers
+ * should only use this after independently confirming the operation wasn't
+ * cancelled (e.g. via the owning proposal's state).
+ */
+export async function assertOperationExecuted(client: TimelockClient, opId: string): Promise<void> {
+  const [ready, pending] = await Promise.all([client.isReady(opId), client.isPending(opId)]);
+  if (ready || pending) {
+    throw new AssertionError(`Operation ${opId}: expected to be executed (still ${ready ? "ready" : "pending"})`);
+  }
+}

--- a/tools/simulation/src/harness.ts
+++ b/tools/simulation/src/harness.ts
@@ -1,0 +1,269 @@
+import { createHash } from "node:crypto";
+import { Address, BASE_FEE, Keypair, nativeToScVal, TransactionBuilder } from "@stellar/stellar-sdk";
+import { GovernorClient, GovernorConfig, Network, TimelockClient, VoteType, VotesClient } from "@nebgov/sdk";
+import { LedgerClock } from "./ledger";
+import { Actor, ActorSet } from "./actors";
+import { GovernorSettingsState, MockLedgerStore } from "./mock/store";
+import { MockSorobanServer } from "./mock/server";
+import { setActiveMockServer } from "./mock/registry";
+import { applyDelegation, seedBalances } from "./mock/token-votes-executor";
+import { BaseScenario, SimulationResult } from "./scenarios/base";
+
+export interface GovernorSimulationSettings {
+  votingDelay: number;
+  votingPeriod: number;
+  quorumNumerator: number;
+  proposalThreshold: bigint;
+  /** Timelock minimum delay, in seconds. */
+  timelockDelay: bigint;
+  /** Timelock execution window, in seconds. Defaults to 14 days. */
+  executionWindow?: bigint;
+  voteType: VoteType;
+  /** Address authorized to veto proposals. Defaults to a deterministic synthetic guardian. */
+  guardian?: string;
+  /** Ledgers a Succeeded-but-unqueued proposal has before it expires. Defaults to 120_960 (~7 days). */
+  proposalGracePeriod?: number;
+  /** Minimum ledgers between proposals from the same proposer. Defaults to 100. */
+  proposalCooldown?: number;
+  /** Maximum proposals per proposer per period. Defaults to 5. */
+  maxProposalsPerPeriod?: number;
+  /** Period length in ledgers for the max-proposals-per-period cap. Defaults to 10_000. */
+  proposalPeriodDuration?: number;
+}
+
+export interface SimulationConfig {
+  /** Whether to run against the built-in mock Soroban runtime or a live/testnet RPC. */
+  mode: "mock" | "testnet";
+  settings: GovernorSimulationSettings;
+  /** Initial token holders: address -> raw token amount. */
+  tokenBalances: Record<string, bigint>;
+  /** Delegation map: delegator -> delegatee (self-delegation activates voting power). */
+  delegations: Record<string, string>;
+  /** Starting ledger sequence number. Defaults to 1000. */
+  initialLedger?: number;
+  /** Required when mode === "testnet". */
+  rpcUrl?: string;
+  network?: Network;
+}
+
+export interface DeployedContracts {
+  governor: string;
+  timelock: string;
+  votes: string;
+}
+
+interface ClockSnapshot {
+  current: number;
+  genesisTimestamp: number;
+}
+
+export interface ContractStateSnapshot {
+  store: MockLedgerStore;
+  clock: ClockSnapshot;
+}
+
+const DEFAULT_EXECUTION_WINDOW = 1_209_600n; // 14 days, matches contracts/timelock's own default.
+const DEFAULT_GRACE_PERIOD = 120_960; // ~7 days at 5s/ledger.
+const DEFAULT_COOLDOWN = 100;
+const DEFAULT_MAX_PER_PERIOD = 5;
+const DEFAULT_PERIOD_DURATION = 10_000;
+const DEFAULT_GUARDIAN = Keypair.fromRawEd25519Seed(
+  createHash("sha256").update("nebgov-simulation-actor:default-guardian").digest(),
+).publicKey();
+// Read-only simulation calls (getSettings, getProposalState, ...) build a
+// throwaway transaction and need a valid classic ("G...") source account —
+// contract addresses aren't valid transaction sources. `@nebgov/sdk`
+// defaults to the governor's own (contract) address unless a
+// `simulationAccount` is configured, so the harness always supplies one.
+const SIMULATION_ACCOUNT = Keypair.fromRawEd25519Seed(
+  createHash("sha256").update("nebgov-simulation-actor:simulation-account").digest(),
+).publicKey();
+
+function contractAddress(marker: number): string {
+  return Address.contract(Buffer.alloc(32, marker)).toString();
+}
+
+export class SimulationHarness {
+  readonly clock: LedgerClock;
+  readonly actors = new Map<string, Actor>();
+  readonly config: SimulationConfig;
+
+  governorClient!: GovernorClient;
+  timelockClient!: TimelockClient;
+  votesClient!: VotesClient;
+
+  private store!: MockLedgerStore;
+  private mockServer?: MockSorobanServer;
+  private addresses!: DeployedContracts;
+
+  constructor(config: SimulationConfig) {
+    if (config.mode === "testnet" && !config.rpcUrl) {
+      throw new Error("SimulationConfig.rpcUrl is required when mode is 'testnet'");
+    }
+    this.config = config;
+    this.clock = new LedgerClock(config.initialLedger ?? 1000);
+  }
+
+  /** Register actors (e.g. from `createActors()`) so scenarios/tests can look them up by name. */
+  registerActors(actorSet: ActorSet): void {
+    for (const [name, actor] of actorSet.all) {
+      this.actors.set(name, actor);
+    }
+  }
+
+  private buildSettingsState(): GovernorSettingsState {
+    const s = this.config.settings;
+    return {
+      votingDelay: s.votingDelay,
+      votingPeriod: s.votingPeriod,
+      quorumNumerator: s.quorumNumerator,
+      proposalThreshold: s.proposalThreshold,
+      guardian: s.guardian ?? DEFAULT_GUARDIAN,
+      voteType: s.voteType,
+      proposalGracePeriod: s.proposalGracePeriod ?? DEFAULT_GRACE_PERIOD,
+      proposalCooldown: s.proposalCooldown ?? DEFAULT_COOLDOWN,
+      maxProposalsPerPeriod: s.maxProposalsPerPeriod ?? DEFAULT_MAX_PER_PERIOD,
+      proposalPeriodDuration: s.proposalPeriodDuration ?? DEFAULT_PERIOD_DURATION,
+    };
+  }
+
+  private buildStore(): MockLedgerStore {
+    const addresses = this.addresses;
+    const store: MockLedgerStore = {
+      addresses,
+      governor: {
+        settings: this.buildSettingsState(),
+        proposals: new Map(),
+        proposalCount: 0n,
+        queueTime: new Map(),
+        lastProposalLedger: new Map(),
+        proposalsInPeriod: new Map(),
+      },
+      timelock: {
+        minDelay: this.config.settings.timelockDelay,
+        executionWindow: this.config.settings.executionWindow ?? DEFAULT_EXECUTION_WINDOW,
+        operations: new Map(),
+      },
+      votes: {
+        balances: new Map(),
+        delegates: new Map(),
+        checkpoints: new Map(),
+        totalSupplyCheckpoints: [],
+      },
+    };
+
+    seedBalances(store.votes, this.config.tokenBalances);
+    for (const [delegator, delegatee] of Object.entries(this.config.delegations)) {
+      applyDelegation(store.votes, this.clock, delegator, delegatee);
+    }
+
+    return store;
+  }
+
+  /** Boot the harness: seed state and (in mock mode) intercept Soroban RPC construction. */
+  async boot(): Promise<DeployedContracts> {
+    this.addresses = {
+      governor: contractAddress(1),
+      timelock: contractAddress(2),
+      votes: contractAddress(3),
+    };
+    this.store = this.buildStore();
+
+    const clientConfig: GovernorConfig = {
+      governorAddress: this.addresses.governor,
+      timelockAddress: this.addresses.timelock,
+      votesAddress: this.addresses.votes,
+      network: this.config.network ?? "testnet",
+      rpcUrl: this.config.mode === "testnet" ? this.config.rpcUrl : "https://mock.invalid",
+      simulationAccount: this.config.mode === "mock" ? SIMULATION_ACCOUNT : undefined,
+      maxAttempts: 1,
+    };
+
+    if (this.config.mode === "mock") {
+      this.mockServer = new MockSorobanServer(this.store, this.clock);
+      setActiveMockServer(this.mockServer);
+    }
+
+    this.governorClient = new GovernorClient(clientConfig);
+    this.timelockClient = new TimelockClient(clientConfig);
+    this.votesClient = new VotesClient(clientConfig);
+
+    return this.addresses;
+  }
+
+  /** Advance the simulated ledger by `n` ledgers. */
+  async advanceLedgers(n: number): Promise<void> {
+    this.clock.advance(n);
+  }
+
+  /** Run a scenario against this harness. */
+  async run<T extends BaseScenario, A extends unknown[]>(
+    ScenarioClass: new (harness: SimulationHarness, ...args: A) => T,
+    ...args: A
+  ): Promise<SimulationResult> {
+    const scenario = new ScenarioClass(this, ...args);
+    return scenario.run();
+  }
+
+  /**
+   * Invoke `cancel_queued` on the governor contract — a guardian veto of a
+   * queued proposal. Not yet wrapped by `@nebgov/sdk`'s `GovernorClient`, so
+   * built the same way the SDK's own write methods build theirs.
+   */
+  async cancelQueuedProposal(guardian: Keypair, proposalId: bigint): Promise<void> {
+    const server = this.governorClient.server;
+    const contract = this.governorClient.contract;
+    const account = await server.getAccount(guardian.publicKey());
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.governorClient.networkPassphrase,
+    })
+      .addOperation(
+        contract.call(
+          "cancel_queued",
+          nativeToScVal(guardian.publicKey(), { type: "address" }),
+          nativeToScVal(proposalId, { type: "u64" }),
+        ),
+      )
+      .setTimeout(30)
+      .build();
+
+    const prepared = await server.prepareTransaction(tx);
+    prepared.sign(guardian);
+
+    const result = await server.sendTransaction(prepared);
+    if (result.status === "ERROR") {
+      throw new Error(`cancel_queued failed: ${JSON.stringify(result)}`);
+    }
+    await this.governorClient.pollForConfirmation(result.hash);
+  }
+
+  /** Snapshot full contract state for later deterministic replay. */
+  async snapshot(): Promise<ContractStateSnapshot> {
+    if (this.config.mode !== "mock") {
+      throw new Error("snapshot() is only supported in mock mode");
+    }
+    return {
+      store: structuredClone(this.store),
+      clock: this.clock.snapshot(),
+    };
+  }
+
+  /** Restore a previously captured snapshot. */
+  async restore(snap: ContractStateSnapshot): Promise<void> {
+    if (this.config.mode !== "mock") {
+      throw new Error("restore() is only supported in mock mode");
+    }
+    this.store = structuredClone(snap.store);
+    this.clock.restore(snap.clock);
+    this.mockServer?.setStore(this.store);
+  }
+
+  /** Tear down the harness, releasing it as the active mock Soroban RPC target. */
+  async teardown(): Promise<void> {
+    if (this.mockServer) {
+      setActiveMockServer(undefined);
+      this.mockServer = undefined;
+    }
+  }
+}

--- a/tools/simulation/src/index.ts
+++ b/tools/simulation/src/index.ts
@@ -1,0 +1,36 @@
+export { LedgerClock } from "./ledger";
+export { Actor, createActors } from "./actors";
+export type { ActorRole, ActorSet } from "./actors";
+export { StateInspector } from "./state";
+export {
+  SimulationHarness,
+} from "./harness";
+export type {
+  ContractStateSnapshot,
+  DeployedContracts,
+  GovernorSimulationSettings,
+  SimulationConfig,
+} from "./harness";
+
+export { BaseScenario } from "./scenarios/base";
+export type { ProposalScenarioConfig, SimulationResult } from "./scenarios/base";
+export { FullLifecycleScenario } from "./scenarios/lifecycle";
+export type { LifecycleScenarioConfig } from "./scenarios/lifecycle";
+export { DefeatScenario } from "./scenarios/defeat";
+export type { DefeatScenarioConfig } from "./scenarios/defeat";
+export { GuardianVetoScenario } from "./scenarios/veto";
+export type { GuardianVetoScenarioConfig } from "./scenarios/veto";
+export { ExpiryScenario } from "./scenarios/expiry";
+export type { ExpiryScenarioConfig } from "./scenarios/expiry";
+export { RateLimitScenario } from "./scenarios/rate-limit";
+export type { RateLimitScenarioConfig } from "./scenarios/rate-limit";
+
+export {
+  assertProposalState,
+  assertQuorumNotReached,
+  assertQuorumReached,
+  assertVoteCounts,
+} from "./assertions/proposal";
+export { assertOperationExecuted, assertOperationReady } from "./assertions/timelock";
+export { assertDelegatedVotes, assertTokenBalance } from "./assertions/balances";
+export { AssertionError } from "./assertions/errors";

--- a/tools/simulation/src/ledger.ts
+++ b/tools/simulation/src/ledger.ts
@@ -1,0 +1,69 @@
+/**
+ * Deterministic ledger-sequence clock for the simulation harness.
+ *
+ * Mirrors the ledger/timestamp relationship the real network uses so that
+ * ledger-based windows (voting delay/period) and timestamp-based windows
+ * (timelock delay/execution window) advance in lockstep.
+ */
+export class LedgerClock {
+  /** Approximate seconds per closed ledger on Stellar mainnet/testnet. */
+  static readonly SECONDS_PER_LEDGER = 5;
+
+  private current: number;
+  private readonly genesisTimestamp: number;
+
+  constructor(initialLedger: number, genesisTimestamp?: number) {
+    this.current = initialLedger;
+    this.genesisTimestamp = genesisTimestamp ?? Math.floor(Date.now() / 1000);
+  }
+
+  /** The current simulated ledger sequence number. */
+  get sequence(): number {
+    return this.current;
+  }
+
+  /** The wall-clock timestamp (unix seconds) implied by the current ledger. */
+  get timestamp(): number {
+    return this.toWallTime(this.genesisTimestamp).getTime() / 1000;
+  }
+
+  /** Advance the clock by an exact number of ledgers. */
+  advance(ledgers: number): void {
+    if (ledgers < 0) {
+      throw new Error(`LedgerClock.advance: ledgers must be >= 0, got ${ledgers}`);
+    }
+    this.current += ledgers;
+  }
+
+  /** Advance until the clock is at or past `targetLedger`. No-op if already there. */
+  advanceTo(targetLedger: number): void {
+    if (targetLedger > this.current) {
+      this.current = targetLedger;
+    }
+  }
+
+  /** Convert a duration in seconds to the number of ledgers it spans, rounding up. */
+  secondsToLedgers(seconds: number): number {
+    return Math.ceil(seconds / LedgerClock.SECONDS_PER_LEDGER);
+  }
+
+  /** Convert a ledger count to the wall-clock seconds it spans. */
+  ledgersToSeconds(ledgers: number): number {
+    return ledgers * LedgerClock.SECONDS_PER_LEDGER;
+  }
+
+  /** The wall-clock time represented by the current ledger, given a genesis timestamp. */
+  toWallTime(genesisTimestamp: number): Date {
+    return new Date((genesisTimestamp + this.current * LedgerClock.SECONDS_PER_LEDGER) * 1000);
+  }
+
+  /** Take an immutable snapshot of the clock's position for later restore. */
+  snapshot(): { current: number; genesisTimestamp: number } {
+    return { current: this.current, genesisTimestamp: this.genesisTimestamp };
+  }
+
+  /** Restore a previously captured snapshot. */
+  restore(snap: { current: number; genesisTimestamp: number }): void {
+    this.current = snap.current;
+  }
+}

--- a/tools/simulation/src/mock/codec.ts
+++ b/tools/simulation/src/mock/codec.ts
@@ -1,0 +1,78 @@
+/**
+ * Explicit XDR <-> native encode/decode helpers used by the mock executors.
+ *
+ * We deliberately avoid `nativeToScVal`'s untyped object/map inference for
+ * struct-shaped return values: Soroban unit-enum variants (e.g.
+ * `ProposalState::Active`) encode as a one-element `Vec<Symbol>`, which
+ * generic inference does not produce. Building every return value explicitly
+ * keeps the encoding unambiguous and matches what `contracts/governor`,
+ * `contracts/timelock`, and `contracts/token-votes` actually put on the wire.
+ */
+import { nativeToScVal, xdr } from "@stellar/stellar-sdk";
+
+export function encAddress(addr: string): xdr.ScVal {
+  return nativeToScVal(addr, { type: "address" });
+}
+
+export function encU32(n: number): xdr.ScVal {
+  return nativeToScVal(n, { type: "u32" });
+}
+
+export function encU64(n: bigint | number): xdr.ScVal {
+  return nativeToScVal(n, { type: "u64" });
+}
+
+export function encI128(n: bigint): xdr.ScVal {
+  return nativeToScVal(n, { type: "i128" });
+}
+
+export function encBool(b: boolean): xdr.ScVal {
+  return nativeToScVal(b, { type: "boolean" });
+}
+
+export function encString(s: string): xdr.ScVal {
+  return nativeToScVal(s, { type: "string" });
+}
+
+export function encBytes(b: Uint8Array): xdr.ScVal {
+  return nativeToScVal(Buffer.from(b), { type: "bytes" });
+}
+
+export function encSymbol(s: string): xdr.ScVal {
+  return xdr.ScVal.scvSymbol(s);
+}
+
+/** A data-less Rust enum variant (e.g. `ProposalState::Active`) -> `Vec<Symbol>` of length 1. */
+export function encEnum(variant: string): xdr.ScVal {
+  return xdr.ScVal.scvVec([xdr.ScVal.scvSymbol(variant)]);
+}
+
+export function encVec(items: xdr.ScVal[]): xdr.ScVal {
+  return xdr.ScVal.scvVec(items);
+}
+
+export function encVoid(): xdr.ScVal {
+  return xdr.ScVal.scvVoid();
+}
+
+/** A `#[contracttype] struct` -> sorted `ScMap` keyed by field name symbols. */
+export function encMap(fields: Record<string, xdr.ScVal>): xdr.ScVal {
+  const keys = Object.keys(fields).sort();
+  return xdr.ScVal.scvMap(
+    keys.map(
+      (key) =>
+        new xdr.ScMapEntry({
+          key: xdr.ScVal.scvSymbol(key),
+          val: fields[key],
+        }),
+    ),
+  );
+}
+
+/** Decode a data-less enum variant name from a `Vec<Symbol>`-shaped native value. */
+export function decodeEnumVariant(native: unknown): string {
+  if (Array.isArray(native) && native.length > 0 && typeof native[0] === "string") {
+    return native[0];
+  }
+  throw new Error(`Expected an enum variant (Vec<Symbol>), got ${JSON.stringify(native)}`);
+}

--- a/tools/simulation/src/mock/errors.ts
+++ b/tools/simulation/src/mock/errors.ts
@@ -1,0 +1,21 @@
+/**
+ * Error thrown by a mock executor to model an on-chain `panic_with_error`.
+ *
+ * Formatted as `Error(Contract, #<code>)` so that `@nebgov/sdk`'s
+ * `extractContractErrorCode`/`parseGovernorError` (and the Timelock/Votes
+ * equivalents) can recover the same typed error a real deployment would
+ * produce.
+ */
+export class MockContractError extends Error {
+  constructor(
+    public readonly code: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "MockContractError";
+  }
+
+  toSorobanErrorString(): string {
+    return `Error(Contract, #${this.code})`;
+  }
+}

--- a/tools/simulation/src/mock/governor-executor.ts
+++ b/tools/simulation/src/mock/governor-executor.ts
@@ -1,0 +1,320 @@
+/**
+ * Mock replica of `contracts/governor/src/lib.rs`'s proposal state machine.
+ *
+ * Bounded scope (see harness plan "deliberate scope reductions"): no
+ * proposer-reputation-adjusted threshold, no Reflector-oracle dynamic
+ * quorum, `Single` voting strategy only (no `MultiToken`), single-action
+ * proposals only (no batch/multi-target `queue`/`execute`).
+ */
+import { LedgerClock } from "../ledger";
+import { GovernorState, MockLedgerStore, ProposalRecord } from "./store";
+import { MockContractError } from "./errors";
+import { tokenVotesExecutor } from "./token-votes-executor";
+import { cancelOperation, executeOperation, scheduleOperation } from "./timelock-executor";
+import { GovernorErrorCode } from "@nebgov/sdk";
+
+export type ProposalStateName =
+  | "Pending"
+  | "Active"
+  | "Defeated"
+  | "Succeeded"
+  | "Queued"
+  | "Executed"
+  | "Cancelled"
+  | "Expired";
+
+function isqrt(n: bigint): bigint {
+  if (n <= 0n) return 0n;
+  let x = n;
+  let y = (x + 1n) / 2n;
+  while (y < x) {
+    x = y;
+    y = (x + n / x) / 2n;
+  }
+  return x;
+}
+
+function applyVoteType(voteType: GovernorState["settings"]["voteType"], rawWeight: bigint): bigint {
+  if (voteType === "Quadratic") return isqrt(rawWeight);
+  return rawWeight;
+}
+
+export function computeQuorum(store: MockLedgerStore, clock: LedgerClock, proposal: ProposalRecord): bigint {
+  const { quorumNumerator } = store.governor.settings;
+  if (quorumNumerator === 0) return 0n;
+  const supply = tokenVotesExecutor.get_past_total_supply(store.votes, clock, "", [proposal.startLedger]);
+  return (supply * BigInt(quorumNumerator)) / 100n;
+}
+
+export function computeProposalState(store: MockLedgerStore, clock: LedgerClock, proposal: ProposalRecord): ProposalStateName {
+  if (proposal.cancelled) return "Cancelled";
+  if (proposal.executed) return "Executed";
+  if (proposal.queued) return "Queued";
+
+  const current = clock.sequence;
+  if (current < proposal.startLedger) return "Pending";
+  if (current <= proposal.endLedger) return "Active";
+
+  const quorumReq = computeQuorum(store, clock, proposal);
+  const quorumMet = proposal.votesFor + proposal.votesAbstain >= quorumReq;
+  const forWins = proposal.votesFor > proposal.votesAgainst;
+
+  if (quorumMet && forWins) {
+    const graceEnd = proposal.endLedger + store.governor.settings.proposalGracePeriod;
+    if (current > graceEnd) return "Expired";
+    return "Succeeded";
+  }
+  return "Defeated";
+}
+
+function mustGetProposal(store: MockLedgerStore, id: bigint): ProposalRecord {
+  const proposal = store.governor.proposals.get(id);
+  if (!proposal) throw new MockContractError(GovernorErrorCode.ProposalNotFound, `proposal ${id} not found`);
+  return proposal;
+}
+
+export const governorExecutor = {
+  propose(store: MockLedgerStore, clock: LedgerClock, caller: string, args: unknown[]): bigint {
+    const [proposer, description, descriptionHash, metadataUri, targets, fnNames, calldatas] = args as [
+      string,
+      string,
+      Uint8Array,
+      string,
+      string[],
+      string[],
+      Uint8Array[],
+    ];
+    if (caller !== proposer) {
+      throw new MockContractError(100, "propose: proposer must authorize this call");
+    }
+    if (targets.length === 0 || targets.length !== fnNames.length || targets.length !== calldatas.length) {
+      throw new MockContractError(GovernorErrorCode.InvalidVectorLengths, "propose: targets/fnNames/calldatas length mismatch");
+    }
+
+    const gov = store.governor;
+    const proposerVotes = tokenVotesExecutor.get_votes(store.votes, clock, proposer, [proposer]);
+    if (proposerVotes < gov.settings.proposalThreshold) {
+      throw new MockContractError(GovernorErrorCode.ProposalThresholdNotMet, "propose: proposal threshold not met");
+    }
+
+    const current = clock.sequence;
+    const cooldown = gov.settings.proposalCooldown;
+    const lastProposalLedger = gov.lastProposalLedger.get(proposer);
+    if (lastProposalLedger !== undefined && current < lastProposalLedger + cooldown) {
+      throw new MockContractError(GovernorErrorCode.ProposalRateLimited, "propose: proposer is in cooldown");
+    }
+
+    const periodDuration = gov.settings.proposalPeriodDuration;
+    const maxPerPeriod = gov.settings.maxProposalsPerPeriod;
+    const currentPeriod = Math.floor(current / periodDuration);
+    const periodKey = `${proposer}:${currentPeriod}`;
+    const proposalsInPeriod = gov.proposalsInPeriod.get(periodKey) ?? 0;
+    if (proposalsInPeriod >= maxPerPeriod) {
+      throw new MockContractError(GovernorErrorCode.ProposalRateLimited, "propose: max proposals per period reached");
+    }
+
+    const id = gov.proposalCount + 1n;
+    const proposal: ProposalRecord = {
+      id,
+      proposer,
+      description,
+      descriptionHash: Buffer.from(descriptionHash).toString("hex"),
+      metadataUri,
+      targets,
+      fnNames,
+      calldatas,
+      startLedger: current + gov.settings.votingDelay,
+      endLedger: current + gov.settings.votingDelay + gov.settings.votingPeriod,
+      votesFor: 0n,
+      votesAgainst: 0n,
+      votesAbstain: 0n,
+      executed: false,
+      cancelled: false,
+      queued: false,
+      opIds: [],
+      hasVoted: {},
+    };
+    gov.proposals.set(id, proposal);
+    gov.proposalCount = id;
+    gov.lastProposalLedger.set(proposer, current);
+    gov.proposalsInPeriod.set(periodKey, proposalsInPeriod + 1);
+    return id;
+  },
+
+  cast_vote(store: MockLedgerStore, clock: LedgerClock, caller: string, args: unknown[]): null {
+    const [voter, proposalId, supportVariant] = args as [string, bigint, string[]];
+    if (caller !== voter) {
+      throw new MockContractError(100, "cast_vote: voter must authorize this call");
+    }
+    const support = supportVariant[0];
+    const gov = store.governor;
+    const proposal = mustGetProposal(store, proposalId);
+
+    if (proposal.hasVoted[voter]) {
+      throw new MockContractError(GovernorErrorCode.AlreadyVoted, "cast_vote: already voted");
+    }
+
+    const voteType = gov.settings.voteType;
+    if (voteType === "Simple" && support === "Abstain") {
+      throw new MockContractError(GovernorErrorCode.InvalidSupport, "cast_vote: abstain not allowed for Simple vote type");
+    }
+
+    const current = clock.sequence;
+    if (proposal.cancelled || proposal.executed || proposal.queued || current < proposal.startLedger || current > proposal.endLedger) {
+      throw new MockContractError(GovernorErrorCode.ProposalNotActive, "cast_vote: proposal is not active");
+    }
+
+    const rawWeight = tokenVotesExecutor.get_past_votes(store.votes, clock, voter, [voter, proposal.startLedger]);
+    const weight = applyVoteType(voteType, rawWeight);
+
+    if (weight > 0n) {
+      if (support === "For") proposal.votesFor += weight;
+      else if (support === "Against") proposal.votesAgainst += weight;
+      else if (support === "Abstain") proposal.votesAbstain += weight;
+    }
+    proposal.hasVoted[voter] = true;
+    return null;
+  },
+
+  queue(store: MockLedgerStore, clock: LedgerClock, _caller: string, args: unknown[]): null {
+    const [proposalId] = args as [bigint];
+    const proposal = mustGetProposal(store, proposalId);
+    const state = computeProposalState(store, clock, proposal);
+
+    if (state === "Expired") {
+      throw new MockContractError(GovernorErrorCode.ProposalExpired, "queue: proposal expired");
+    }
+    if (state !== "Succeeded") {
+      throw new MockContractError(GovernorErrorCode.ProposalNotSucceeded, "queue: proposal not succeeded");
+    }
+
+    const requiredQuorum = computeQuorum(store, clock, proposal);
+    const quorumMet = proposal.votesFor + proposal.votesAbstain >= requiredQuorum;
+    const forWins = proposal.votesFor > proposal.votesAgainst;
+    if (!quorumMet || !forWins) {
+      throw new MockContractError(GovernorErrorCode.ProposalNotSucceeded, "queue: quorum/majority not met");
+    }
+
+    if (proposal.targets.length === 0) {
+      throw new MockContractError(GovernorErrorCode.NoTargets, "queue: no targets");
+    }
+
+    const delay = store.timelock.minDelay;
+    const opId = scheduleOperation(store.timelock, clock, proposal.targets[0], proposal.calldatas[0], proposal.fnNames[0], delay);
+
+    proposal.opIds = [opId];
+    proposal.queued = true;
+    store.governor.queueTime.set(proposalId, clock.sequence);
+    return null;
+  },
+
+  execute(store: MockLedgerStore, clock: LedgerClock, _caller: string, args: unknown[]): null {
+    const [proposalId] = args as [bigint];
+    const proposal = mustGetProposal(store, proposalId);
+    const state = computeProposalState(store, clock, proposal);
+    if (state !== "Queued") {
+      throw new MockContractError(GovernorErrorCode.ProposalNotQueued, "execute: proposal not queued");
+    }
+    if (proposal.executed) {
+      throw new MockContractError(GovernorErrorCode.ProposalAlreadyExecuted, "execute: already executed");
+    }
+    if (proposal.opIds.length === 0) {
+      throw new MockContractError(GovernorErrorCode.MissingOpIds, "execute: missing op ids");
+    }
+    executeOperation(store.timelock, clock, proposal.opIds[0]);
+    proposal.executed = true;
+    return null;
+  },
+
+  cancel(store: MockLedgerStore, clock: LedgerClock, caller: string, args: unknown[]): null {
+    const [cancelCaller, proposalId] = args as [string, bigint];
+    if (caller !== cancelCaller) {
+      throw new MockContractError(100, "cancel: caller must authorize this call");
+    }
+    const proposal = mustGetProposal(store, proposalId);
+    const state = computeProposalState(store, clock, proposal);
+    const guardian = store.governor.settings.guardian;
+    const canCancel =
+      (cancelCaller === proposal.proposer && state === "Pending") || (cancelCaller === guardian && state === "Active");
+    if (!canCancel) {
+      throw new MockContractError(GovernorErrorCode.UnauthorizedCancel, "cancel: unauthorized");
+    }
+    proposal.cancelled = true;
+    return null;
+  },
+
+  cancel_queued(store: MockLedgerStore, clock: LedgerClock, caller: string, args: unknown[]): null {
+    const [cancelCaller, proposalId] = args as [string, bigint];
+    if (caller !== cancelCaller) {
+      throw new MockContractError(100, "cancel_queued: caller must authorize this call");
+    }
+    const proposal = mustGetProposal(store, proposalId);
+    if (!proposal.queued || proposal.cancelled) {
+      throw new MockContractError(GovernorErrorCode.ProposalNotQueued, "cancel_queued: proposal not queued");
+    }
+    const guardian = store.governor.settings.guardian;
+    if (cancelCaller !== guardian) {
+      throw new MockContractError(GovernorErrorCode.UnauthorizedGuardian, "cancel_queued: only guardian may veto");
+    }
+    const queueTime = store.governor.queueTime.get(proposalId);
+    if (queueTime === undefined) {
+      throw new MockContractError(GovernorErrorCode.ProposalNotQueued, "cancel_queued: missing queue time");
+    }
+    const delayLedgers = Math.floor(Number(store.timelock.minDelay) / LedgerClock.SECONDS_PER_LEDGER);
+    const vetoWindowEndLedger = queueTime + delayLedgers;
+    if (clock.sequence >= vetoWindowEndLedger) {
+      throw new MockContractError(GovernorErrorCode.VetoWindowClosed, "cancel_queued: veto window closed");
+    }
+
+    proposal.cancelled = true;
+    for (const opId of proposal.opIds) {
+      cancelOperation(store.timelock, opId);
+    }
+    return null;
+  },
+
+  state(store: MockLedgerStore, clock: LedgerClock, _caller: string, args: unknown[]): ProposalStateName {
+    const [proposalId] = args as [bigint];
+    const proposal = mustGetProposal(store, proposalId);
+    return computeProposalState(store, clock, proposal);
+  },
+
+  get_settings(store: MockLedgerStore): GovernorState["settings"] {
+    return store.governor.settings;
+  },
+
+  get_quorum(store: MockLedgerStore, clock: LedgerClock, _caller: string, args: unknown[]): bigint {
+    const [proposalId] = args as [bigint];
+    const proposal = mustGetProposal(store, proposalId);
+    return computeQuorum(store, clock, proposal);
+  },
+
+  is_quorum_reached(store: MockLedgerStore, clock: LedgerClock, _caller: string, args: unknown[]): boolean {
+    const [proposalId] = args as [bigint];
+    const proposal = mustGetProposal(store, proposalId);
+    const requiredQuorum = computeQuorum(store, clock, proposal);
+    return proposal.votesFor + proposal.votesAbstain >= requiredQuorum;
+  },
+
+  proposal_threshold(store: MockLedgerStore): bigint {
+    return store.governor.settings.proposalThreshold;
+  },
+
+  proposal_votes(store: MockLedgerStore, _clock: LedgerClock, _caller: string, args: unknown[]): [bigint, bigint, bigint] {
+    const [proposalId] = args as [bigint];
+    const proposal = mustGetProposal(store, proposalId);
+    return [proposal.votesFor, proposal.votesAgainst, proposal.votesAbstain];
+  },
+
+  has_voted(store: MockLedgerStore, _clock: LedgerClock, _caller: string, args: unknown[]): boolean {
+    const [proposalId, voter] = args as [bigint, string];
+    const proposal = mustGetProposal(store, proposalId);
+    return Boolean(proposal.hasVoted[voter]);
+  },
+
+  proposal_count(store: MockLedgerStore): bigint {
+    return store.governor.proposalCount;
+  },
+};
+
+export type GovernorFunction = keyof typeof governorExecutor;

--- a/tools/simulation/src/mock/registry.ts
+++ b/tools/simulation/src/mock/registry.ts
@@ -1,0 +1,22 @@
+/**
+ * `SorobanRpc.Server` is exported by `@stellar/stellar-sdk` as a
+ * non-configurable getter, so it cannot be monkey-patched at runtime — it
+ * must be replaced via `jest.mock("@stellar/stellar-sdk", ...)` (wired up
+ * once in `tests/jest.setup.ts`). That mock factory runs before any
+ * `SimulationHarness` exists, so it can't close over a specific server
+ * instance directly; instead it looks up whichever server is "active" here.
+ */
+import { MockSorobanServer } from "./server";
+
+let active: MockSorobanServer | undefined;
+
+export function setActiveMockServer(server: MockSorobanServer | undefined): void {
+  active = server;
+}
+
+export function getActiveMockServer(): MockSorobanServer {
+  if (!active) {
+    throw new Error("No active MockSorobanServer — call SimulationHarness.boot({ mode: 'mock' }) first");
+  }
+  return active;
+}

--- a/tools/simulation/src/mock/server.ts
+++ b/tools/simulation/src/mock/server.ts
@@ -1,0 +1,260 @@
+/**
+ * `MockSorobanServer` — a stateful, in-memory stand-in for
+ * `SorobanRpc.Server`, wired in by `SimulationHarness.boot()` via
+ * `jest.mock("@stellar/stellar-sdk", ...)` (the same seam
+ * `sdk/src/__tests__/governor.test.ts` uses).
+ *
+ * `@nebgov/sdk`'s `GovernorClient`/`TimelockClient`/`VotesClient` build real
+ * Soroban operations via `Contract.call()` + `TransactionBuilder`, so this
+ * class decodes the real XDR operation off the transaction it's handed
+ * (contract address, function name, args) and dispatches to the matching
+ * in-memory executor, rather than short-circuiting the SDK's own encoding.
+ */
+import { Address, nativeToScVal, scValToNative, SorobanDataBuilder, xdr } from "@stellar/stellar-sdk";
+import { LedgerClock } from "../ledger";
+import { cloneStore, MockLedgerStore } from "./store";
+import { MockContractError } from "./errors";
+import { governorExecutor } from "./governor-executor";
+import { timelockExecutor } from "./timelock-executor";
+import { tokenVotesExecutor } from "./token-votes-executor";
+import { encAddress, encBool, encEnum, encI128, encMap, encU32, encU64, encVec, encVoid } from "./codec";
+
+interface DecodedInvocation {
+  contractAddress: string;
+  functionName: string;
+  args: unknown[];
+  caller: string;
+}
+
+interface StoredTxResult {
+  status: "SUCCESS" | "FAILED";
+  returnValue?: xdr.ScVal;
+  error?: string;
+}
+
+/**
+ * Duck-typed `Account` (the trio `TransactionBuilder` actually calls:
+ * `accountId()`/`sequenceNumber()`/`incrementSequenceNumber()`). Several SDK
+ * read paths call `getAccount()` with a contract ("C...") address as a
+ * throwaway simulation source, which the real `Account` class's strkey
+ * validation would reject — this accepts any id.
+ */
+class MockAccount {
+  constructor(
+    private readonly id: string,
+    private sequence: bigint,
+  ) {}
+
+  accountId(): string {
+    return this.id;
+  }
+
+  sequenceNumber(): string {
+    return this.sequence.toString();
+  }
+
+  incrementSequenceNumber(): void {
+    this.sequence += 1n;
+  }
+}
+
+function decodeInvocation(tx: { operations: unknown[]; source: string }): DecodedInvocation {
+  const op = tx.operations[0] as { type?: string; func?: xdr.HostFunction; source?: string };
+  if (!op || op.type !== "invokeHostFunction" || !op.func) {
+    throw new Error("MockSorobanServer only supports a single invokeHostFunction operation");
+  }
+  const invoke = op.func.invokeContract();
+  const contractAddress = Address.fromScAddress(invoke.contractAddress()).toString();
+  const rawName = invoke.functionName();
+  const functionName = typeof rawName === "string" ? rawName : Buffer.from(rawName).toString();
+  const args = invoke.args().map((arg) => scValToNative(arg));
+  return { contractAddress, functionName, args, caller: op.source ?? tx.source };
+}
+
+function encodeGovernorSettings(settings: MockLedgerStore["governor"]["settings"]): xdr.ScVal {
+  return encMap({
+    voting_delay: encU32(settings.votingDelay),
+    voting_period: encU32(settings.votingPeriod),
+    quorum_numerator: encU32(settings.quorumNumerator),
+    proposal_threshold: encI128(settings.proposalThreshold),
+    guardian: encAddress(settings.guardian),
+    vote_type: encEnum(settings.voteType),
+    proposal_grace_period: encU32(settings.proposalGracePeriod),
+    use_dynamic_quorum: encBool(false),
+    reflector_oracle: encVoid(),
+    min_quorum_usd: encI128(0n),
+    max_calldata_size: encU32(10_000),
+    proposal_cooldown: encU32(settings.proposalCooldown),
+    max_proposals_per_period: encU32(settings.maxProposalsPerPeriod),
+    proposal_period_duration: encU32(settings.proposalPeriodDuration),
+  });
+}
+
+function encodeReturn(contract: "governor" | "timelock" | "votes", fnName: string, value: unknown): xdr.ScVal {
+  if (contract === "governor") {
+    switch (fnName) {
+      case "propose":
+      case "proposal_count":
+        return encU64(value as bigint);
+      case "cast_vote":
+      case "queue":
+      case "execute":
+      case "cancel":
+      case "cancel_queued":
+        return encVoid();
+      case "state":
+        return encEnum(value as string);
+      case "get_settings":
+        return encodeGovernorSettings(value as MockLedgerStore["governor"]["settings"]);
+      case "get_quorum":
+      case "proposal_threshold":
+        return encI128(value as bigint);
+      case "is_quorum_reached":
+        return encBool(value as boolean);
+      case "proposal_votes":
+        return encVec((value as bigint[]).map(encI128));
+      case "has_voted":
+        return encBool(value as boolean);
+      default:
+        throw new Error(`MockSorobanServer: no encoder for governor.${fnName}`);
+    }
+  }
+  if (contract === "timelock") {
+    switch (fnName) {
+      case "is_ready":
+      case "is_pending":
+        return encBool(value as boolean);
+      case "min_delay":
+      case "execution_window":
+        return encU64(value as bigint);
+      default:
+        throw new Error(`MockSorobanServer: no encoder for timelock.${fnName}`);
+    }
+  }
+  switch (fnName) {
+    case "delegate":
+      return encVoid();
+    case "get_votes":
+    case "get_base_votes":
+    case "get_past_votes":
+    case "get_past_total_supply":
+      return encI128(value as bigint);
+    case "delegates":
+      return value ? encAddress(value as string) : encVoid();
+    default:
+      throw new Error(`MockSorobanServer: no encoder for votes.${fnName}`);
+  }
+}
+
+export class MockSorobanServer {
+  private readonly results = new Map<string, StoredTxResult>();
+
+  constructor(
+    private store: MockLedgerStore,
+    private readonly clock: LedgerClock,
+  ) {}
+
+  /** Swap in a restored store (e.g. after `SimulationHarness.restore()`). */
+  setStore(store: MockLedgerStore): void {
+    this.store = store;
+    this.results.clear();
+  }
+
+  private resolveContract(address: string): "governor" | "timelock" | "votes" {
+    if (address === this.store.addresses.governor) return "governor";
+    if (address === this.store.addresses.timelock) return "timelock";
+    if (address === this.store.addresses.votes) return "votes";
+    throw new Error(`MockSorobanServer: unknown contract address ${address}`);
+  }
+
+  private dispatch(invocation: DecodedInvocation, store: MockLedgerStore): unknown {
+    const contract = this.resolveContract(invocation.contractAddress);
+    if (contract === "governor") {
+      const handler = (governorExecutor as Record<string, (...a: unknown[]) => unknown>)[invocation.functionName];
+      if (!handler) throw new Error(`MockSorobanServer: unknown governor function ${invocation.functionName}`);
+      return handler(store, this.clock, invocation.caller, invocation.args);
+    }
+    if (contract === "timelock") {
+      const handler = (timelockExecutor as Record<string, (...a: unknown[]) => unknown>)[invocation.functionName];
+      if (!handler) throw new Error(`MockSorobanServer: unknown timelock function ${invocation.functionName}`);
+      return handler(store.timelock, this.clock, invocation.caller, invocation.args);
+    }
+    const handler = (tokenVotesExecutor as Record<string, (...a: unknown[]) => unknown>)[invocation.functionName];
+    if (!handler) throw new Error(`MockSorobanServer: unknown votes function ${invocation.functionName}`);
+    return handler(store.votes, this.clock, invocation.caller, invocation.args);
+  }
+
+  async getAccount(accountId: string): Promise<MockAccount> {
+    return new MockAccount(accountId, 0n);
+  }
+
+  async getLatestLedger(): Promise<{ id: string; protocolVersion: number; sequence: number }> {
+    return { id: "mock-ledger", protocolVersion: 21, sequence: this.clock.sequence };
+  }
+
+  async prepareTransaction<T>(tx: T): Promise<T> {
+    return tx;
+  }
+
+  async simulateTransaction(tx: { operations: unknown[]; source: string }): Promise<Record<string, unknown>> {
+    const invocation = decodeInvocation(tx);
+    const contract = this.resolveContract(invocation.contractAddress);
+    const scratch = cloneStore(this.store);
+
+    try {
+      const value = this.dispatch(invocation, scratch);
+      const retval = encodeReturn(contract, invocation.functionName, value);
+      return {
+        _parsed: true,
+        id: "1",
+        latestLedger: this.clock.sequence,
+        events: [],
+        transactionData: new SorobanDataBuilder(),
+        minResourceFee: "100000",
+        cost: { cpuInsns: "0", memBytes: "0" },
+        result: { auth: [], retval },
+      };
+    } catch (e) {
+      return {
+        _parsed: true,
+        id: "1",
+        latestLedger: this.clock.sequence,
+        events: [],
+        error: e instanceof MockContractError ? e.toSorobanErrorString() : String(e instanceof Error ? e.message : e),
+      };
+    }
+  }
+
+  async sendTransaction(tx: { operations: unknown[]; source: string; hash(): Buffer }): Promise<Record<string, unknown>> {
+    const invocation = decodeInvocation(tx);
+    const contract = this.resolveContract(invocation.contractAddress);
+    const hash = tx.hash().toString("hex");
+
+    try {
+      const value = this.dispatch(invocation, this.store);
+      const returnValue = encodeReturn(contract, invocation.functionName, value);
+      this.results.set(hash, { status: "SUCCESS", returnValue });
+      return { status: "PENDING", hash, latestLedgerCloseTime: String(Math.floor(this.clock.timestamp)) };
+    } catch (e) {
+      const message = e instanceof MockContractError ? e.toSorobanErrorString() : String(e instanceof Error ? e.message : e);
+      this.results.set(hash, { status: "FAILED", error: message });
+      return { status: "ERROR", hash, error: message };
+    }
+  }
+
+  async getTransaction(hash: string): Promise<Record<string, unknown>> {
+    const result = this.results.get(hash);
+    if (!result) {
+      return { status: "NOT_FOUND" };
+    }
+    if (result.status === "FAILED") {
+      return { status: "FAILED" };
+    }
+    return { status: "SUCCESS", returnValue: result.returnValue, latestLedger: this.clock.sequence };
+  }
+}
+
+// Re-exported so callers building raw operations (functions not yet wrapped
+// by @nebgov/sdk, e.g. `cancel_queued`) can reuse the same native<->ScVal
+// helpers the executors were verified against.
+export { nativeToScVal, scValToNative };

--- a/tools/simulation/src/mock/store.ts
+++ b/tools/simulation/src/mock/store.ts
@@ -1,0 +1,98 @@
+/**
+ * In-memory ledger state shared by the mock Governor/Timelock/TokenVotes
+ * executors. This is intentionally a plain, structured-cloneable object graph
+ * (no class instances, no XDR types) so that `snapshot()`/`restore()` and the
+ * side-effect-free `simulateTransaction` dry run can both use
+ * `structuredClone`.
+ */
+
+export interface ProposalRecord {
+  id: bigint;
+  proposer: string;
+  description: string;
+  descriptionHash: string;
+  metadataUri: string;
+  targets: string[];
+  fnNames: string[];
+  calldatas: Uint8Array[];
+  startLedger: number;
+  endLedger: number;
+  votesFor: bigint;
+  votesAgainst: bigint;
+  votesAbstain: bigint;
+  executed: boolean;
+  cancelled: boolean;
+  queued: boolean;
+  opIds: string[];
+  hasVoted: Record<string, boolean>;
+}
+
+export interface GovernorSettingsState {
+  votingDelay: number;
+  votingPeriod: number;
+  quorumNumerator: number;
+  proposalThreshold: bigint;
+  guardian: string;
+  voteType: "Simple" | "Extended" | "Quadratic";
+  proposalGracePeriod: number;
+  proposalCooldown: number;
+  maxProposalsPerPeriod: number;
+  proposalPeriodDuration: number;
+}
+
+export interface GovernorState {
+  settings: GovernorSettingsState;
+  proposals: Map<bigint, ProposalRecord>;
+  proposalCount: bigint;
+  queueTime: Map<bigint, number>;
+  lastProposalLedger: Map<string, number>;
+  proposalsInPeriod: Map<string, number>;
+}
+
+export interface TimelockOperationRecord {
+  target: string;
+  fnName: string;
+  data: Uint8Array;
+  readyAt: number;
+  expiresAt: number;
+  executed: boolean;
+  cancelled: boolean;
+}
+
+export interface TimelockState {
+  minDelay: bigint;
+  executionWindow: bigint;
+  operations: Map<string, TimelockOperationRecord>;
+}
+
+export interface Checkpoint {
+  ledger: number;
+  votes: bigint;
+}
+
+export interface TokenVotesState {
+  /** Raw token balance seeded per account (not moved by delegation). */
+  balances: Map<string, bigint>;
+  /** delegator -> delegatee (self if undelegated/self-delegated). */
+  delegates: Map<string, string>;
+  /** account -> checkpoint history of its delegated voting power. */
+  checkpoints: Map<string, Checkpoint[]>;
+  totalSupplyCheckpoints: Checkpoint[];
+}
+
+export interface ContractAddresses {
+  governor: string;
+  timelock: string;
+  votes: string;
+}
+
+export interface MockLedgerStore {
+  addresses: ContractAddresses;
+  governor: GovernorState;
+  timelock: TimelockState;
+  votes: TokenVotesState;
+}
+
+export function cloneStore(store: MockLedgerStore): MockLedgerStore {
+  return structuredClone(store);
+}

--- a/tools/simulation/src/mock/timelock-executor.ts
+++ b/tools/simulation/src/mock/timelock-executor.ts
@@ -1,0 +1,115 @@
+/**
+ * Mock replica of `contracts/timelock/src/lib.rs`'s scheduling/execution
+ * bookkeeping. `schedule`/`execute`/`cancel` are only ever invoked
+ * in-process by the Governor executor (mirroring how the real Governor
+ * contract is the sole `require_governor`-gated caller of the Timelock
+ * contract), never dispatched from a directly-signed Actor transaction.
+ *
+ * Simplification: `execute()` marks the operation executed but does not
+ * actually invoke the scheduled target/fn_name/calldata — the harness has no
+ * general-purpose contract-call dispatcher for arbitrary targets. Execution
+ * success is modeled as "the timelock operation transitioned to executed",
+ * matching the six `ProposalState` transitions the acceptance criteria care
+ * about.
+ */
+import { createHash } from "node:crypto";
+import { LedgerClock } from "../ledger";
+import { TimelockOperationRecord, TimelockState } from "./store";
+import { MockContractError } from "./errors";
+import { TimelockErrorCode } from "@nebgov/sdk";
+
+function computeOpId(target: string, data: Uint8Array, fnName: string, delay: bigint, predecessor: Uint8Array, salt: Uint8Array): string {
+  return createHash("sha256")
+    .update(target)
+    .update(fnName)
+    .update(Buffer.from(data))
+    .update(String(delay))
+    .update(Buffer.from(predecessor))
+    .update(Buffer.from(salt))
+    .digest("hex");
+}
+
+export function requireGovernor(state: TimelockState, governorAddress: string, caller: string): void {
+  if (caller !== governorAddress) {
+    throw new MockContractError(TimelockErrorCode.PredecessorNotDone, "timelock: caller is not the governor");
+  }
+}
+
+export function scheduleOperation(
+  state: TimelockState,
+  clock: LedgerClock,
+  target: string,
+  data: Uint8Array,
+  fnName: string,
+  delay: bigint,
+  predecessor: Uint8Array = new Uint8Array(),
+  salt: Uint8Array = new Uint8Array(),
+): string {
+  if (delay < state.minDelay) {
+    throw new MockContractError(100, "schedule: delay too short");
+  }
+  const opId = computeOpId(target, data, fnName, delay, predecessor, salt);
+  const readyAt = clock.timestamp + Number(delay);
+  const expiresAt = readyAt + Number(state.executionWindow);
+  const op: TimelockOperationRecord = {
+    target,
+    fnName,
+    data,
+    readyAt,
+    expiresAt,
+    executed: false,
+    cancelled: false,
+  };
+  state.operations.set(opId, op);
+  return opId;
+}
+
+export function executeOperation(state: TimelockState, clock: LedgerClock, opId: string): void {
+  const op = state.operations.get(opId);
+  if (!op) throw new MockContractError(100, "execute: operation not found");
+  if (op.executed || op.cancelled) {
+    throw new MockContractError(100, "execute: invalid operation state");
+  }
+  if (clock.timestamp < op.readyAt) {
+    throw new MockContractError(100, "execute: operation not ready");
+  }
+  if (clock.timestamp > op.expiresAt) {
+    throw new MockContractError(TimelockErrorCode.OperationExpired, "execute: operation expired");
+  }
+  op.executed = true;
+}
+
+export function cancelOperation(state: TimelockState, opId: string): void {
+  const op = state.operations.get(opId);
+  if (!op) throw new MockContractError(100, "cancel: operation not found");
+  if (op.executed) throw new MockContractError(100, "cancel: already executed");
+  op.cancelled = true;
+}
+
+export const timelockExecutor = {
+  is_ready(state: TimelockState, clock: LedgerClock, _caller: string, args: unknown[]): boolean {
+    const [opIdBytes] = args as [Uint8Array];
+    const opId = Buffer.from(opIdBytes).toString("hex");
+    const op = state.operations.get(opId);
+    if (!op) return false;
+    return !op.executed && !op.cancelled && clock.timestamp >= op.readyAt && clock.timestamp <= op.expiresAt;
+  },
+
+  is_pending(state: TimelockState, clock: LedgerClock, _caller: string, args: unknown[]): boolean {
+    const [opIdBytes] = args as [Uint8Array];
+    const opId = Buffer.from(opIdBytes).toString("hex");
+    const op = state.operations.get(opId);
+    if (!op) return false;
+    return !op.executed && !op.cancelled && clock.timestamp < op.readyAt;
+  },
+
+  min_delay(state: TimelockState): bigint {
+    return state.minDelay;
+  },
+
+  execution_window(state: TimelockState): bigint {
+    return state.executionWindow;
+  },
+};
+
+export type TimelockFunction = keyof typeof timelockExecutor;

--- a/tools/simulation/src/mock/token-votes-executor.ts
+++ b/tools/simulation/src/mock/token-votes-executor.ts
@@ -1,0 +1,114 @@
+/**
+ * Mock replica of `contracts/token-votes/src/lib.rs`'s delegation +
+ * checkpoint bookkeeping (`delegate`, `get_votes`, `get_past_votes`).
+ *
+ * Simplification (documented in the harness plan): there is no separate
+ * simulated SEP-41 token contract. `SimulationConfig.tokenBalances` seeds
+ * each account's raw, delegatable balance directly into this executor.
+ * Time-weighted checkpoints (`weighted_sum` bonus) are out of scope — voting
+ * power is the flat delegated amount, which is sufficient to exercise the
+ * governor's quorum/threshold/vote-weight logic exactly as the six
+ * `ProposalState` transitions require.
+ */
+import { LedgerClock } from "../ledger";
+import { Checkpoint, TokenVotesState } from "./store";
+import { MockContractError } from "./errors";
+
+function lastCheckpointVotes(list: Checkpoint[] | undefined): bigint {
+  if (!list || list.length === 0) return 0n;
+  return list[list.length - 1].votes;
+}
+
+function pushCheckpoint(map: Map<string, Checkpoint[]>, account: string, ledger: number, votes: bigint): void {
+  const list = map.get(account) ?? [];
+  list.push({ ledger, votes });
+  map.set(account, list);
+}
+
+function checkpointAt(list: Checkpoint[] | undefined, ledger: number): bigint {
+  if (!list || list.length === 0) return 0n;
+  // Checkpoints are appended in non-decreasing ledger order; scan from the
+  // end for the last entry at or before the target ledger.
+  for (let i = list.length - 1; i >= 0; i--) {
+    if (list[i].ledger <= ledger) return list[i].votes;
+  }
+  return 0n;
+}
+
+export function seedBalances(state: TokenVotesState, balances: Record<string, bigint>): void {
+  for (const [account, amount] of Object.entries(balances)) {
+    state.balances.set(account, amount);
+  }
+}
+
+export function applyDelegation(
+  state: TokenVotesState,
+  clock: LedgerClock,
+  delegator: string,
+  delegatee: string,
+): void {
+  const amount = state.balances.get(delegator) ?? 0n;
+  const isFirstDelegation = !state.delegates.has(delegator);
+  const oldDelegatee = state.delegates.get(delegator) ?? delegator;
+
+  // On a delegator's first-ever `delegate()` call there is no prior
+  // checkpoint to net against (even when self-delegating, i.e.
+  // `oldDelegatee === delegatee` by default) — it must still activate their
+  // voting power by crediting the new delegatee.
+  if (isFirstDelegation || oldDelegatee !== delegatee) {
+    if (!isFirstDelegation) {
+      pushCheckpoint(state.checkpoints, oldDelegatee, clock.sequence, lastCheckpointVotes(state.checkpoints.get(oldDelegatee)) - amount);
+    }
+    pushCheckpoint(state.checkpoints, delegatee, clock.sequence, lastCheckpointVotes(state.checkpoints.get(delegatee)) + amount);
+  }
+  state.delegates.set(delegator, delegatee);
+
+  if (isFirstDelegation && amount > 0n) {
+    const lastTotal = lastCheckpointVotes(state.totalSupplyCheckpoints);
+    state.totalSupplyCheckpoints.push({ ledger: clock.sequence, votes: lastTotal + amount });
+  }
+}
+
+export const tokenVotesExecutor = {
+  delegate(state: TokenVotesState, clock: LedgerClock, caller: string, args: unknown[]): unknown {
+    const [delegator, delegatee] = args as [string, string];
+    if (caller !== delegator) {
+      throw new MockContractError(1, "delegate: delegator must authorize this call");
+    }
+    applyDelegation(state, clock, delegator, delegatee);
+    return null;
+  },
+
+  get_votes(state: TokenVotesState, _clock: LedgerClock, _caller: string, args: unknown[]): bigint {
+    const [account] = args as [string];
+    return lastCheckpointVotes(state.checkpoints.get(account));
+  },
+
+  get_base_votes(state: TokenVotesState, _clock: LedgerClock, _caller: string, args: unknown[]): bigint {
+    const [account] = args as [string];
+    return state.balances.get(account) ?? 0n;
+  },
+
+  get_past_votes(state: TokenVotesState, clock: LedgerClock, _caller: string, args: unknown[]): bigint {
+    const [account, ledger] = args as [string, number];
+    if (ledger > clock.sequence) {
+      throw new MockContractError(100, "get_past_votes: cannot query a future ledger");
+    }
+    return checkpointAt(state.checkpoints.get(account), ledger);
+  },
+
+  get_past_total_supply(state: TokenVotesState, clock: LedgerClock, _caller: string, args: unknown[]): bigint {
+    const [ledger] = args as [number];
+    if (ledger > clock.sequence) {
+      throw new MockContractError(100, "get_past_total_supply: cannot query a future ledger");
+    }
+    return checkpointAt(state.totalSupplyCheckpoints, ledger);
+  },
+
+  delegates(state: TokenVotesState, _clock: LedgerClock, _caller: string, args: unknown[]): string | null {
+    const [account] = args as [string];
+    return state.delegates.get(account) ?? null;
+  },
+};
+
+export type TokenVotesFunction = keyof typeof tokenVotesExecutor;

--- a/tools/simulation/src/scenarios/base.ts
+++ b/tools/simulation/src/scenarios/base.ts
@@ -1,0 +1,26 @@
+import { ProposalState, VoteSupport } from "@nebgov/sdk";
+import { Actor } from "../actors";
+import { SimulationHarness } from "../harness";
+
+/** Shared shape for the single-action proposals every scenario submits. */
+export interface ProposalScenarioConfig {
+  proposer: Actor;
+  voters: Array<{ actor: Actor; support: VoteSupport }>;
+  description: string;
+  targets: string[];
+  fnNames: string[];
+  calldatas: Buffer[];
+}
+
+export interface SimulationResult {
+  success: boolean;
+  proposalId?: bigint;
+  finalState?: ProposalState;
+  ledgersElapsed: number;
+  errors: string[];
+}
+
+export abstract class BaseScenario {
+  constructor(protected harness: SimulationHarness) {}
+  abstract run(): Promise<SimulationResult>;
+}

--- a/tools/simulation/src/scenarios/defeat.ts
+++ b/tools/simulation/src/scenarios/defeat.ts
@@ -1,0 +1,48 @@
+import { ProposalState } from "@nebgov/sdk";
+import { SimulationHarness } from "../harness";
+import { BaseScenario, ProposalScenarioConfig, SimulationResult } from "./base";
+
+export type DefeatScenarioConfig = ProposalScenarioConfig;
+
+/** Votes fail quorum or majority: proposal should resolve to Defeated. */
+export class DefeatScenario extends BaseScenario {
+  constructor(
+    harness: SimulationHarness,
+    private config: DefeatScenarioConfig,
+  ) {
+    super(harness);
+  }
+
+  async run(): Promise<SimulationResult> {
+    const startLedger = this.harness.clock.sequence;
+    const { governorClient } = this.harness;
+
+    const proposalId = await governorClient.propose(
+      this.config.proposer.keypair,
+      this.config.description,
+      "0".repeat(64),
+      "ipfs://simulation",
+      this.config.targets,
+      this.config.fnNames,
+      this.config.calldatas,
+    );
+
+    const settings = await governorClient.getSettings();
+    await this.harness.advanceLedgers(settings.votingDelay + 1);
+
+    for (const { actor, support } of this.config.voters) {
+      await actor.vote(governorClient, proposalId, support);
+    }
+
+    await this.harness.advanceLedgers(settings.votingPeriod + 1);
+
+    const finalState = await governorClient.getProposalState(proposalId);
+    return {
+      success: finalState === ProposalState.Defeated,
+      proposalId,
+      finalState,
+      ledgersElapsed: this.harness.clock.sequence - startLedger,
+      errors: [],
+    };
+  }
+}

--- a/tools/simulation/src/scenarios/expiry.ts
+++ b/tools/simulation/src/scenarios/expiry.ts
@@ -1,0 +1,50 @@
+import { ProposalState } from "@nebgov/sdk";
+import { SimulationHarness } from "../harness";
+import { BaseScenario, ProposalScenarioConfig, SimulationResult } from "./base";
+
+export type ExpiryScenarioConfig = ProposalScenarioConfig;
+
+/** A proposal that succeeds but is never queued expires once its grace period elapses. */
+export class ExpiryScenario extends BaseScenario {
+  constructor(
+    harness: SimulationHarness,
+    private config: ExpiryScenarioConfig,
+  ) {
+    super(harness);
+  }
+
+  async run(): Promise<SimulationResult> {
+    const startLedger = this.harness.clock.sequence;
+    const { governorClient } = this.harness;
+
+    const proposalId = await governorClient.propose(
+      this.config.proposer.keypair,
+      this.config.description,
+      "0".repeat(64),
+      "ipfs://simulation",
+      this.config.targets,
+      this.config.fnNames,
+      this.config.calldatas,
+    );
+
+    const settings = await governorClient.getSettings();
+    await this.harness.advanceLedgers(settings.votingDelay + 1);
+
+    for (const { actor, support } of this.config.voters) {
+      await actor.vote(governorClient, proposalId, support);
+    }
+
+    // Advance past the voting period (Succeeded) and then past the grace
+    // period without ever calling queue().
+    await this.harness.advanceLedgers(settings.votingPeriod + settings.proposalGracePeriod + 2);
+
+    const finalState = await governorClient.getProposalState(proposalId);
+    return {
+      success: finalState === ProposalState.Expired,
+      proposalId,
+      finalState,
+      ledgersElapsed: this.harness.clock.sequence - startLedger,
+      errors: [],
+    };
+  }
+}

--- a/tools/simulation/src/scenarios/lifecycle.ts
+++ b/tools/simulation/src/scenarios/lifecycle.ts
@@ -1,0 +1,73 @@
+import { ProposalState } from "@nebgov/sdk";
+import { SimulationHarness } from "../harness";
+import { BaseScenario, ProposalScenarioConfig, SimulationResult } from "./base";
+
+export type LifecycleScenarioConfig = ProposalScenarioConfig;
+
+/** Drives a proposal through all six lifecycle states: propose -> vote -> queue -> execute. */
+export class FullLifecycleScenario extends BaseScenario {
+  constructor(
+    harness: SimulationHarness,
+    private config: LifecycleScenarioConfig,
+  ) {
+    super(harness);
+  }
+
+  async run(): Promise<SimulationResult> {
+    const startLedger = this.harness.clock.sequence;
+    const { governorClient, timelockClient } = this.harness;
+    const errors: string[] = [];
+
+    const proposalId = await governorClient.propose(
+      this.config.proposer.keypair,
+      this.config.description,
+      "0".repeat(64),
+      "ipfs://simulation",
+      this.config.targets,
+      this.config.fnNames,
+      this.config.calldatas,
+    );
+
+    const settings = await governorClient.getSettings();
+
+    // Phase 1: advance past the voting delay so the proposal becomes Active.
+    await this.harness.advanceLedgers(settings.votingDelay + 1);
+
+    // Phase 2: cast votes.
+    for (const { actor, support } of this.config.voters) {
+      await actor.vote(governorClient, proposalId, support);
+    }
+
+    // Phase 3: advance past the voting period so the proposal resolves.
+    await this.harness.advanceLedgers(settings.votingPeriod + 1);
+
+    // Phase 4: queue (transitions to Timelock).
+    try {
+      await governorClient.queue(this.config.proposer.keypair, proposalId);
+    } catch (e) {
+      errors.push(e instanceof Error ? e.message : String(e));
+      const finalState = await governorClient.getProposalState(proposalId);
+      return { success: false, proposalId, finalState, ledgersElapsed: this.harness.clock.sequence - startLedger, errors };
+    }
+
+    // Phase 5: advance past the timelock delay.
+    const delaySeconds = await timelockClient.minDelay();
+    await this.harness.advanceLedgers(this.harness.clock.secondsToLedgers(Number(delaySeconds)) + 1);
+
+    // Phase 6: execute.
+    try {
+      await governorClient.execute(this.config.proposer.keypair, proposalId);
+    } catch (e) {
+      errors.push(e instanceof Error ? e.message : String(e));
+    }
+
+    const finalState = await governorClient.getProposalState(proposalId);
+    return {
+      success: finalState === ProposalState.Executed,
+      proposalId,
+      finalState,
+      ledgersElapsed: this.harness.clock.sequence - startLedger,
+      errors,
+    };
+  }
+}

--- a/tools/simulation/src/scenarios/rate-limit.ts
+++ b/tools/simulation/src/scenarios/rate-limit.ts
@@ -1,0 +1,60 @@
+import { Actor } from "../actors";
+import { SimulationHarness } from "../harness";
+import { BaseScenario, SimulationResult } from "./base";
+
+export interface RateLimitScenarioConfig {
+  proposer: Actor;
+  description: string;
+  targets: string[];
+  fnNames: string[];
+  calldatas: Buffer[];
+}
+
+/** A second proposal from the same proposer within the rate-limit period is rejected. */
+export class RateLimitScenario extends BaseScenario {
+  constructor(
+    harness: SimulationHarness,
+    private config: RateLimitScenarioConfig,
+  ) {
+    super(harness);
+  }
+
+  async run(): Promise<SimulationResult> {
+    const startLedger = this.harness.clock.sequence;
+    const { governorClient } = this.harness;
+    const errors: string[] = [];
+
+    const firstId = await governorClient.propose(
+      this.config.proposer.keypair,
+      `${this.config.description} #1`,
+      "0".repeat(64),
+      "ipfs://simulation",
+      this.config.targets,
+      this.config.fnNames,
+      this.config.calldatas,
+    );
+
+    let rejected = false;
+    try {
+      await governorClient.propose(
+        this.config.proposer.keypair,
+        `${this.config.description} #2`,
+        "0".repeat(64),
+        "ipfs://simulation",
+        this.config.targets,
+        this.config.fnNames,
+        this.config.calldatas,
+      );
+    } catch (e) {
+      rejected = true;
+      errors.push(e instanceof Error ? e.message : String(e));
+    }
+
+    return {
+      success: rejected,
+      proposalId: firstId,
+      ledgersElapsed: this.harness.clock.sequence - startLedger,
+      errors,
+    };
+  }
+}

--- a/tools/simulation/src/scenarios/veto.ts
+++ b/tools/simulation/src/scenarios/veto.ts
@@ -1,0 +1,67 @@
+import { ProposalState } from "@nebgov/sdk";
+import { Actor } from "../actors";
+import { SimulationHarness } from "../harness";
+import { BaseScenario, ProposalScenarioConfig, SimulationResult } from "./base";
+
+export interface GuardianVetoScenarioConfig extends ProposalScenarioConfig {
+  guardian: Actor;
+  /** Ledgers to advance after queuing before the guardian attempts the veto. Defaults to 0 (immediately). */
+  advanceBeforeVeto?: number;
+}
+
+/** Guardian cancels a queued proposal, inside or outside its veto window. */
+export class GuardianVetoScenario extends BaseScenario {
+  constructor(
+    harness: SimulationHarness,
+    private config: GuardianVetoScenarioConfig,
+  ) {
+    super(harness);
+  }
+
+  async run(): Promise<SimulationResult> {
+    const startLedger = this.harness.clock.sequence;
+    const { governorClient } = this.harness;
+    const errors: string[] = [];
+
+    const proposalId = await governorClient.propose(
+      this.config.proposer.keypair,
+      this.config.description,
+      "0".repeat(64),
+      "ipfs://simulation",
+      this.config.targets,
+      this.config.fnNames,
+      this.config.calldatas,
+    );
+
+    const settings = await governorClient.getSettings();
+    await this.harness.advanceLedgers(settings.votingDelay + 1);
+
+    for (const { actor, support } of this.config.voters) {
+      await actor.vote(governorClient, proposalId, support);
+    }
+
+    await this.harness.advanceLedgers(settings.votingPeriod + 1);
+    await governorClient.queue(this.config.proposer.keypair, proposalId);
+
+    if (this.config.advanceBeforeVeto) {
+      await this.harness.advanceLedgers(this.config.advanceBeforeVeto);
+    }
+
+    let vetoed = false;
+    try {
+      await this.harness.cancelQueuedProposal(this.config.guardian.keypair, proposalId);
+      vetoed = true;
+    } catch (e) {
+      errors.push(e instanceof Error ? e.message : String(e));
+    }
+
+    const finalState = await governorClient.getProposalState(proposalId);
+    return {
+      success: vetoed && finalState === ProposalState.Cancelled,
+      proposalId,
+      finalState,
+      ledgersElapsed: this.harness.clock.sequence - startLedger,
+      errors,
+    };
+  }
+}

--- a/tools/simulation/src/state.ts
+++ b/tools/simulation/src/state.ts
@@ -1,0 +1,26 @@
+import { GovernorClient, ProposalState, ProposalVotes, TimelockClient, VotesClient } from "@nebgov/sdk";
+
+/** Thin read-only wrapper around the three governance clients, for scenarios/assertions. */
+export class StateInspector {
+  constructor(
+    private readonly governor: GovernorClient,
+    private readonly timelock: TimelockClient,
+    private readonly votes: VotesClient,
+  ) {}
+
+  proposalState(proposalId: bigint): Promise<ProposalState> {
+    return this.governor.getProposalState(proposalId);
+  }
+
+  proposalVotes(proposalId: bigint): Promise<ProposalVotes> {
+    return this.governor.getProposalVotes(proposalId);
+  }
+
+  delegatedVotes(account: string): Promise<bigint> {
+    return this.votes.getVotes(account);
+  }
+
+  isOperationReady(opId: string): Promise<boolean> {
+    return this.timelock.isReady(opId);
+  }
+}

--- a/tools/simulation/tests/defeat.sim.ts
+++ b/tools/simulation/tests/defeat.sim.ts
@@ -1,0 +1,68 @@
+import { ProposalState, VoteSupport } from "@nebgov/sdk";
+import { assertVoteCounts, DefeatScenario, DeployedContracts, SimulationHarness } from "../src";
+import { buildTestSetup, PLACEHOLDER_CALLDATA } from "./helpers";
+
+describe("Proposal defeat (mock runtime)", () => {
+  let harness: SimulationHarness;
+  let addresses: DeployedContracts;
+  let setup: ReturnType<typeof buildTestSetup>;
+
+  beforeAll(async () => {
+    setup = buildTestSetup({ proposers: 1, voters: 5 });
+    harness = new SimulationHarness(setup.config);
+    harness.registerActors(setup.actors);
+    addresses = await harness.boot();
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  // Each test proposes from the same proposer; clear the proposer cooldown
+  // (100 ledgers by default) between tests so they don't interfere.
+  beforeEach(async () => {
+    await harness.advanceLedgers(200);
+  });
+
+  it("resolves to Defeated when quorum is not reached", async () => {
+    // quorumNumerator=40% of a 6,000,000 total supply requires 2,400,000
+    // participating votes; only one voter (1,000,000) participates.
+    const result = await harness.run(DefeatScenario, {
+      proposer: setup.actors.proposers[0],
+      voters: [{ actor: setup.actors.voters[0], support: VoteSupport.For }],
+      description: "Underfunded quorum attempt",
+      targets: [addresses.governor],
+      fnNames: ["noop"],
+      calldatas: [PLACEHOLDER_CALLDATA],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.finalState).toBe(ProposalState.Defeated);
+  });
+
+  it("resolves to Defeated when against votes meet or exceed for votes, even with quorum reached", async () => {
+    // Abstain counts toward quorum but not toward the for/against comparison,
+    // so quorum (2,400,000) is met via abstains while for (0) <= against (1,000,000).
+    const result = await harness.run(DefeatScenario, {
+      proposer: setup.actors.proposers[0],
+      voters: [
+        { actor: setup.actors.voters[0], support: VoteSupport.Abstain },
+        { actor: setup.actors.voters[1], support: VoteSupport.Abstain },
+        { actor: setup.actors.voters[2], support: VoteSupport.Abstain },
+        { actor: setup.actors.voters[3], support: VoteSupport.Against },
+      ],
+      description: "Outvoted proposal",
+      targets: [addresses.governor],
+      fnNames: ["noop"],
+      calldatas: [PLACEHOLDER_CALLDATA],
+    });
+
+    await assertVoteCounts(harness.governorClient, result.proposalId!, {
+      votesFor: 0n,
+      votesAgainst: 1_000_000n,
+      votesAbstain: 3_000_000n,
+    });
+    expect(result.success).toBe(true);
+    expect(result.finalState).toBe(ProposalState.Defeated);
+  });
+});

--- a/tools/simulation/tests/expiry.sim.ts
+++ b/tools/simulation/tests/expiry.sim.ts
@@ -1,0 +1,41 @@
+import { ProposalState, VoteSupport } from "@nebgov/sdk";
+import { DeployedContracts, ExpiryScenario, SimulationHarness } from "../src";
+import { buildTestSetup, PLACEHOLDER_CALLDATA } from "./helpers";
+
+describe("Proposal expiry (mock runtime)", () => {
+  let harness: SimulationHarness;
+  let addresses: DeployedContracts;
+  let setup: ReturnType<typeof buildTestSetup>;
+
+  beforeAll(async () => {
+    setup = buildTestSetup({ proposers: 1, voters: 5, settings: { proposalGracePeriod: 50 } });
+    harness = new SimulationHarness(setup.config);
+    harness.registerActors(setup.actors);
+    addresses = await harness.boot();
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  it("expires a Succeeded proposal that was never queued once its grace period elapses", async () => {
+    const result = await harness.run(ExpiryScenario, {
+      proposer: setup.actors.proposers[0],
+      voters: [
+        { actor: setup.actors.voters[0], support: VoteSupport.For },
+        { actor: setup.actors.voters[1], support: VoteSupport.For },
+        { actor: setup.actors.voters[2], support: VoteSupport.For },
+      ],
+      description: "Never queued in time",
+      targets: [addresses.governor],
+      fnNames: ["noop"],
+      calldatas: [PLACEHOLDER_CALLDATA],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.finalState).toBe(ProposalState.Expired);
+
+    // queue() should now reject: the proposal is past its grace period.
+    await expect(harness.governorClient.queue(setup.actors.proposers[0].keypair, result.proposalId!)).rejects.toThrow();
+  });
+});

--- a/tools/simulation/tests/helpers.ts
+++ b/tools/simulation/tests/helpers.ts
@@ -1,0 +1,55 @@
+import { VoteType } from "@nebgov/sdk";
+import { ActorSet, createActors, SimulationConfig } from "../src";
+
+export const PLACEHOLDER_CALLDATA = Buffer.from([]);
+
+export interface TestSetup {
+  actors: ActorSet;
+  config: SimulationConfig;
+}
+
+/**
+ * A default deterministic scenario config: every actor is funded and
+ * self-delegated, so `voter-N`'s balance is directly its voting power.
+ */
+export function buildTestSetup(
+  overrides: {
+    proposers?: number;
+    voters?: number;
+    hasGuardian?: boolean;
+    balances?: Record<string, bigint>;
+    settings?: Partial<SimulationConfig["settings"]>;
+  } = {},
+): TestSetup {
+  const actors = createActors({
+    proposers: overrides.proposers ?? 1,
+    voters: overrides.voters ?? 5,
+    hasGuardian: overrides.hasGuardian ?? false,
+  });
+
+  const tokenBalances: Record<string, bigint> = {};
+  const delegations: Record<string, string> = {};
+  for (const actor of actors.all.values()) {
+    tokenBalances[actor.publicKey] = overrides.balances?.[actor.name] ?? 1_000_000n;
+    delegations[actor.publicKey] = actor.publicKey;
+  }
+
+  const config: SimulationConfig = {
+    mode: "mock",
+    settings: {
+      votingDelay: 10,
+      votingPeriod: 100,
+      quorumNumerator: 40,
+      proposalThreshold: 1n,
+      timelockDelay: 3_600n,
+      voteType: VoteType.Extended,
+      guardian: actors.guardian?.publicKey,
+      ...overrides.settings,
+    },
+    tokenBalances,
+    delegations,
+    initialLedger: 1000,
+  };
+
+  return { actors, config };
+}

--- a/tools/simulation/tests/jest.setup.ts
+++ b/tools/simulation/tests/jest.setup.ts
@@ -1,0 +1,20 @@
+/**
+ * Runs before every `*.sim.ts` test file (see `jest.config.js`
+ * `setupFiles`). Replaces `SorobanRpc.Server` with one that always
+ * constructs to whichever `MockSorobanServer` the currently-booted
+ * `SimulationHarness` registered — the same `jest.mock("@stellar/stellar-sdk")`
+ * seam `sdk/src/__tests__/governor.test.ts` uses, kept in one place so
+ * individual scenario suites don't repeat it.
+ */
+import { getActiveMockServer } from "../src/mock/registry";
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const actual = jest.requireActual("@stellar/stellar-sdk");
+  return {
+    ...actual,
+    SorobanRpc: {
+      ...actual.SorobanRpc,
+      Server: jest.fn().mockImplementation(() => getActiveMockServer()),
+    },
+  };
+});

--- a/tools/simulation/tests/lifecycle.sim.ts
+++ b/tools/simulation/tests/lifecycle.sim.ts
@@ -1,0 +1,120 @@
+import { ProposalState, VoteSupport } from "@nebgov/sdk";
+import { assertProposalState, assertVoteCounts, DeployedContracts, FullLifecycleScenario, SimulationHarness } from "../src";
+import { buildTestSetup, PLACEHOLDER_CALLDATA } from "./helpers";
+
+describe("Full governance lifecycle (mock runtime)", () => {
+  let harness: SimulationHarness;
+  let addresses: DeployedContracts;
+  let setup: ReturnType<typeof buildTestSetup>;
+
+  beforeAll(async () => {
+    setup = buildTestSetup({ proposers: 1, voters: 5 });
+    harness = new SimulationHarness(setup.config);
+    harness.registerActors(setup.actors);
+    addresses = await harness.boot();
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  // Each test proposes from the same proposer; clear the proposer cooldown
+  // (100 ledgers by default) between tests so they don't interfere.
+  beforeEach(async () => {
+    await harness.advanceLedgers(200);
+  });
+
+  it("advances through all six lifecycle phases to Executed state", async () => {
+    const result = await harness.run(FullLifecycleScenario, {
+      proposer: setup.actors.proposers[0],
+      voters: [
+        { actor: setup.actors.voters[0], support: VoteSupport.For },
+        { actor: setup.actors.voters[1], support: VoteSupport.For },
+        { actor: setup.actors.voters[2], support: VoteSupport.For },
+        { actor: setup.actors.voters[3], support: VoteSupport.Against },
+        { actor: setup.actors.voters[4], support: VoteSupport.Abstain },
+      ],
+      description: "Upgrade fee parameter to 50bps",
+      targets: [addresses.governor],
+      fnNames: ["noop"],
+      calldatas: [PLACEHOLDER_CALLDATA],
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.success).toBe(true);
+    expect(result.finalState).toBe(ProposalState.Executed);
+    await assertProposalState(harness.governorClient, result.proposalId!, ProposalState.Executed);
+  });
+
+  it("is Queued once queue() succeeds, before the timelock delay elapses", async () => {
+    const proposalId = await harness.governorClient.propose(
+      setup.actors.proposers[0].keypair,
+      "Queued-only check",
+      "0".repeat(64),
+      "ipfs://simulation",
+      [addresses.governor],
+      ["noop"],
+      [PLACEHOLDER_CALLDATA],
+    );
+
+    const settings = await harness.governorClient.getSettings();
+    await harness.advanceLedgers(settings.votingDelay + 1);
+    // quorumNumerator=40% of the 6,000,000 total supply requires 2,400,000
+    // participating votes: three voters clear it comfortably.
+    await setup.actors.voters[0].vote(harness.governorClient, proposalId, VoteSupport.For);
+    await setup.actors.voters[1].vote(harness.governorClient, proposalId, VoteSupport.For);
+    await setup.actors.voters[2].vote(harness.governorClient, proposalId, VoteSupport.For);
+    await harness.advanceLedgers(settings.votingPeriod + 1);
+
+    await harness.governorClient.queue(setup.actors.proposers[0].keypair, proposalId);
+    await assertProposalState(harness.governorClient, proposalId, ProposalState.Queued);
+  });
+
+  it("accumulates vote weights proportional to each voter's delegated balance", async () => {
+    const proposalId = await harness.governorClient.propose(
+      setup.actors.proposers[0].keypair,
+      "Vote weight check",
+      "0".repeat(64),
+      "ipfs://simulation",
+      [addresses.governor],
+      ["noop"],
+      [PLACEHOLDER_CALLDATA],
+    );
+
+    const settings = await harness.governorClient.getSettings();
+    await harness.advanceLedgers(settings.votingDelay + 1);
+    await setup.actors.voters[0].vote(harness.governorClient, proposalId, VoteSupport.For);
+    await setup.actors.voters[1].vote(harness.governorClient, proposalId, VoteSupport.Against);
+
+    await assertVoteCounts(harness.governorClient, proposalId, {
+      votesFor: 1_000_000n,
+      votesAgainst: 1_000_000n,
+      votesAbstain: 0n,
+    });
+  });
+
+  it("re-runs deterministically from a snapshot", async () => {
+    const snap = await harness.snapshot();
+
+    const scenarioConfig = {
+      proposer: setup.actors.proposers[0],
+      voters: [
+        { actor: setup.actors.voters[0], support: VoteSupport.For },
+        { actor: setup.actors.voters[1], support: VoteSupport.For },
+        { actor: setup.actors.voters[2], support: VoteSupport.For },
+      ],
+      description: "Deterministic replay check",
+      targets: [addresses.governor],
+      fnNames: ["noop"],
+      calldatas: [PLACEHOLDER_CALLDATA],
+    };
+
+    const result1 = await harness.run(FullLifecycleScenario, scenarioConfig);
+    await harness.restore(snap);
+    const result2 = await harness.run(FullLifecycleScenario, scenarioConfig);
+
+    expect(result1.finalState).toBe(result2.finalState);
+    expect(result1.proposalId).toBe(result2.proposalId);
+    expect(result1.ledgersElapsed).toBe(result2.ledgersElapsed);
+  });
+});

--- a/tools/simulation/tests/rate-limit.sim.ts
+++ b/tools/simulation/tests/rate-limit.sim.ts
@@ -1,0 +1,49 @@
+import { DeployedContracts, RateLimitScenario, SimulationHarness } from "../src";
+import { buildTestSetup, PLACEHOLDER_CALLDATA } from "./helpers";
+
+describe("Proposer rate limiting (mock runtime)", () => {
+  let harness: SimulationHarness;
+  let addresses: DeployedContracts;
+  let setup: ReturnType<typeof buildTestSetup>;
+
+  beforeAll(async () => {
+    setup = buildTestSetup({ proposers: 1, voters: 5, settings: { proposalCooldown: 100 } });
+    harness = new SimulationHarness(setup.config);
+    harness.registerActors(setup.actors);
+    addresses = await harness.boot();
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  it("rejects a second proposal from the same proposer within the cooldown period", async () => {
+    const result = await harness.run(RateLimitScenario, {
+      proposer: setup.actors.proposers[0],
+      description: "Cooldown probe",
+      targets: [addresses.governor],
+      fnNames: ["noop"],
+      calldatas: [PLACEHOLDER_CALLDATA],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.proposalId).toBeDefined();
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it("allows a new proposal from the same proposer once the cooldown has elapsed", async () => {
+    await harness.advanceLedgers(101);
+
+    const proposalId = await harness.governorClient.propose(
+      setup.actors.proposers[0].keypair,
+      "Post-cooldown proposal",
+      "0".repeat(64),
+      "ipfs://simulation",
+      [addresses.governor],
+      ["noop"],
+      [PLACEHOLDER_CALLDATA],
+    );
+
+    expect(proposalId).toBeGreaterThan(0n);
+  });
+});

--- a/tools/simulation/tests/veto.sim.ts
+++ b/tools/simulation/tests/veto.sim.ts
@@ -1,0 +1,71 @@
+import { ProposalState, VoteSupport } from "@nebgov/sdk";
+import { DeployedContracts, GuardianVetoScenario, SimulationHarness } from "../src";
+import { buildTestSetup, PLACEHOLDER_CALLDATA } from "./helpers";
+
+describe("Guardian veto of a queued proposal (mock runtime)", () => {
+  let harness: SimulationHarness;
+  let addresses: DeployedContracts;
+  let setup: ReturnType<typeof buildTestSetup>;
+
+  beforeAll(async () => {
+    setup = buildTestSetup({ proposers: 1, voters: 5, hasGuardian: true });
+    harness = new SimulationHarness(setup.config);
+    harness.registerActors(setup.actors);
+    addresses = await harness.boot();
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  // Each test proposes from the same proposer; clear the proposer cooldown
+  // (100 ledgers by default) between tests so they don't interfere.
+  beforeEach(async () => {
+    await harness.advanceLedgers(200);
+  });
+
+  it("cancels a queued proposal when the guardian vetoes inside the veto window", async () => {
+    const result = await harness.run(GuardianVetoScenario, {
+      proposer: setup.actors.proposers[0],
+      voters: [
+        { actor: setup.actors.voters[0], support: VoteSupport.For },
+        { actor: setup.actors.voters[1], support: VoteSupport.For },
+        { actor: setup.actors.voters[2], support: VoteSupport.For },
+      ],
+      guardian: setup.actors.guardian!,
+      description: "Vetoed while still in the window",
+      targets: [addresses.governor],
+      fnNames: ["noop"],
+      calldatas: [PLACEHOLDER_CALLDATA],
+      // Immediate veto attempt, well inside the window (timelockDelay=3600s -> 720 ledgers).
+      advanceBeforeVeto: 1,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.success).toBe(true);
+    expect(result.finalState).toBe(ProposalState.Cancelled);
+  });
+
+  it("rejects the veto once the veto window has closed", async () => {
+    const result = await harness.run(GuardianVetoScenario, {
+      proposer: setup.actors.proposers[0],
+      voters: [
+        { actor: setup.actors.voters[0], support: VoteSupport.For },
+        { actor: setup.actors.voters[1], support: VoteSupport.For },
+        { actor: setup.actors.voters[2], support: VoteSupport.For },
+      ],
+      guardian: setup.actors.guardian!,
+      description: "Veto attempted too late",
+      targets: [addresses.governor],
+      fnNames: ["noop"],
+      calldatas: [PLACEHOLDER_CALLDATA],
+      // timelockDelay=3600s / SECONDS_PER_LEDGER(5) = 720 ledgers; advance past that.
+      advanceBeforeVeto: 900,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toContain("Error(Contract, #19)");
+    expect(result.finalState).toBe(ProposalState.Queued);
+  });
+});

--- a/tools/simulation/tsconfig.json
+++ b/tools/simulation/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}


### PR DESCRIPTION
Adds a new @nebgov/simulation TypeScript package (tools/simulation/) that drives the full propose -> vote -> queue -> execute governance lifecycle against a deterministic, in-memory mock Soroban RPC runtime, giving contributors offline integration coverage without deploying anything or touching testnet.

- LedgerClock for deterministic ledger/timestamp advancement, and deterministic Actor/createActors keypair generation for reproducible runs.
- A MockSorobanServer that decodes real Soroban invokeHostFunction operations built by @nebgov/sdk's GovernorClient/TimelockClient/VotesClient and dispatches them to in-memory executors replicating the governor ProposalState machine, timelock scheduling/execution, and token-votes checkpointed delegation from contracts/governor, contracts/timelock, and contracts/token-votes.
- SimulationHarness with boot()/advanceLedgers()/run()/snapshot()/restore()/ teardown(), wired into the SDK clients via the same jest.mock seam sdk/src/__tests__/governor.test.ts already uses.
- Five scenarios (FullLifecycleScenario, DefeatScenario, GuardianVetoScenario, ExpiryScenario, RateLimitScenario) plus proposal/timelock/balance assertion helpers, each covered by a *.sim.ts Jest suite (11 tests total, ~110s, no network calls).
- CI: a path-filtered "Simulation Tests" job in .github/workflows/sdk.yml that runs on contracts/**, sdk/**, or tools/simulation/** changes.

Closes #782