### PR TITLE
feat(indexer+backend+frontend): real-time governance notification and alert system

### DIFF
--- a/app/src/app/notifications/page.tsx
+++ b/app/src/app/notifications/page.tsx
@@ -98,7 +98,12 @@ export default function NotificationsPage() {
       <h1 className="text-3xl font-bold text-gray-900">Notifications</h1>
       <p className="text-gray-500 mt-1 mb-6">
         Browser alerts for governance lifecycle events. Everything stays in
-        your browser—no server.
+        your browser—no server. Want email, webhook, or Telegram alerts
+        instead?{" "}
+        <Link href="/notifications/rules" className="text-indigo-600 hover:text-indigo-800">
+          Set up notification rules
+        </Link>
+        .
       </p>
 
       <div className="rounded-xl border border-gray-200 bg-white p-4 mb-8">

--- a/app/src/app/notifications/rules/page.tsx
+++ b/app/src/app/notifications/rules/page.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import toast from "react-hot-toast";
+import { useNotifications, type NotificationRule } from "../../../hooks/useNotifications";
+import { NotificationRuleBuilder } from "../../../components/NotificationRuleBuilder";
+import { useWallet } from "../../../lib/wallet-context";
+
+function channelSummary(rule: NotificationRule): string {
+  return rule.channels.map((c) => c.type).join(", ");
+}
+
+export default function NotificationRulesPage() {
+  const { isConnected } = useWallet();
+  const { rules, loading, updateRule, deleteRule, testRule } = useNotifications();
+  const [showBuilder, setShowBuilder] = useState(false);
+  const [busyId, setBusyId] = useState<number | null>(null);
+
+  async function handleToggle(rule: NotificationRule) {
+    setBusyId(rule.id);
+    try {
+      await updateRule(rule.id, { enabled: !rule.enabled });
+    } catch {
+      toast.error("Failed to update rule");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleDelete(rule: NotificationRule) {
+    setBusyId(rule.id);
+    try {
+      await deleteRule(rule.id);
+    } catch {
+      toast.error("Failed to delete rule");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleTest(rule: NotificationRule) {
+    setBusyId(rule.id);
+    try {
+      await testRule(rule.id);
+      toast.success("Test notification sent");
+    } catch {
+      toast.error("Failed to send test notification");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8">
+      <div className="flex items-center justify-between mb-1">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Notification rules</h1>
+        {isConnected && (
+          <button
+            onClick={() => setShowBuilder(true)}
+            className="px-4 py-2 rounded-full bg-indigo-600 text-white text-sm font-semibold hover:bg-indigo-700 transition-colors"
+          >
+            Add rule
+          </button>
+        )}
+      </div>
+      <p className="text-gray-500 mt-1 mb-6">
+        Get notified in-app, by email, webhook, or Telegram when specific governance events happen.{" "}
+        <Link href="/notifications" className="text-indigo-600 hover:text-indigo-800">
+          View activity &amp; browser alerts
+        </Link>
+      </p>
+
+      {!isConnected ? (
+        <p className="text-sm text-gray-500 rounded-xl border border-dashed border-gray-200 dark:border-gray-800 bg-gray-50/80 dark:bg-gray-900/50 p-6">
+          Connect your wallet to create notification rules.
+        </p>
+      ) : loading && rules.length === 0 ? (
+        <p className="text-sm text-gray-500">Loading rules…</p>
+      ) : rules.length === 0 ? (
+        <p className="text-sm text-gray-500 rounded-xl border border-dashed border-gray-200 dark:border-gray-800 bg-gray-50/80 dark:bg-gray-900/50 p-6">
+          No rules yet. Add one to get notified about proposals, votes, and delegation changes.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {rules.map((rule) => (
+            <li
+              key={rule.id}
+              className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="font-medium text-gray-900 dark:text-white">{rule.name}</p>
+                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+                    {rule.trigger_type.replace(/_/g, " ")} · {channelSummary(rule)}
+                  </p>
+                  <p className="text-xs text-gray-400 mt-1">
+                    Triggered {rule.trigger_count} time{rule.trigger_count === 1 ? "" : "s"}
+                    {rule.last_triggered_at ? ` · last ${new Date(rule.last_triggered_at).toLocaleString()}` : ""}
+                  </p>
+                </div>
+                <label className="flex items-center gap-2 shrink-0">
+                  <input
+                    type="checkbox"
+                    checked={rule.enabled}
+                    disabled={busyId === rule.id}
+                    onChange={() => void handleToggle(rule)}
+                    className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                  />
+                  <span className="text-xs text-gray-500">Enabled</span>
+                </label>
+              </div>
+              <div className="flex items-center gap-3 mt-3">
+                <button
+                  onClick={() => void handleTest(rule)}
+                  disabled={busyId === rule.id}
+                  className="text-xs font-medium text-indigo-600 hover:text-indigo-800 disabled:opacity-50"
+                >
+                  Test
+                </button>
+                <button
+                  onClick={() => void handleDelete(rule)}
+                  disabled={busyId === rule.id}
+                  className="text-xs font-medium text-rose-600 hover:text-rose-800 disabled:opacity-50"
+                >
+                  Delete
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {showBuilder && <NotificationRuleBuilder onClose={() => setShowBuilder(false)} />}
+    </div>
+  );
+}

--- a/app/src/components/NavBar.tsx
+++ b/app/src/components/NavBar.tsx
@@ -25,6 +25,7 @@ import { useTranslations } from "next-intl";
 import toast from "react-hot-toast";
 import { loadNotificationHistory } from "../lib/governance-notifications";
 import { useGovernanceBalance } from "../lib/use-governance-balance";
+import { NotificationBell } from "./NotificationBell";
 
 function formatGovernanceAmount(v: bigint): string {
   const n = Number(v);
@@ -173,6 +174,7 @@ export function NavBar() {
         </div>
 
         <div className="flex items-center gap-4">
+          <NotificationBell />
           <button
             onClick={toggleTheme}
             aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} theme`}

--- a/app/src/components/NotificationBell.tsx
+++ b/app/src/components/NotificationBell.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useRef, useState } from "react";
+import Link from "next/link";
+import { Bell } from "lucide-react";
+import { useNotifications } from "../hooks/useNotifications";
+import { useWallet } from "../lib/wallet-context";
+
+function timeAgo(iso: string): string {
+  const seconds = Math.max(0, Math.floor((Date.now() - new Date(iso).getTime()) / 1000));
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+export function NotificationBell() {
+  const { isConnected } = useWallet();
+  const { unreadCount, notifications, markRead } = useNotifications();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  if (!isConnected) return null;
+
+  const unread = notifications.filter((n) => !n.read).slice(0, 5);
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-label={unreadCount > 0 ? `${unreadCount} unread notifications` : "Notifications"}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        className="relative p-2 rounded-xl text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+      >
+        <Bell className="w-5 h-5" aria-hidden />
+        {unreadCount > 0 && (
+          <span className="absolute -top-0.5 -right-0.5 min-w-4 h-4 px-1 rounded-full bg-indigo-600 text-white text-[10px] leading-4 text-center">
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <>
+          <div
+            className="fixed inset-0 z-[199]"
+            onClick={() => setOpen(false)}
+            aria-hidden
+          />
+          <div
+            role="menu"
+            className="absolute right-0 mt-2 w-80 bg-white dark:bg-gray-900 rounded-2xl shadow-xl border border-gray-100 dark:border-gray-800 py-2 z-[200] overflow-hidden"
+          >
+            <div className="px-4 py-2 border-b border-gray-50 dark:border-gray-800">
+              <p className="text-xs text-gray-400 font-medium uppercase tracking-wider">
+                Notifications
+              </p>
+            </div>
+
+            {unread.length === 0 ? (
+              <p className="px-4 py-6 text-sm text-gray-500 dark:text-gray-400 text-center">
+                You&apos;re all caught up.
+              </p>
+            ) : (
+              <ul>
+                {unread.map((n) => (
+                  <li key={n.id}>
+                    <button
+                      onClick={() => void markRead(n.id)}
+                      className="w-full text-left px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                    >
+                      <p className="text-sm font-medium text-gray-900 dark:text-white">{n.title}</p>
+                      <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5 line-clamp-2">
+                        {n.body}
+                      </p>
+                      <span className="text-xs text-gray-400 mt-1 block">{timeAgo(n.created_at)}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <div className="border-t border-gray-50 dark:border-gray-800 mt-1 pt-1">
+              <Link
+                href="/notifications"
+                onClick={() => setOpen(false)}
+                className="block px-4 py-2 text-sm font-medium text-indigo-600 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+              >
+                View all
+              </Link>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/NotificationRuleBuilder.tsx
+++ b/app/src/components/NotificationRuleBuilder.tsx
@@ -1,0 +1,380 @@
+"use client";
+
+import { useState } from "react";
+import { X } from "lucide-react";
+import {
+  useNotifications,
+  type CreateRuleParams,
+  type NotificationChannel,
+  type TriggerConfig,
+  type TriggerType,
+} from "../hooks/useNotifications";
+
+const TRIGGER_OPTIONS: { value: TriggerType; label: string; description: string }[] = [
+  { value: "proposal_created", label: "Proposal created", description: "A new proposal is created (optionally by a specific proposer)." },
+  { value: "proposal_state_changed", label: "Proposal state changed", description: "A proposal is queued, executed, or cancelled." },
+  { value: "vote_cast", label: "Vote cast", description: "A vote is cast, optionally on a specific proposal or by a specific voter." },
+  { value: "proposal_ending_soon", label: "Voting ending soon", description: "An active proposal is within N ledgers of its end." },
+  { value: "delegation_received", label: "Delegation received", description: "Someone delegates their voting power to an address." },
+  { value: "delegation_lost", label: "Delegation revoked", description: "A delegation is revoked from an address." },
+  { value: "config_updated", label: "Governor config updated", description: "The governor's configuration parameters change." },
+  { value: "contract_upgraded", label: "Governor upgraded", description: "The governor contract is upgraded." },
+  { value: "guardian_veto", label: "Guardian veto", description: "A guardian vetoes a proposal. (Not yet emitted on-chain.)" },
+  { value: "treasury_stream_spend", label: "Treasury stream spend", description: "A spend is made from a treasury stream. (Not yet emitted on-chain.)" },
+  { value: "contract_paused", label: "Contract paused", description: "A governance contract is paused. (Not yet emitted on-chain.)" },
+  { value: "proposal_vote_threshold", label: "Vote threshold reached", description: "A proposal reaches a % of quorum. (Not yet computable — see docs.)" },
+  { value: "quorum_reached", label: "Quorum reached", description: "A proposal reaches quorum. (Not yet computable — see docs.)" },
+];
+
+const STEPS = ["Trigger", "Configure", "Channels", "Review"] as const;
+
+interface Props {
+  onClose: () => void;
+  onCreated?: () => void;
+}
+
+export function NotificationRuleBuilder({ onClose, onCreated }: Props) {
+  const { createRule } = useNotifications();
+  const [step, setStep] = useState(0);
+  const [name, setName] = useState("");
+  const [triggerType, setTriggerType] = useState<TriggerType>("proposal_created");
+  const [config, setConfig] = useState<TriggerConfig>({});
+  const [channels, setChannels] = useState<NotificationChannel[]>([{ type: "in_app" }]);
+  const [cooldownSeconds, setCooldownSeconds] = useState(300);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function toggleChannel(type: NotificationChannel["type"], enabled: boolean) {
+    setChannels((prev) => {
+      if (enabled) {
+        if (prev.some((c) => c.type === type)) return prev;
+        const next: NotificationChannel =
+          type === "email"
+            ? { type: "email", address: "" }
+            : type === "webhook"
+              ? { type: "webhook", url: "" }
+              : type === "telegram"
+                ? { type: "telegram", chat_id: "" }
+                : { type: "in_app" };
+        return [...prev, next];
+      }
+      return prev.filter((c) => c.type !== type);
+    });
+  }
+
+  function updateChannelField(type: NotificationChannel["type"], field: string, value: string) {
+    setChannels((prev) =>
+      prev.map((c) => (c.type === type ? ({ ...c, [field]: value } as NotificationChannel) : c)),
+    );
+  }
+
+  async function handleSubmit() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const params: CreateRuleParams = {
+        name: name.trim() || TRIGGER_OPTIONS.find((t) => t.value === triggerType)?.label || "Untitled rule",
+        trigger_type: triggerType,
+        trigger_config: config,
+        channels,
+        cooldown_seconds: cooldownSeconds,
+        enabled: true,
+      };
+      await createRule(params);
+      onCreated?.();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create rule");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const canProceedFromChannels = channels.every((c) => {
+    if (c.type === "email") return c.address.trim().length > 0;
+    if (c.type === "webhook") return c.url.trim().length > 0;
+    if (c.type === "telegram") return c.chat_id.trim().length > 0;
+    return true;
+  }) && channels.length > 0;
+
+  return (
+    <div className="fixed inset-0 z-[300] flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-gray-900/40 backdrop-blur-sm" onClick={onClose} aria-hidden />
+      <div className="relative w-full max-w-lg bg-white dark:bg-gray-900 rounded-2xl shadow-2xl border border-gray-100 dark:border-gray-800 overflow-hidden">
+        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-gray-800">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">New notification rule</h2>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
+          >
+            <X className="w-5 h-5" aria-hidden />
+          </button>
+        </div>
+
+        <div className="px-5 pt-4 flex items-center gap-2">
+          {STEPS.map((label, i) => (
+            <div key={label} className="flex-1">
+              <div className={`h-1 rounded-full ${i <= step ? "bg-indigo-600" : "bg-gray-200 dark:bg-gray-700"}`} />
+              <p className={`text-[11px] mt-1 ${i === step ? "text-indigo-600 font-medium" : "text-gray-400"}`}>
+                {label}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <div className="px-5 py-5 max-h-[60vh] overflow-y-auto">
+          {step === 0 && (
+            <div className="space-y-2">
+              {TRIGGER_OPTIONS.map((opt) => (
+                <label
+                  key={opt.value}
+                  className={`block p-3 rounded-xl border cursor-pointer transition-colors ${
+                    triggerType === opt.value
+                      ? "border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20"
+                      : "border-gray-200 dark:border-gray-700 hover:border-gray-300"
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="trigger-type"
+                    className="sr-only"
+                    checked={triggerType === opt.value}
+                    onChange={() => setTriggerType(opt.value)}
+                  />
+                  <span className="block text-sm font-medium text-gray-900 dark:text-white">{opt.label}</span>
+                  <span className="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">{opt.description}</span>
+                </label>
+              ))}
+            </div>
+          )}
+
+          {step === 1 && (
+            <TriggerConfigFields triggerType={triggerType} config={config} onChange={setConfig} />
+          )}
+
+          {step === 2 && (
+            <div className="space-y-3">
+              <ChannelRow
+                label="In-app"
+                checked={channels.some((c) => c.type === "in_app")}
+                onToggle={(v) => toggleChannel("in_app", v)}
+              />
+              <ChannelRow
+                label="Email"
+                checked={channels.some((c) => c.type === "email")}
+                onToggle={(v) => toggleChannel("email", v)}
+              >
+                {channels.find((c) => c.type === "email") && (
+                  <input
+                    type="email"
+                    placeholder="you@example.com"
+                    value={(channels.find((c) => c.type === "email") as { address: string }).address}
+                    onChange={(e) => updateChannelField("email", "address", e.target.value)}
+                    className="mt-2 w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-transparent px-3 py-2 text-sm"
+                  />
+                )}
+              </ChannelRow>
+              <ChannelRow
+                label="Webhook"
+                checked={channels.some((c) => c.type === "webhook")}
+                onToggle={(v) => toggleChannel("webhook", v)}
+              >
+                {channels.find((c) => c.type === "webhook") && (
+                  <input
+                    type="url"
+                    placeholder="https://example.com/hooks/nebgov"
+                    value={(channels.find((c) => c.type === "webhook") as { url: string }).url}
+                    onChange={(e) => updateChannelField("webhook", "url", e.target.value)}
+                    className="mt-2 w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-transparent px-3 py-2 text-sm"
+                  />
+                )}
+              </ChannelRow>
+              <ChannelRow
+                label="Telegram"
+                checked={channels.some((c) => c.type === "telegram")}
+                onToggle={(v) => toggleChannel("telegram", v)}
+              >
+                {channels.find((c) => c.type === "telegram") && (
+                  <input
+                    type="text"
+                    placeholder="Chat ID"
+                    value={(channels.find((c) => c.type === "telegram") as { chat_id: string }).chat_id}
+                    onChange={(e) => updateChannelField("telegram", "chat_id", e.target.value)}
+                    className="mt-2 w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-transparent px-3 py-2 text-sm"
+                  />
+                )}
+              </ChannelRow>
+            </div>
+          )}
+
+          {step === 3 && (
+            <div className="space-y-4">
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1">Rule name</label>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder={TRIGGER_OPTIONS.find((t) => t.value === triggerType)?.label}
+                  className="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-transparent px-3 py-2 text-sm"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1">
+                  Cooldown between notifications (seconds)
+                </label>
+                <input
+                  type="number"
+                  min={0}
+                  value={cooldownSeconds}
+                  onChange={(e) => setCooldownSeconds(Number(e.target.value))}
+                  className="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-transparent px-3 py-2 text-sm"
+                />
+              </div>
+              {error && <p className="text-sm text-rose-600">{error}</p>}
+            </div>
+          )}
+        </div>
+
+        <div className="px-5 py-4 border-t border-gray-100 dark:border-gray-800 flex items-center justify-between">
+          <button
+            onClick={() => setStep((s) => Math.max(0, s - 1))}
+            disabled={step === 0}
+            className="text-sm font-medium text-gray-500 disabled:opacity-40"
+          >
+            Back
+          </button>
+          {step < STEPS.length - 1 ? (
+            <button
+              onClick={() => setStep((s) => Math.min(STEPS.length - 1, s + 1))}
+              disabled={step === 2 && !canProceedFromChannels}
+              className="px-4 py-2 rounded-full bg-indigo-600 text-white text-sm font-semibold disabled:opacity-50"
+            >
+              Next
+            </button>
+          ) : (
+            <button
+              onClick={() => void handleSubmit()}
+              disabled={submitting}
+              className="px-4 py-2 rounded-full bg-indigo-600 text-white text-sm font-semibold disabled:opacity-50"
+            >
+              {submitting ? "Creating…" : "Create rule"}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ChannelRow({
+  label,
+  checked,
+  onToggle,
+  children,
+}: {
+  label: string;
+  checked: boolean;
+  onToggle: (v: boolean) => void;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="p-3 rounded-xl border border-gray-200 dark:border-gray-700">
+      <label className="flex items-center gap-3 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(e) => onToggle(e.target.checked)}
+          className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+        />
+        <span className="text-sm font-medium text-gray-900 dark:text-white">{label}</span>
+      </label>
+      {children}
+    </div>
+  );
+}
+
+function TriggerConfigFields({
+  triggerType,
+  config,
+  onChange,
+}: {
+  triggerType: TriggerType;
+  config: TriggerConfig;
+  onChange: (config: TriggerConfig) => void;
+}) {
+  function set(field: keyof TriggerConfig, value: string) {
+    onChange({ ...config, [field]: value === "" ? undefined : value });
+  }
+
+  const fields: React.ReactNode[] = [];
+
+  if (triggerType === "proposal_created") {
+    fields.push(
+      <TextField key="proposer" label="Proposer address (optional)" value={config.proposer ?? ""} onChange={(v) => set("proposer", v)} />,
+    );
+  }
+  if (triggerType === "proposal_state_changed") {
+    fields.push(
+      <div key="to_state">
+        <label className="block text-xs font-medium text-gray-500 mb-1">New state</label>
+        <select
+          value={config.to_state ?? ""}
+          onChange={(e) => set("to_state", e.target.value)}
+          className="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-transparent px-3 py-2 text-sm"
+        >
+          <option value="">Any</option>
+          <option value="Queued">Queued</option>
+          <option value="Executed">Executed</option>
+          <option value="Cancelled">Cancelled</option>
+        </select>
+      </div>,
+    );
+  }
+  if (triggerType === "vote_cast") {
+    fields.push(
+      <TextField key="proposal_id" label="Proposal ID (optional)" value={config.proposal_id?.toString() ?? ""} onChange={(v) => set("proposal_id", v)} />,
+      <TextField key="voter" label="Voter address (optional)" value={config.voter ?? ""} onChange={(v) => set("voter", v)} />,
+    );
+  }
+  if (triggerType === "proposal_ending_soon") {
+    fields.push(
+      <TextField key="ledgers_remaining" label="Ledgers remaining threshold" value={config.ledgers_remaining?.toString() ?? "500"} onChange={(v) => set("ledgers_remaining", v)} />,
+    );
+  }
+  if (triggerType === "proposal_vote_threshold") {
+    fields.push(
+      <TextField key="threshold_bps" label="Threshold (basis points of quorum)" value={config.threshold_bps?.toString() ?? "8000"} onChange={(v) => set("threshold_bps", v)} />,
+    );
+  }
+  if (triggerType === "delegation_received" || triggerType === "delegation_lost") {
+    fields.push(
+      <TextField key="delegatee" label="Your delegatee address (optional — leave blank to match everyone)" value={config.delegatee ?? ""} onChange={(v) => set("delegatee", v)} />,
+    );
+  }
+
+  if (fields.length === 0) {
+    return (
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        This trigger has no additional configuration — it fires for every matching event.
+      </p>
+    );
+  }
+
+  return <div className="space-y-4">{fields}</div>;
+}
+
+function TextField({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-gray-500 mb-1">{label}</label>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-transparent px-3 py-2 text-sm"
+      />
+    </div>
+  );
+}

--- a/app/src/hooks/useNotifications.ts
+++ b/app/src/hooks/useNotifications.ts
@@ -1,0 +1,189 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { backendFetch } from "../lib/backend";
+import { useWallet } from "../lib/wallet-context";
+
+export type TriggerType =
+  | "proposal_created"
+  | "proposal_state_changed"
+  | "proposal_vote_threshold"
+  | "proposal_ending_soon"
+  | "vote_cast"
+  | "guardian_veto"
+  | "treasury_stream_spend"
+  | "config_updated"
+  | "contract_paused"
+  | "contract_upgraded"
+  | "delegation_received"
+  | "delegation_lost"
+  | "quorum_reached";
+
+export type NotificationChannel =
+  | { type: "in_app" }
+  | { type: "email"; address: string }
+  | { type: "webhook"; url: string; secret?: string }
+  | { type: "telegram"; chat_id: string };
+
+export interface TriggerConfig {
+  proposer?: string;
+  from_state?: string;
+  to_state?: string;
+  threshold_bps?: number;
+  ledgers_remaining?: number;
+  proposal_id?: number;
+  voter?: string;
+  stream_id?: number;
+  min_amount?: number;
+  delegatee?: string;
+}
+
+export interface NotificationRule {
+  id: number;
+  user_id: number;
+  name: string;
+  trigger_type: TriggerType;
+  trigger_config: TriggerConfig;
+  channels: NotificationChannel[];
+  enabled: boolean;
+  cooldown_seconds: number;
+  last_triggered_at: string | null;
+  trigger_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface InAppNotification {
+  id: number;
+  rule_id: number | null;
+  title: string;
+  body: string;
+  action_url: string | null;
+  read: boolean;
+  created_at: string;
+}
+
+export interface CreateRuleParams {
+  name: string;
+  trigger_type: TriggerType;
+  trigger_config?: TriggerConfig;
+  channels: NotificationChannel[];
+  enabled?: boolean;
+  cooldown_seconds?: number;
+}
+
+interface InboxResponse {
+  data: InAppNotification[];
+  meta: { total: number; unread: number; limit: number; offset: number };
+}
+
+const POLL_INTERVAL_MS = 30_000;
+
+export function useNotifications() {
+  const { isConnected } = useWallet();
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [notifications, setNotifications] = useState<InAppNotification[]>([]);
+  const [rules, setRules] = useState<NotificationRule[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const refreshInbox = useCallback(async () => {
+    if (!isConnected) return;
+    try {
+      const res = await backendFetch<InboxResponse>("/notifications/inbox?limit=20", { auth: true });
+      setNotifications(res.data);
+      setUnreadCount(res.meta.unread);
+    } catch {
+      // Backend unreachable — leave prior state in place.
+    }
+  }, [isConnected]);
+
+  const refreshRules = useCallback(async () => {
+    if (!isConnected) return;
+    setLoading(true);
+    try {
+      const res = await backendFetch<NotificationRule[]>("/notifications/rules", { auth: true });
+      setRules(res);
+    } catch {
+      // Backend unreachable — leave prior state in place.
+    } finally {
+      setLoading(false);
+    }
+  }, [isConnected]);
+
+  useEffect(() => {
+    if (!isConnected) {
+      setNotifications([]);
+      setUnreadCount(0);
+      setRules([]);
+      return;
+    }
+    void refreshInbox();
+    void refreshRules();
+    const interval = setInterval(() => void refreshInbox(), POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [isConnected, refreshInbox, refreshRules]);
+
+  const markRead = useCallback(
+    async (id: number) => {
+      await backendFetch(`/notifications/inbox/${id}/read`, { method: "PUT", auth: true });
+      await refreshInbox();
+    },
+    [refreshInbox],
+  );
+
+  const markAllRead = useCallback(async () => {
+    await backendFetch("/notifications/inbox/read-all", { method: "PUT", auth: true });
+    await refreshInbox();
+  }, [refreshInbox]);
+
+  const createRule = useCallback(
+    async (rule: CreateRuleParams) => {
+      await backendFetch("/notifications/rules", {
+        method: "POST",
+        body: JSON.stringify(rule),
+        auth: true,
+      });
+      await refreshRules();
+    },
+    [refreshRules],
+  );
+
+  const updateRule = useCallback(
+    async (id: number, updates: Partial<CreateRuleParams>) => {
+      await backendFetch(`/notifications/rules/${id}`, {
+        method: "PUT",
+        body: JSON.stringify(updates),
+        auth: true,
+      });
+      await refreshRules();
+    },
+    [refreshRules],
+  );
+
+  const deleteRule = useCallback(
+    async (id: number) => {
+      await backendFetch(`/notifications/rules/${id}`, { method: "DELETE", auth: true });
+      await refreshRules();
+    },
+    [refreshRules],
+  );
+
+  const testRule = useCallback(async (id: number) => {
+    return backendFetch(`/notifications/rules/${id}/test`, { method: "POST", auth: true });
+  }, []);
+
+  return {
+    unreadCount,
+    notifications,
+    rules,
+    loading,
+    markRead,
+    markAllRead,
+    createRule,
+    updateRule,
+    deleteRule,
+    testRule,
+    refreshInbox,
+    refreshRules,
+  };
+}

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,3 +26,14 @@ RELAYER_DAILY_PERMIT_LIMIT=5
 SECURITY_LARGE_TRANSFER_THRESHOLD=1000000000000 # 1,000,000 tokens (assuming 7 decimals)
 SECURITY_ALERT_WEBHOOK_URL=https://discord.com/api/webhooks/...
 SECURITY_SCAN_INTERVAL_MS=30000
+
+# Notification engine (issue #774)
+NOTIFICATION_PROCESSOR_INTERVAL_MS=10000
+DELIVERY_RETRY_INTERVAL_MS=15000
+# Transactional email provider, called as POST {url} with a bearer token.
+# Email channel deliveries fail (and retry) until both are set.
+EMAIL_PROVIDER_API_URL=
+EMAIL_PROVIDER_API_KEY=
+EMAIL_FROM_ADDRESS=notifications@nebgov.dev
+# Telegram channel deliveries fail (and retry) until set.
+TELEGRAM_BOT_TOKEN=

--- a/backend/migrations/008_add_notification_engine.sql
+++ b/backend/migrations/008_add_notification_engine.sql
@@ -1,0 +1,66 @@
+-- Up Migration
+
+CREATE TABLE notification_rules (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name VARCHAR(128) NOT NULL,
+  trigger_type VARCHAR(64) NOT NULL,
+  trigger_config JSONB NOT NULL DEFAULT '{}',
+  channels JSONB NOT NULL DEFAULT '[]',
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  cooldown_seconds INTEGER NOT NULL DEFAULT 300,
+  last_triggered_at TIMESTAMPTZ,
+  trigger_count INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE notification_deliveries (
+  id SERIAL PRIMARY KEY,
+  rule_id INTEGER NOT NULL REFERENCES notification_rules(id) ON DELETE CASCADE,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  event_type VARCHAR(64) NOT NULL,
+  event_payload JSONB NOT NULL,
+  channel_type VARCHAR(32) NOT NULL,
+  status VARCHAR(32) NOT NULL DEFAULT 'pending', -- pending|delivered|failed|retrying
+  attempts INTEGER NOT NULL DEFAULT 0,
+  last_attempt_at TIMESTAMPTZ,
+  next_retry_at TIMESTAMPTZ,
+  delivered_at TIMESTAMPTZ,
+  error_message TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE in_app_notifications (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  rule_id INTEGER REFERENCES notification_rules(id) ON DELETE SET NULL,
+  title VARCHAR(256) NOT NULL,
+  body TEXT NOT NULL,
+  action_url TEXT,
+  read BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Single-row cursor tracking the last indexer event_log.id the notification
+-- processor has evaluated, so restarts resume without re-scanning history or
+-- re-delivering already-matched notifications.
+CREATE TABLE notification_event_cursor (
+  id SMALLINT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+  last_event_id BIGINT NOT NULL DEFAULT 0
+);
+INSERT INTO notification_event_cursor (id, last_event_id) VALUES (1, 0)
+  ON CONFLICT (id) DO NOTHING;
+
+CREATE INDEX idx_notification_rules_user ON notification_rules(user_id);
+CREATE INDEX idx_notification_rules_trigger_type ON notification_rules(trigger_type) WHERE enabled = true;
+CREATE INDEX idx_notification_deliveries_status ON notification_deliveries(status, next_retry_at);
+CREATE INDEX idx_notification_deliveries_rule ON notification_deliveries(rule_id);
+CREATE INDEX idx_in_app_notifications_user ON in_app_notifications(user_id, read, created_at DESC);
+
+-- Down Migration
+
+DROP TABLE IF EXISTS notification_event_cursor;
+DROP TABLE IF EXISTS in_app_notifications;
+DROP TABLE IF EXISTS notification_deliveries;
+DROP TABLE IF EXISTS notification_rules;

--- a/backend/src/__tests__/notification-engine.test.ts
+++ b/backend/src/__tests__/notification-engine.test.ts
@@ -1,0 +1,174 @@
+import { ruleMatchesEvent } from "../notifications/engine";
+import { renderNotification } from "../notifications/templates";
+import type { IndexerEvent, NotificationRule, TriggerType } from "../notifications/rules";
+
+function makeRule(overrides: Partial<NotificationRule> = {}): NotificationRule {
+  return {
+    id: 1,
+    user_id: 1,
+    name: "Test rule",
+    trigger_type: "proposal_created",
+    trigger_config: {},
+    channels: [{ type: "in_app" }],
+    enabled: true,
+    cooldown_seconds: 300,
+    last_triggered_at: null,
+    trigger_count: 0,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeEvent(overrides: Partial<IndexerEvent> = {}): IndexerEvent {
+  return {
+    id: 1,
+    event_type: "ProposalCreated",
+    ledger: 100,
+    transaction_hash: "abc",
+    contract_address: "C123",
+    payload: { topics: ["ProposalCreated", "GPROPOSER"], value: { proposal_id: "5" } },
+    indexed_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("ruleMatchesEvent", () => {
+  it("matches proposal_created with no proposer filter", () => {
+    const rule = makeRule({ trigger_type: "proposal_created" });
+    const event = makeEvent({ event_type: "ProposalCreated" });
+    expect(ruleMatchesEvent(rule, event)).toBe(true);
+  });
+
+  it("filters proposal_created by proposer", () => {
+    const rule = makeRule({
+      trigger_type: "proposal_created",
+      trigger_config: { proposer: "GOTHER" },
+    });
+    const event = makeEvent({
+      event_type: "ProposalCreated",
+      payload: { topics: ["ProposalCreated", "GPROPOSER"], value: { proposal_id: "5", proposer: "GPROPOSER" } },
+    });
+    expect(ruleMatchesEvent(rule, event)).toBe(false);
+  });
+
+  it("matches proposal_created when proposer filter matches", () => {
+    const rule = makeRule({
+      trigger_type: "proposal_created",
+      trigger_config: { proposer: "GPROPOSER" },
+    });
+    const event = makeEvent({
+      event_type: "ProposalCreated",
+      payload: { topics: ["ProposalCreated", "GPROPOSER"], value: { proposal_id: "5", proposer: "GPROPOSER" } },
+    });
+    expect(ruleMatchesEvent(rule, event)).toBe(true);
+  });
+
+  it("matches proposal_state_changed only for the configured to_state", () => {
+    const rule = makeRule({
+      trigger_type: "proposal_state_changed",
+      trigger_config: { to_state: "Executed" },
+    });
+    const queuedEvent = makeEvent({ event_type: "ProposalQueued", payload: { topics: ["ProposalQueued", "5"], value: undefined } });
+    const executedEvent = makeEvent({ event_type: "ProposalExecuted", payload: { topics: ["ProposalExecuted", "5"], value: undefined } });
+
+    expect(ruleMatchesEvent(rule, queuedEvent)).toBe(false);
+    expect(ruleMatchesEvent(rule, executedEvent)).toBe(true);
+  });
+
+  it("filters vote_cast by proposal_id and voter", () => {
+    const rule = makeRule({
+      trigger_type: "vote_cast",
+      trigger_config: { proposal_id: 5, voter: "GVOTER" },
+    });
+    const matching = makeEvent({
+      event_type: "VoteCast",
+      payload: { topics: ["VoteCast", "GVOTER"], value: ["5", 1, "1000"] },
+    });
+    const wrongVoter = makeEvent({
+      event_type: "VoteCast",
+      payload: { topics: ["VoteCast", "GSOMEONEELSE"], value: ["5", 1, "1000"] },
+    });
+    const wrongProposal = makeEvent({
+      event_type: "VoteCast",
+      payload: { topics: ["VoteCast", "GVOTER"], value: ["9", 1, "1000"] },
+    });
+
+    expect(ruleMatchesEvent(rule, matching)).toBe(true);
+    expect(ruleMatchesEvent(rule, wrongVoter)).toBe(false);
+    expect(ruleMatchesEvent(rule, wrongProposal)).toBe(false);
+  });
+
+  it("filters delegation_received by delegatee address", () => {
+    const rule = makeRule({
+      trigger_type: "delegation_received",
+      trigger_config: { delegatee: "GDELEGATEE" },
+    });
+    const matching = makeEvent({
+      event_type: "DelegationRegistered",
+      payload: { topics: ["DelegationRegistered", "GDELEGATOR"], value: ["GDELEGATEE", "1000", 1] },
+    });
+    const nonMatching = makeEvent({
+      event_type: "DelegationRegistered",
+      payload: { topics: ["DelegationRegistered", "GDELEGATOR"], value: ["GOTHER", "1000", 1] },
+    });
+
+    expect(ruleMatchesEvent(rule, matching)).toBe(true);
+    expect(ruleMatchesEvent(rule, nonMatching)).toBe(false);
+  });
+
+  it("matches proposal_ending_soon only within the configured ledger window", () => {
+    const rule = makeRule({
+      trigger_type: "proposal_ending_soon",
+      trigger_config: { ledgers_remaining: 100 },
+    });
+    const soon = makeEvent({
+      event_type: "proposal_ending_soon",
+      payload: { topics: [], value: { proposal_id: "5", remaining_ledgers: 50 } },
+    });
+    const notSoon = makeEvent({
+      event_type: "proposal_ending_soon",
+      payload: { topics: [], value: { proposal_id: "5", remaining_ledgers: 500 } },
+    });
+
+    expect(ruleMatchesEvent(rule, soon)).toBe(true);
+    expect(ruleMatchesEvent(rule, notSoon)).toBe(false);
+  });
+});
+
+describe("renderNotification", () => {
+  const triggerTypes: TriggerType[] = [
+    "proposal_created",
+    "proposal_state_changed",
+    "proposal_vote_threshold",
+    "proposal_ending_soon",
+    "vote_cast",
+    "guardian_veto",
+    "treasury_stream_spend",
+    "config_updated",
+    "contract_paused",
+    "contract_upgraded",
+    "delegation_received",
+    "delegation_lost",
+    "quorum_reached",
+  ];
+
+  it.each(triggerTypes)("renders a non-empty subject and body for %s", (trigger) => {
+    const event = makeEvent({
+      payload: {
+        topics: ["x", "GADDR"],
+        value: { proposal_id: "5", delegatee: "GDELEGATEE" },
+      },
+    });
+    const message = renderNotification(trigger, event);
+    expect(message.subject.length).toBeGreaterThan(0);
+    expect(message.body.length).toBeGreaterThan(0);
+    expect(message.short.length).toBeGreaterThan(0);
+  });
+
+  it("includes an actionUrl for proposal-scoped triggers", () => {
+    const event = makeEvent({ payload: { topics: ["x"], value: { proposal_id: "42" } } });
+    const message = renderNotification("proposal_created", event);
+    expect(message.actionUrl).toBe("/proposal/42");
+  });
+});

--- a/backend/src/__tests__/notifications.test.ts
+++ b/backend/src/__tests__/notifications.test.ts
@@ -145,5 +145,170 @@ describe("Notification Endpoints", () => {
       );
     });
   });
+
+  describe("Notification Rules Endpoints", () => {
+    let ruleId: number;
+
+    it("POST /notifications/rules creates a rule", async () => {
+      const res = await request(app)
+        .post("/notifications/rules")
+        .set("Authorization", `Bearer ${authToken}`)
+        .send({
+          name: "Notify me on new proposals",
+          trigger_type: "proposal_created",
+          channels: [{ type: "in_app" }],
+        })
+        .expect(201);
+
+      expect(res.body).toHaveProperty("id");
+      expect(res.body.trigger_type).toBe("proposal_created");
+      expect(res.body.enabled).toBe(true);
+      expect(res.body.cooldown_seconds).toBe(300);
+      ruleId = res.body.id;
+    });
+
+    it("rejects a rule with no channels", async () => {
+      await request(app)
+        .post("/notifications/rules")
+        .set("Authorization", `Bearer ${authToken}`)
+        .send({ name: "No channels", trigger_type: "proposal_created", channels: [] })
+        .expect(400);
+    });
+
+    it("GET /notifications/rules lists the caller's rules", async () => {
+      const res = await request(app)
+        .get("/notifications/rules")
+        .set("Authorization", `Bearer ${authToken}`)
+        .expect(200);
+
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body.some((r: { id: number }) => r.id === ruleId)).toBe(true);
+    });
+
+    it("masks a webhook channel's secret after creation but not on create response", async () => {
+      const created = await request(app)
+        .post("/notifications/rules")
+        .set("Authorization", `Bearer ${authToken}`)
+        .send({
+          name: "Webhook rule",
+          trigger_type: "vote_cast",
+          channels: [{ type: "webhook", url: "https://example.com/hook" }],
+        })
+        .expect(201);
+
+      const webhookChannel = created.body.channels.find((c: { type: string }) => c.type === "webhook");
+      expect(webhookChannel.secret).toBeDefined();
+      expect(webhookChannel.secret).not.toBe("***");
+
+      const list = await request(app)
+        .get("/notifications/rules")
+        .set("Authorization", `Bearer ${authToken}`)
+        .expect(200);
+
+      const listed = list.body.find((r: { id: number }) => r.id === created.body.id);
+      const listedChannel = listed.channels.find((c: { type: string }) => c.type === "webhook");
+      expect(listedChannel.secret).toBe("***");
+
+      await pool.query("DELETE FROM notification_rules WHERE id = $1", [created.body.id]);
+    });
+
+    it("PUT /notifications/rules/:id updates a rule owned by the caller", async () => {
+      const res = await request(app)
+        .put(`/notifications/rules/${ruleId}`)
+        .set("Authorization", `Bearer ${authToken}`)
+        .send({ enabled: false })
+        .expect(200);
+
+      expect(res.body.enabled).toBe(false);
+    });
+
+    it("PUT /notifications/rules/:id returns 404 for another user's rule", async () => {
+      await request(app)
+        .put("/notifications/rules/999999")
+        .set("Authorization", `Bearer ${authToken}`)
+        .send({ enabled: true })
+        .expect(404);
+    });
+
+    it("POST /notifications/rules/:id/test delivers to in_app and appears in the inbox", async () => {
+      await request(app)
+        .post(`/notifications/rules/${ruleId}/test`)
+        .set("Authorization", `Bearer ${authToken}`)
+        .expect(200);
+
+      const inbox = await request(app)
+        .get("/notifications/inbox")
+        .set("Authorization", `Bearer ${authToken}`)
+        .expect(200);
+
+      expect(inbox.body.data.length).toBeGreaterThan(0);
+      expect(inbox.body.data[0].title).toMatch(/^\[Test\]/);
+    });
+
+    it("PUT /notifications/inbox/:id/read marks a single notification read", async () => {
+      const inbox = await request(app)
+        .get("/notifications/inbox?unread_only=true")
+        .set("Authorization", `Bearer ${authToken}`)
+        .expect(200);
+
+      const notificationId = inbox.body.data[0].id;
+      await request(app)
+        .put(`/notifications/inbox/${notificationId}/read`)
+        .set("Authorization", `Bearer ${authToken}`)
+        .expect(200);
+
+      const after = await request(app)
+        .get("/notifications/inbox?unread_only=true")
+        .set("Authorization", `Bearer ${authToken}`)
+        .expect(200);
+
+      expect(after.body.data.some((n: { id: number }) => n.id === notificationId)).toBe(false);
+    });
+
+    it("PUT /notifications/inbox/read-all clears unread count", async () => {
+      await request(app)
+        .put("/notifications/inbox/read-all")
+        .set("Authorization", `Bearer ${authToken}`)
+        .expect(200);
+
+      const inbox = await request(app)
+        .get("/notifications/inbox")
+        .set("Authorization", `Bearer ${authToken}`)
+        .expect(200);
+
+      expect(inbox.body.meta.unread).toBe(0);
+    });
+
+    it("GET /notifications/deliveries returns delivery history", async () => {
+      const res = await request(app)
+        .get("/notifications/deliveries")
+        .set("Authorization", `Bearer ${authToken}`)
+        .expect(200);
+
+      expect(Array.isArray(res.body.data)).toBe(true);
+      expect(res.body.data.some((d: { rule_id: number }) => d.rule_id === ruleId)).toBe(true);
+    });
+
+    it("DELETE /notifications/rules/:id removes the rule", async () => {
+      await request(app)
+        .delete(`/notifications/rules/${ruleId}`)
+        .set("Authorization", `Bearer ${authToken}`)
+        .expect(200);
+
+      const list = await request(app)
+        .get("/notifications/rules")
+        .set("Authorization", `Bearer ${authToken}`)
+        .expect(200);
+
+      expect(list.body.some((r: { id: number }) => r.id === ruleId)).toBe(false);
+    });
+
+    it("requires authentication on rules and inbox endpoints", async () => {
+      await request(app).get("/notifications/rules").expect(401);
+      await request(app).post("/notifications/rules").send({}).expect(401);
+      await request(app).get("/notifications/inbox").expect(401);
+      await request(app).get("/notifications/deliveries").expect(401);
+    });
+  });
 });
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,6 +10,8 @@ import notificationsRouter from "./routes/notifications";
 import securityRouter from "./routes/security";
 import relayerRouter from "./routes/relayer";
 import { securityMonitor } from "./services/security-monitor";
+import { notificationProcessor } from "./jobs/notification-processor";
+import { deliveryRetry } from "./jobs/delivery-retry";
 import { runBackendMigrations } from "./db/migrationRunner";
 import pino from "pino";
 import pinoHttp from "pino-http";
@@ -130,6 +132,10 @@ async function bootstrap(): Promise<void> {
     securityMonitor.start().catch((err) => {
       logger.error({ err }, "Failed to start security monitor");
     });
+
+    // Start the notification engine's background jobs
+    notificationProcessor.start();
+    deliveryRetry.start();
   });
 }
 

--- a/backend/src/jobs/delivery-retry.ts
+++ b/backend/src/jobs/delivery-retry.ts
@@ -1,0 +1,97 @@
+import pool from "../db/pool";
+import { logger } from "../logger";
+import { notificationEngine, type StoredNotificationChannel } from "../notifications/engine";
+import { renderNotification } from "../notifications/templates";
+import { rowToRule, type IndexerEvent } from "../notifications/rules";
+
+const RETRY_BATCH_SIZE = 50;
+
+/** Redelivers `notification_deliveries` rows past their exponential-backoff `next_retry_at`. */
+export class DeliveryRetryService {
+  private interval: NodeJS.Timeout | null = null;
+  private isProcessing = false;
+
+  start() {
+    const intervalMs = Number(process.env.DELIVERY_RETRY_INTERVAL_MS ?? "15000");
+    logger.info({ intervalMs }, "Starting delivery retry job");
+    this.interval = setInterval(() => this.tick(), intervalMs);
+    this.tick();
+  }
+
+  stop() {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+
+  private async tick() {
+    if (this.isProcessing) return;
+    this.isProcessing = true;
+    try {
+      await this.processDueRetries();
+    } catch (error) {
+      logger.error({ err: error }, "Delivery retry tick failed");
+    } finally {
+      this.isProcessing = false;
+    }
+  }
+
+  async processDueRetries(): Promise<void> {
+    const due = await pool.query(
+      `SELECT nd.*, nr.channels, nr.trigger_type, nr.user_id AS rule_user_id,
+              nr.trigger_config, nr.cooldown_seconds, nr.enabled, nr.name,
+              nr.last_triggered_at, nr.trigger_count, nr.created_at AS rule_created_at,
+              nr.updated_at AS rule_updated_at
+       FROM notification_deliveries nd
+       JOIN notification_rules nr ON nr.id = nd.rule_id
+       WHERE nd.status = 'retrying' AND nd.next_retry_at IS NOT NULL AND nd.next_retry_at <= NOW()
+       ORDER BY nd.next_retry_at ASC
+       LIMIT $1`,
+      [RETRY_BATCH_SIZE],
+    );
+
+    for (const row of due.rows) {
+      const channels = (row.channels ?? []) as StoredNotificationChannel[];
+      const channel = channels.find((c) => c.type === row.channel_type);
+      if (!channel) {
+        // The rule was edited to drop this channel — nothing left to retry against.
+        await pool.query(
+          `UPDATE notification_deliveries SET status = 'failed', next_retry_at = NULL WHERE id = $1`,
+          [row.id],
+        );
+        continue;
+      }
+
+      const rule = rowToRule({
+        id: row.rule_id,
+        user_id: row.rule_user_id,
+        name: row.name,
+        trigger_type: row.trigger_type,
+        trigger_config: row.trigger_config,
+        channels: row.channels,
+        enabled: row.enabled,
+        cooldown_seconds: row.cooldown_seconds,
+        last_triggered_at: row.last_triggered_at,
+        trigger_count: row.trigger_count,
+        created_at: row.rule_created_at,
+        updated_at: row.rule_updated_at,
+      });
+
+      const event: IndexerEvent = {
+        id: 0,
+        event_type: row.event_type,
+        ledger: 0,
+        transaction_hash: null,
+        contract_address: "",
+        payload: row.event_payload,
+        indexed_at: new Date().toISOString(),
+      };
+
+      const message = renderNotification(rule.trigger_type, event);
+      await notificationEngine.attemptDelivery(row.id, rule, event, channel, message);
+    }
+  }
+}
+
+export const deliveryRetry = new DeliveryRetryService();

--- a/backend/src/jobs/notification-processor.ts
+++ b/backend/src/jobs/notification-processor.ts
@@ -1,0 +1,158 @@
+import pool from "../db/pool";
+import { logger } from "../logger";
+import { notificationEngine } from "../notifications/engine";
+import type { IndexerEvent } from "../notifications/rules";
+
+const EVENT_BATCH_SIZE = 200;
+
+/**
+ * Reads new rows from the indexer's `event_log` (same physical database,
+ * separate migration history — see packages/indexer/migrations) and
+ * evaluates every enabled notification rule against them. Runs on its own
+ * interval rather than in the indexer process so a slow email/webhook
+ * delivery never blocks chain polling.
+ */
+export class NotificationProcessorService {
+  private interval: NodeJS.Timeout | null = null;
+  private isProcessing = false;
+
+  start() {
+    const intervalMs = Number(process.env.NOTIFICATION_PROCESSOR_INTERVAL_MS ?? "10000");
+    logger.info({ intervalMs }, "Starting notification processor");
+    this.interval = setInterval(() => this.tick(), intervalMs);
+    this.tick();
+  }
+
+  stop() {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+
+  private async tick() {
+    if (this.isProcessing) return;
+    this.isProcessing = true;
+    try {
+      await this.processNewEvents();
+      await this.checkProposalTimers();
+    } catch (error) {
+      logger.error({ err: error }, "Notification processor tick failed");
+    } finally {
+      this.isProcessing = false;
+    }
+  }
+
+  private async getCursor(): Promise<number> {
+    const result = await pool.query(
+      "SELECT last_event_id FROM notification_event_cursor WHERE id = 1",
+    );
+    return result.rows[0]?.last_event_id ?? 0;
+  }
+
+  private async setCursor(lastEventId: number): Promise<void> {
+    await pool.query(
+      "UPDATE notification_event_cursor SET last_event_id = $1 WHERE id = 1",
+      [lastEventId],
+    );
+  }
+
+  async processNewEvents(): Promise<void> {
+    const cursor = await this.getCursor();
+    const result = await pool.query(
+      `SELECT id, event_type, ledger, transaction_hash, contract_address, payload, indexed_at
+       FROM event_log
+       WHERE id > $1
+       ORDER BY id ASC
+       LIMIT $2`,
+      [cursor, EVENT_BATCH_SIZE],
+    );
+
+    if (result.rowCount === 0) return;
+
+    let maxId = cursor;
+    for (const row of result.rows) {
+      const event: IndexerEvent = {
+        id: row.id,
+        event_type: row.event_type,
+        ledger: row.ledger,
+        transaction_hash: row.transaction_hash,
+        contract_address: row.contract_address,
+        payload: row.payload,
+        indexed_at: row.indexed_at,
+      };
+
+      try {
+        await notificationEngine.evaluateEvent(event);
+      } catch (error) {
+        logger.error({ err: error, eventId: row.id }, "Failed to evaluate event for notifications");
+      }
+
+      if (row.id > maxId) maxId = row.id;
+    }
+
+    await this.setCursor(maxId);
+  }
+
+  /**
+   * `proposal_ending_soon` isn't a discrete contract event — it's a
+   * condition on a proposal's current state — so it's evaluated by
+   * periodically scanning open proposals against the indexer's last-seen
+   * ledger rather than reacting to `event_log` rows.
+   *
+   * `proposal_vote_threshold` and `quorum_reached` are intentionally NOT
+   * evaluated here: computing "% of quorum reached" needs the total voting
+   * supply quorum is measured against, and the indexed schema
+   * (proposals/config_updates) has no such snapshot — only per-proposal
+   * vote tallies and a raw `quorum_numerator`, whose denominator isn't
+   * indexed either. Rather than fabricate a percentage, rules with these
+   * two trigger types are accepted and stored (see rules.ts) but never
+   * fire, the same scope boundary the analytics module documented for
+   * `top_delegate_share_bps`.
+   */
+  async checkProposalTimers(): Promise<void> {
+    const hasSubscribers = await pool.query(
+      `SELECT 1 FROM notification_rules
+       WHERE enabled = true AND trigger_type = 'proposal_ending_soon'
+       LIMIT 1`,
+    );
+    if (hasSubscribers.rowCount === 0) return;
+
+    const ledgerResult = await pool.query("SELECT last_ledger FROM indexer_state WHERE id = 1");
+    const currentLedger: number = ledgerResult.rows[0]?.last_ledger ?? 0;
+    if (currentLedger === 0) return;
+
+    const proposals = await pool.query(
+      `SELECT id, end_ledger
+       FROM proposals
+       WHERE executed = false AND cancelled = false AND end_ledger > $1`,
+      [currentLedger],
+    );
+
+    for (const proposal of proposals.rows) {
+      await this.evaluateSynthetic("proposal_ending_soon", proposal.id, {
+        proposal_id: String(proposal.id),
+        remaining_ledgers: proposal.end_ledger - currentLedger,
+      });
+    }
+  }
+
+  private async evaluateSynthetic(
+    eventType: string,
+    proposalId: number | string,
+    value: Record<string, unknown>,
+  ): Promise<void> {
+    const event: IndexerEvent = {
+      id: 0,
+      event_type: eventType,
+      ledger: 0,
+      transaction_hash: null,
+      contract_address: "",
+      payload: { topics: ["synthetic", String(proposalId)], value },
+      indexed_at: new Date().toISOString(),
+    };
+    await notificationEngine.evaluateEvent(event);
+  }
+}
+
+export const notificationProcessor = new NotificationProcessorService();

--- a/backend/src/notifications/engine.ts
+++ b/backend/src/notifications/engine.ts
@@ -1,0 +1,378 @@
+import crypto from "crypto";
+import pool from "../db/pool";
+import { logger } from "../logger";
+import {
+  EVENT_TYPE_TO_TRIGGER,
+  rowToRule,
+  STATE_CHANGE_EVENTS,
+  TRIGGER_TYPES,
+  type IndexerEvent,
+  type NotificationRule,
+  type TriggerType,
+} from "./rules";
+import { renderNotification, type NotificationMessage } from "./templates";
+
+const WEBHOOK_TIMEOUT_MS = 10_000;
+const MAX_RETRIES = 5;
+const BASE_RETRY_DELAY_MS = 30_000;
+
+export interface DeliveryResult {
+  ruleId: number;
+  channelType: string;
+  status: "delivered" | "failed";
+  error?: string;
+}
+
+export interface StoredWebhookChannel {
+  type: "webhook";
+  url: string;
+  secret: string;
+}
+
+export type StoredNotificationChannel =
+  | { type: "in_app" }
+  | { type: "email"; address: string }
+  | StoredWebhookChannel
+  | { type: "telegram"; chat_id: string };
+
+function resolveTriggerTypes(event: IndexerEvent): TriggerType[] {
+  if (event.event_type in STATE_CHANGE_EVENTS) return ["proposal_state_changed"];
+  if ((TRIGGER_TYPES as readonly string[]).includes(event.event_type)) {
+    return [event.event_type as TriggerType];
+  }
+  return EVENT_TYPE_TO_TRIGGER[event.event_type] ?? [];
+}
+
+function eventProposalId(event: IndexerEvent): string | undefined {
+  const value = event.payload.value;
+  if (value && typeof value === "object" && "proposal_id" in (value as Record<string, unknown>)) {
+    return String((value as Record<string, unknown>).proposal_id);
+  }
+  if (Array.isArray(value) && value.length > 0) return String(value[0]);
+  const topics = event.payload.topics ?? [];
+  return topics[1] !== undefined ? String(topics[1]) : undefined;
+}
+
+function eventVoter(event: IndexerEvent): string | undefined {
+  const topics = event.payload.topics ?? [];
+  return topics[1] !== undefined ? String(topics[1]) : undefined;
+}
+
+function eventProposer(event: IndexerEvent): string | undefined {
+  const value = event.payload.value;
+  if (value && typeof value === "object" && "proposer" in (value as Record<string, unknown>)) {
+    return String((value as Record<string, unknown>).proposer);
+  }
+  const topics = event.payload.topics ?? [];
+  return topics[1] !== undefined ? String(topics[1]) : undefined;
+}
+
+function eventDelegatee(event: IndexerEvent): string | undefined {
+  const value = event.payload.value;
+  return Array.isArray(value) && value.length > 0 ? String(value[0]) : undefined;
+}
+
+/**
+ * Returns true if `rule`'s optional trigger_config filters (proposer, voter,
+ * to_state, delegatee, proposal_id) all match the concrete event. Filters
+ * left unset on the rule match anything — they narrow, they never widen.
+ */
+export function ruleMatchesEvent(rule: NotificationRule, event: IndexerEvent): boolean {
+  const cfg = rule.trigger_config;
+
+  switch (rule.trigger_type) {
+    case "proposal_state_changed": {
+      const toState = STATE_CHANGE_EVENTS[event.event_type];
+      if (cfg.to_state && cfg.to_state !== toState) return false;
+      return true;
+    }
+    case "proposal_created": {
+      if (cfg.proposer && cfg.proposer !== eventProposer(event)) return false;
+      return true;
+    }
+    case "vote_cast": {
+      if (cfg.proposal_id !== undefined && String(cfg.proposal_id) !== eventProposalId(event)) {
+        return false;
+      }
+      if (cfg.voter && cfg.voter !== eventVoter(event)) return false;
+      return true;
+    }
+    case "delegation_received":
+    case "delegation_lost": {
+      if (cfg.delegatee && cfg.delegatee !== eventDelegatee(event)) return false;
+      return true;
+    }
+    case "proposal_ending_soon": {
+      const value = event.payload.value as Record<string, unknown>;
+      const remaining = Number(value.remaining_ledgers);
+      if (cfg.proposal_id !== undefined && String(cfg.proposal_id) !== String(value.proposal_id)) {
+        return false;
+      }
+      return remaining <= (cfg.ledgers_remaining ?? 500);
+    }
+    case "proposal_vote_threshold": {
+      const value = event.payload.value as Record<string, unknown>;
+      const currentBps = Number(value.current_bps);
+      if (cfg.proposal_id !== undefined && String(cfg.proposal_id) !== String(value.proposal_id)) {
+        return false;
+      }
+      return currentBps >= (cfg.threshold_bps ?? 8000);
+    }
+    case "quorum_reached": {
+      const value = event.payload.value as Record<string, unknown>;
+      if (cfg.proposal_id !== undefined && String(cfg.proposal_id) !== String(value.proposal_id)) {
+        return false;
+      }
+      return true;
+    }
+    default:
+      return true;
+  }
+}
+
+function isInCooldown(rule: NotificationRule): boolean {
+  if (!rule.last_triggered_at) return false;
+  const elapsedMs = Date.now() - new Date(rule.last_triggered_at).getTime();
+  return elapsedMs < rule.cooldown_seconds * 1000;
+}
+
+function computeHmac(payload: string, secret: string): string {
+  return crypto.createHmac("sha256", secret).update(payload).digest("hex");
+}
+
+export class NotificationEngine {
+  async matchRules(event: IndexerEvent): Promise<NotificationRule[]> {
+    const triggerTypes = resolveTriggerTypes(event);
+    if (triggerTypes.length === 0) return [];
+
+    const result = await pool.query(
+      `SELECT id, user_id, name, trigger_type, trigger_config, channels, enabled,
+              cooldown_seconds, last_triggered_at, trigger_count, created_at, updated_at
+       FROM notification_rules
+       WHERE enabled = true AND trigger_type = ANY($1::text[])`,
+      [triggerTypes],
+    );
+
+    return result.rows.map(rowToRule).filter((rule) => ruleMatchesEvent(rule, event));
+  }
+
+  async evaluateEvent(event: IndexerEvent): Promise<DeliveryResult[]> {
+    const rules = await this.matchRules(event);
+    const results: DeliveryResult[] = [];
+
+    for (const rule of rules) {
+      if (isInCooldown(rule)) continue;
+
+      const message = renderNotification(rule.trigger_type, event);
+      const channels = (rule.channels as unknown as StoredNotificationChannel[]) ?? [];
+
+      for (const channel of channels) {
+        results.push(await this.deliverNotification(rule, event, channel, message));
+      }
+
+      await pool.query(
+        `UPDATE notification_rules
+         SET last_triggered_at = NOW(), trigger_count = trigger_count + 1
+         WHERE id = $1`,
+        [rule.id],
+      );
+    }
+
+    return results;
+  }
+
+  async deliverNotification(
+    rule: NotificationRule,
+    event: IndexerEvent,
+    channel: StoredNotificationChannel,
+    message: NotificationMessage,
+  ): Promise<DeliveryResult> {
+    const deliveryId = await this.recordDelivery(rule, event, channel.type);
+    return this.attemptDelivery(deliveryId, rule, event, channel, message);
+  }
+
+  // Reuses an existing delivery row so the manual retry endpoint updates it in place instead of inserting a duplicate.
+  async attemptDelivery(
+    deliveryId: number,
+    rule: NotificationRule,
+    event: IndexerEvent,
+    channel: StoredNotificationChannel,
+    message: NotificationMessage,
+  ): Promise<DeliveryResult> {
+    try {
+      switch (channel.type) {
+        case "in_app":
+          await this.deliverInApp(rule, message);
+          break;
+        case "email":
+          await this.deliverEmail(channel, message);
+          break;
+        case "webhook":
+          await this.deliverWebhook(channel, event, message);
+          break;
+        case "telegram":
+          await this.deliverTelegram(channel, message);
+          break;
+      }
+
+      await pool.query(
+        `UPDATE notification_deliveries
+         SET status = 'delivered', delivered_at = NOW(), attempts = attempts + 1, last_attempt_at = NOW()
+         WHERE id = $1`,
+        [deliveryId],
+      );
+      return { ruleId: rule.id, channelType: channel.type, status: "delivered" };
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      await this.enqueueRetry(deliveryId, errorMessage);
+      logger.warn(
+        { ruleId: rule.id, channelType: channel.type, err: errorMessage },
+        "Notification delivery failed",
+      );
+      return { ruleId: rule.id, channelType: channel.type, status: "failed", error: errorMessage };
+    }
+  }
+
+  private async recordDelivery(
+    rule: NotificationRule,
+    event: IndexerEvent,
+    channelType: string,
+  ): Promise<number> {
+    const result = await pool.query(
+      `INSERT INTO notification_deliveries (rule_id, user_id, event_type, event_payload, channel_type, status)
+       VALUES ($1, $2, $3, $4, $5, 'pending')
+       RETURNING id`,
+      [rule.id, rule.user_id, event.event_type, JSON.stringify(event.payload), channelType],
+    );
+    return result.rows[0].id;
+  }
+
+  async enqueueRetry(deliveryId: number, errorMessage: string): Promise<void> {
+    const result = await pool.query(
+      `UPDATE notification_deliveries
+       SET attempts = attempts + 1, last_attempt_at = NOW(), error_message = $2,
+           status = CASE WHEN attempts + 1 >= $3 THEN 'failed' ELSE 'retrying' END,
+           next_retry_at = CASE
+             WHEN attempts + 1 >= $3 THEN NULL
+             ELSE NOW() + (($4::bigint * POWER(2, attempts)) || ' milliseconds')::interval
+           END
+       WHERE id = $1
+       RETURNING status`,
+      [deliveryId, errorMessage, MAX_RETRIES, BASE_RETRY_DELAY_MS],
+    );
+
+    if (result.rows[0]?.status === "failed") {
+      logger.error({ deliveryId, errorMessage }, "Notification delivery permanently failed");
+    }
+  }
+
+  async deliverInApp(rule: NotificationRule, message: NotificationMessage): Promise<void> {
+    await pool.query(
+      `INSERT INTO in_app_notifications (user_id, rule_id, title, body, action_url)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [rule.user_id, rule.id, message.subject, message.body, message.actionUrl ?? null],
+    );
+  }
+
+  async deliverEmail(
+    channel: { type: "email"; address: string },
+    message: NotificationMessage,
+  ): Promise<void> {
+    const apiUrl = process.env.EMAIL_PROVIDER_API_URL;
+    const apiKey = process.env.EMAIL_PROVIDER_API_KEY;
+    const fromAddress = process.env.EMAIL_FROM_ADDRESS ?? "notifications@nebgov.dev";
+
+    if (!apiUrl || !apiKey) {
+      throw new Error("Email provider not configured (EMAIL_PROVIDER_API_URL / EMAIL_PROVIDER_API_KEY)");
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS);
+    try {
+      const response = await fetch(apiUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          from: fromAddress,
+          to: channel.address,
+          subject: message.subject,
+          text: message.body,
+        }),
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`Email provider returned HTTP ${response.status}`);
+      }
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async deliverWebhook(
+    channel: StoredWebhookChannel,
+    event: IndexerEvent,
+    message: NotificationMessage,
+  ): Promise<void> {
+    const body = JSON.stringify({
+      event: event.event_type,
+      message,
+      timestamp: new Date().toISOString(),
+    });
+    const signature = computeHmac(body, channel.secret);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS);
+    try {
+      const response = await fetch(channel.url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Notification-Signature": signature,
+          "X-Notification-Event": event.event_type,
+        },
+        body,
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`Webhook endpoint returned HTTP ${response.status}`);
+      }
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async deliverTelegram(
+    channel: { type: "telegram"; chat_id: string },
+    message: NotificationMessage,
+  ): Promise<void> {
+    const botToken = process.env.TELEGRAM_BOT_TOKEN;
+    if (!botToken) {
+      throw new Error("Telegram bot not configured (TELEGRAM_BOT_TOKEN)");
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS);
+    try {
+      const response = await fetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chat_id: channel.chat_id, text: message.short }),
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`Telegram API returned HTTP ${response.status}`);
+      }
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+export const notificationEngine = new NotificationEngine();
+
+export function generateWebhookSecret(): string {
+  return crypto.randomBytes(32).toString("hex");
+}

--- a/backend/src/notifications/rules.ts
+++ b/backend/src/notifications/rules.ts
@@ -1,0 +1,170 @@
+import { z } from "zod";
+
+/**
+ * Trigger types the notification engine can evaluate.
+ *
+ * `guardian_veto`, `treasury_stream_spend`, and `contract_paused` are
+ * accepted here and stored on rules like any other trigger, but nothing
+ * currently writes those event types into the indexer's `event_log` — the
+ * governor contract has no guardian-veto event, the treasury contract only
+ * indexes batched transfers (not per-stream `stream_spend` calls), and there
+ * is no pause event wired up yet. Rules using these triggers are valid and
+ * persisted but will not fire until a future indexer change emits the
+ * corresponding events, matching how `top_delegate_share_bps` was left at 0
+ * in the analytics module rather than faked.
+ */
+export const TRIGGER_TYPES = [
+  "proposal_created",
+  "proposal_state_changed",
+  "proposal_vote_threshold",
+  "proposal_ending_soon",
+  "vote_cast",
+  "guardian_veto",
+  "treasury_stream_spend",
+  "config_updated",
+  "contract_paused",
+  "contract_upgraded",
+  "delegation_received",
+  "delegation_lost",
+  "quorum_reached",
+] as const;
+
+export type TriggerType = (typeof TRIGGER_TYPES)[number];
+
+export const PROPOSAL_STATES = [
+  "Pending",
+  "Active",
+  "Defeated",
+  "Succeeded",
+  "Queued",
+  "Executed",
+  "Cancelled",
+  "Expired",
+] as const;
+
+export type ProposalState = (typeof PROPOSAL_STATES)[number];
+
+export const CHANNEL_TYPES = ["in_app", "email", "webhook", "telegram"] as const;
+export type ChannelType = (typeof CHANNEL_TYPES)[number];
+
+export const triggerConfigSchema = z
+  .object({
+    proposer: z.string().trim().min(1).optional(),
+    from_state: z.enum(PROPOSAL_STATES).optional(),
+    to_state: z.enum(PROPOSAL_STATES).optional(),
+    threshold_bps: z.coerce.number().int().min(1).max(10000).optional(),
+    ledgers_remaining: z.coerce.number().int().min(1).optional(),
+    proposal_id: z.coerce.number().int().min(0).optional(),
+    voter: z.string().trim().min(1).optional(),
+    stream_id: z.coerce.number().int().min(0).optional(),
+    min_amount: z.coerce.number().int().min(0).optional(),
+    delegatee: z.string().trim().min(1).optional(),
+  })
+  .strict();
+
+export type TriggerConfig = z.infer<typeof triggerConfigSchema>;
+
+export const channelSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("in_app") }),
+  z.object({ type: z.literal("email"), address: z.string().trim().email() }),
+  z.object({ type: z.literal("webhook"), url: z.string().trim().url() }),
+  z.object({ type: z.literal("telegram"), chat_id: z.string().trim().min(1) }),
+]);
+
+export type NotificationChannel = z.infer<typeof channelSchema>;
+
+export const createRuleSchema = z.object({
+  name: z.string().trim().min(1).max(128),
+  trigger_type: z.enum(TRIGGER_TYPES),
+  trigger_config: triggerConfigSchema.optional().default({}),
+  channels: z.array(channelSchema).min(1).max(10),
+  enabled: z.boolean().optional().default(true),
+  cooldown_seconds: z.coerce.number().int().min(0).max(86400).optional().default(300),
+});
+
+export const updateRuleSchema = z.object({
+  name: z.string().trim().min(1).max(128).optional(),
+  trigger_type: z.enum(TRIGGER_TYPES).optional(),
+  trigger_config: triggerConfigSchema.optional(),
+  channels: z.array(channelSchema).min(1).max(10).optional(),
+  enabled: z.boolean().optional(),
+  cooldown_seconds: z.coerce.number().int().min(0).max(86400).optional(),
+});
+
+export interface NotificationRule {
+  id: number;
+  user_id: number;
+  name: string;
+  trigger_type: TriggerType;
+  trigger_config: TriggerConfig;
+  channels: NotificationChannel[];
+  enabled: boolean;
+  cooldown_seconds: number;
+  last_triggered_at: string | null;
+  trigger_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface IndexerEvent {
+  id: number;
+  event_type: string;
+  ledger: number;
+  transaction_hash: string | null;
+  contract_address: string;
+  payload: { topics: unknown[]; value: unknown; tx_hash?: string };
+  indexed_at: string;
+}
+
+interface NotificationRuleRow {
+  id: number;
+  user_id: number;
+  name: string;
+  trigger_type: TriggerType;
+  trigger_config: TriggerConfig | null;
+  channels: NotificationChannel[] | null;
+  enabled: boolean;
+  cooldown_seconds: number;
+  last_triggered_at: Date | string | null;
+  trigger_count: number;
+  created_at: Date | string;
+  updated_at: Date | string;
+}
+
+export function rowToRule(row: NotificationRuleRow): NotificationRule {
+  return {
+    id: row.id,
+    user_id: row.user_id,
+    name: row.name,
+    trigger_type: row.trigger_type,
+    trigger_config: row.trigger_config ?? {},
+    channels: row.channels ?? [],
+    enabled: row.enabled,
+    cooldown_seconds: row.cooldown_seconds,
+    last_triggered_at: row.last_triggered_at ? new Date(row.last_triggered_at).toISOString() : null,
+    trigger_count: row.trigger_count,
+    created_at: new Date(row.created_at).toISOString(),
+    updated_at: new Date(row.updated_at).toISOString(),
+  };
+}
+
+/**
+ * Maps a raw indexer `event_log.event_type` to the trigger type(s) a rule
+ * could match on. `proposal_state_changed` is matched separately by the
+ * engine (it also needs `to_state`), so it isn't listed here.
+ */
+export const EVENT_TYPE_TO_TRIGGER: Record<string, TriggerType[]> = {
+  ProposalCreated: ["proposal_created"],
+  VoteCast: ["vote_cast"],
+  VoteCastWithReason: ["vote_cast"],
+  ConfigUpdated: ["config_updated"],
+  GovernorUpgraded: ["contract_upgraded"],
+  DelegationRegistered: ["delegation_received"],
+  DelegationRevoked: ["delegation_lost"],
+};
+
+export const STATE_CHANGE_EVENTS: Record<string, ProposalState> = {
+  ProposalQueued: "Queued",
+  ProposalExecuted: "Executed",
+  ProposalCancelled: "Cancelled",
+};

--- a/backend/src/notifications/templates.ts
+++ b/backend/src/notifications/templates.ts
@@ -1,0 +1,138 @@
+import type { IndexerEvent, ProposalState, TriggerType } from "./rules";
+
+export interface NotificationMessage {
+  subject: string;
+  body: string;
+  /** Short single-line form for in-app / Telegram delivery. */
+  short: string;
+  actionUrl?: string;
+}
+
+function proposalUrl(proposalId: unknown): string | undefined {
+  if (proposalId === undefined || proposalId === null) return undefined;
+  return `/proposal/${proposalId}`;
+}
+
+function extractProposalId(event: IndexerEvent): unknown {
+  const value = event.payload.value;
+  if (value && typeof value === "object" && "proposal_id" in (value as Record<string, unknown>)) {
+    return (value as Record<string, unknown>).proposal_id;
+  }
+  if (Array.isArray(value)) return value[0];
+  // ProposalQueued/ProposalExecuted carry the id only in topics[1], not value.
+  return event.payload.topics?.[1];
+}
+
+function extractDelegateeAddress(event: IndexerEvent): string {
+  const value = event.payload.value;
+  return Array.isArray(value) ? String(value[0]) : "someone";
+}
+
+const TEMPLATES: Record<TriggerType, (event: IndexerEvent) => NotificationMessage> = {
+  proposal_created: (event) => {
+    const proposalId = extractProposalId(event);
+    return {
+      subject: `New proposal #${proposalId}`,
+      body: `A new governance proposal (#${proposalId}) has been created and is now visible on the dashboard.`,
+      short: `New proposal #${proposalId} created`,
+      actionUrl: proposalUrl(proposalId),
+    };
+  },
+  proposal_state_changed: (event) => {
+    const proposalId = extractProposalId(event);
+    return {
+      subject: `Proposal #${proposalId} update`,
+      body: `Proposal #${proposalId} changed state.`,
+      short: `Proposal #${proposalId} state changed`,
+      actionUrl: proposalUrl(proposalId),
+    };
+  },
+  proposal_vote_threshold: (event) => {
+    const proposalId = extractProposalId(event);
+    return {
+      subject: `Proposal #${proposalId} nearing quorum`,
+      body: `Proposal #${proposalId} has reached your configured vote threshold.`,
+      short: `Proposal #${proposalId} hit vote threshold`,
+      actionUrl: proposalUrl(proposalId),
+    };
+  },
+  proposal_ending_soon: (event) => {
+    const proposalId = extractProposalId(event);
+    return {
+      subject: `Voting closing soon: proposal #${proposalId}`,
+      body: `Voting on proposal #${proposalId} is ending soon. Cast your vote before it closes.`,
+      short: `Proposal #${proposalId} voting ends soon`,
+      actionUrl: proposalUrl(proposalId),
+    };
+  },
+  vote_cast: (event) => {
+    const proposalId = extractProposalId(event);
+    return {
+      subject: `New vote on proposal #${proposalId}`,
+      body: `A vote was cast on proposal #${proposalId}.`,
+      short: `Vote cast on #${proposalId}`,
+      actionUrl: proposalUrl(proposalId),
+    };
+  },
+  guardian_veto: () => ({
+    subject: "Guardian veto issued",
+    body: "A guardian veto was issued on a proposal you're watching.",
+    short: "Guardian veto issued",
+  }),
+  treasury_stream_spend: () => ({
+    subject: "Treasury stream spend",
+    body: "A spend was made from a treasury stream you own.",
+    short: "Treasury stream spend",
+  }),
+  config_updated: () => ({
+    subject: "Governor configuration updated",
+    body: "The governor's configuration parameters were updated.",
+    short: "Governor config updated",
+  }),
+  contract_paused: () => ({
+    subject: "Contract paused",
+    body: "A governance contract was paused.",
+    short: "Contract paused",
+  }),
+  contract_upgraded: () => ({
+    subject: "Governor upgraded",
+    body: "The governor contract was upgraded to a new implementation.",
+    short: "Governor upgraded",
+  }),
+  delegation_received: (event) => {
+    const delegator = String(event.payload.topics?.[1] ?? "someone");
+    return {
+      subject: "New delegation received",
+      body: `${delegator} delegated their voting power to ${extractDelegateeAddress(event)}.`,
+      short: "New delegation received",
+    };
+  },
+  delegation_lost: (event) => {
+    const delegator = String(event.payload.topics?.[1] ?? "A delegator");
+    return {
+      subject: "Delegation revoked",
+      body: `${delegator} revoked their delegation to ${extractDelegateeAddress(event)}.`,
+      short: "Delegation revoked",
+    };
+  },
+  quorum_reached: (event) => {
+    const proposalId = extractProposalId(event);
+    return {
+      subject: `Proposal #${proposalId} reached quorum`,
+      body: `Proposal #${proposalId} has reached quorum.`,
+      short: `Proposal #${proposalId} reached quorum`,
+      actionUrl: proposalUrl(proposalId),
+    };
+  },
+};
+
+export function renderNotification(
+  triggerType: TriggerType,
+  event: IndexerEvent,
+): NotificationMessage {
+  return TEMPLATES[triggerType](event);
+}
+
+export function proposalStateLabel(state: ProposalState): string {
+  return state;
+}

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -5,8 +5,46 @@ import pool from "../db/pool";
 import { authenticate, AuthRequest } from "../middleware/auth";
 import { validate } from "../middleware/validate";
 import { logger } from "../logger";
+import {
+  createRuleSchema,
+  rowToRule,
+  updateRuleSchema,
+  type NotificationRule,
+} from "../notifications/rules";
+import {
+  generateWebhookSecret,
+  notificationEngine,
+  type StoredNotificationChannel,
+} from "../notifications/engine";
+import { renderNotification } from "../notifications/templates";
 
 const router = Router();
+
+const idParamSchema = z.object({ id: z.coerce.number().int().min(1) });
+
+const listDeliveriesSchema = z.object({
+  limit: z.coerce.number().int().min(1).max(200).optional().default(50),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+  status: z.enum(["pending", "delivered", "failed", "retrying"]).optional(),
+});
+
+/** Masks generated webhook secrets before a rule is sent back to the client. */
+function maskRuleForOutput(rule: NotificationRule) {
+  const channels = (rule.channels as unknown as StoredNotificationChannel[]).map((channel) =>
+    channel.type === "webhook" ? { type: "webhook" as const, url: channel.url, secret: "***" } : channel,
+  );
+  return { ...rule, channels };
+}
+
+function attachGeneratedSecrets(
+  channels: z.infer<typeof createRuleSchema>["channels"],
+): StoredNotificationChannel[] {
+  return channels.map((channel) =>
+    channel.type === "webhook"
+      ? { type: "webhook" as const, url: channel.url, secret: generateWebhookSecret() }
+      : channel,
+  );
+}
 
 const PREF_KEYS = [
   "created_self",
@@ -257,6 +295,355 @@ router.post(
     } catch (error) {
       logger.error({ err: error }, "Error registering webhook");
       res.status(500).json({ error: "Failed to register webhook" });
+    }
+  },
+);
+
+// POST /notifications/rules - create a notification rule (auth required)
+router.post(
+  "/rules",
+  authenticate,
+  validate({ body: createRuleSchema }),
+  async (req: AuthRequest, res: Response) => {
+    const userId = req.userId!;
+    const body = req.body as z.infer<typeof createRuleSchema>;
+
+    try {
+      const channels = attachGeneratedSecrets(body.channels);
+      const inserted = await pool.query(
+        `INSERT INTO notification_rules (user_id, name, trigger_type, trigger_config, channels, enabled, cooldown_seconds)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         RETURNING *`,
+        [
+          userId,
+          body.name,
+          body.trigger_type,
+          JSON.stringify(body.trigger_config),
+          JSON.stringify(channels),
+          body.enabled,
+          body.cooldown_seconds,
+        ],
+      );
+
+      // Secrets are returned once, at creation time, so the caller can wire up
+      // signature verification — every later read masks them.
+      res.status(201).json(rowToRule(inserted.rows[0]));
+    } catch (error) {
+      logger.error({ err: error }, "Error creating notification rule");
+      res.status(500).json({ error: "Failed to create rule" });
+    }
+  },
+);
+
+// GET /notifications/rules - list the caller's rules (auth required)
+router.get("/rules", authenticate, async (req: AuthRequest, res: Response) => {
+  const userId = req.userId!;
+
+  try {
+    const result = await pool.query(
+      `SELECT * FROM notification_rules WHERE user_id = $1 ORDER BY created_at DESC`,
+      [userId],
+    );
+    res.json(result.rows.map(rowToRule).map(maskRuleForOutput));
+  } catch (error) {
+    logger.error({ err: error }, "Error listing notification rules");
+    res.status(500).json({ error: "Failed to list rules" });
+  }
+});
+
+// PUT /notifications/rules/:id - update a rule (auth required, owner only)
+router.put(
+  "/rules/:id",
+  authenticate,
+  validate({ params: idParamSchema, body: updateRuleSchema }),
+  async (req: AuthRequest, res: Response) => {
+    const userId = req.userId!;
+    const ruleId = (req.params as any).id as number;
+    const body = req.body as z.infer<typeof updateRuleSchema>;
+
+    try {
+      const existing = await pool.query(
+        `SELECT * FROM notification_rules WHERE id = $1 AND user_id = $2`,
+        [ruleId, userId],
+      );
+      if (existing.rowCount === 0) {
+        res.status(404).json({ error: "Rule not found" });
+        return;
+      }
+
+      const current = rowToRule(existing.rows[0]);
+      const channels = body.channels ? attachGeneratedSecrets(body.channels) : current.channels;
+
+      const updated = await pool.query(
+        `UPDATE notification_rules SET
+           name = $3, trigger_type = $4, trigger_config = $5, channels = $6,
+           enabled = $7, cooldown_seconds = $8, updated_at = NOW()
+         WHERE id = $1 AND user_id = $2
+         RETURNING *`,
+        [
+          ruleId,
+          userId,
+          body.name ?? current.name,
+          body.trigger_type ?? current.trigger_type,
+          JSON.stringify(body.trigger_config ?? current.trigger_config),
+          JSON.stringify(channels),
+          body.enabled ?? current.enabled,
+          body.cooldown_seconds ?? current.cooldown_seconds,
+        ],
+      );
+
+      res.json(maskRuleForOutput(rowToRule(updated.rows[0])));
+    } catch (error) {
+      logger.error({ err: error }, "Error updating notification rule");
+      res.status(500).json({ error: "Failed to update rule" });
+    }
+  },
+);
+
+// DELETE /notifications/rules/:id - delete a rule (auth required, owner only)
+router.delete(
+  "/rules/:id",
+  authenticate,
+  validate({ params: idParamSchema }),
+  async (req: AuthRequest, res: Response) => {
+    const userId = req.userId!;
+    const ruleId = (req.params as any).id as number;
+
+    try {
+      const result = await pool.query(
+        `DELETE FROM notification_rules WHERE id = $1 AND user_id = $2`,
+        [ruleId, userId],
+      );
+      if (result.rowCount === 0) {
+        res.status(404).json({ error: "Rule not found" });
+        return;
+      }
+      res.json({ ok: true });
+    } catch (error) {
+      logger.error({ err: error }, "Error deleting notification rule");
+      res.status(500).json({ error: "Failed to delete rule" });
+    }
+  },
+);
+
+// POST /notifications/rules/:id/test - deliver a sample notification through
+// all of the rule's channels without waiting for a matching on-chain event.
+router.post(
+  "/rules/:id/test",
+  authenticate,
+  validate({ params: idParamSchema }),
+  async (req: AuthRequest, res: Response) => {
+    const userId = req.userId!;
+    const ruleId = (req.params as any).id as number;
+
+    try {
+      const result = await pool.query(
+        `SELECT * FROM notification_rules WHERE id = $1 AND user_id = $2`,
+        [ruleId, userId],
+      );
+      if (result.rowCount === 0) {
+        res.status(404).json({ error: "Rule not found" });
+        return;
+      }
+
+      const rule = rowToRule(result.rows[0]);
+      const sampleEvent = {
+        id: 0,
+        event_type: "test",
+        ledger: 0,
+        transaction_hash: null,
+        contract_address: "test",
+        payload: { topics: ["test", "GTEST"], value: { proposal_id: "0" } },
+        indexed_at: new Date().toISOString(),
+      };
+      const message = renderNotification(rule.trigger_type, sampleEvent);
+      message.subject = `[Test] ${message.subject}`;
+      message.short = `[Test] ${message.short}`;
+
+      const channels = rule.channels as unknown as StoredNotificationChannel[];
+      const results = [];
+      for (const channel of channels) {
+        results.push(await notificationEngine.deliverNotification(rule, sampleEvent, channel, message));
+      }
+
+      res.json({ results });
+    } catch (error) {
+      logger.error({ err: error }, "Error sending test notification");
+      res.status(500).json({ error: "Failed to send test notification" });
+    }
+  },
+);
+
+// GET /notifications/inbox - paginated in-app notifications (auth required)
+router.get(
+  "/inbox",
+  authenticate,
+  validate({ query: listNotificationsSchema }),
+  async (req: AuthRequest, res: Response) => {
+    const userId = req.userId!;
+    const { limit, offset, unread_only: unreadOnly } = req.query as any;
+
+    try {
+      const whereUnread = unreadOnly ? "AND read = false" : "";
+      const rows = await pool.query(
+        `SELECT id, rule_id, title, body, action_url, read, created_at
+         FROM in_app_notifications
+         WHERE user_id = $1 ${whereUnread}
+         ORDER BY created_at DESC
+         LIMIT $2 OFFSET $3`,
+        [userId, limit, offset],
+      );
+
+      const count = await pool.query(
+        `SELECT COUNT(*)::int AS total,
+                SUM(CASE WHEN read = false THEN 1 ELSE 0 END)::int AS unread
+         FROM in_app_notifications
+         WHERE user_id = $1`,
+        [userId],
+      );
+
+      res.json({
+        data: rows.rows,
+        meta: {
+          total: count.rows[0]?.total ?? 0,
+          unread: count.rows[0]?.unread ?? 0,
+          limit,
+          offset,
+        },
+      });
+    } catch (error) {
+      logger.error({ err: error }, "Error fetching notification inbox");
+      res.status(500).json({ error: "Failed to fetch inbox" });
+    }
+  },
+);
+
+// PUT /notifications/inbox/:id/read - mark a single in-app notification read
+router.put(
+  "/inbox/:id/read",
+  authenticate,
+  validate({ params: idParamSchema }),
+  async (req: AuthRequest, res: Response) => {
+    const userId = req.userId!;
+    const id = (req.params as any).id as number;
+
+    try {
+      const result = await pool.query(
+        `UPDATE in_app_notifications SET read = true WHERE id = $1 AND user_id = $2 RETURNING id`,
+        [id, userId],
+      );
+      if (result.rowCount === 0) {
+        res.status(404).json({ error: "Notification not found" });
+        return;
+      }
+      res.json({ ok: true });
+    } catch (error) {
+      logger.error({ err: error }, "Error marking inbox notification read");
+      res.status(500).json({ error: "Failed to mark read" });
+    }
+  },
+);
+
+// PUT /notifications/inbox/read-all - mark all in-app notifications read
+router.put("/inbox/read-all", authenticate, async (req: AuthRequest, res: Response) => {
+  const userId = req.userId!;
+
+  try {
+    await pool.query(
+      `UPDATE in_app_notifications SET read = true WHERE user_id = $1 AND read = false`,
+      [userId],
+    );
+    res.json({ ok: true });
+  } catch (error) {
+    logger.error({ err: error }, "Error marking all inbox notifications read");
+    res.status(500).json({ error: "Failed to mark all read" });
+  }
+});
+
+// GET /notifications/deliveries - delivery history with status (auth required)
+router.get(
+  "/deliveries",
+  authenticate,
+  validate({ query: listDeliveriesSchema }),
+  async (req: AuthRequest, res: Response) => {
+    const userId = req.userId!;
+    const { limit, offset, status } = req.query as any;
+
+    try {
+      const whereStatus = status ? "AND status = $4" : "";
+      const params = status ? [userId, limit, offset, status] : [userId, limit, offset];
+      const rows = await pool.query(
+        `SELECT id, rule_id, event_type, channel_type, status, attempts,
+                last_attempt_at, next_retry_at, delivered_at, error_message, created_at
+         FROM notification_deliveries
+         WHERE user_id = $1 ${whereStatus}
+         ORDER BY created_at DESC
+         LIMIT $2 OFFSET $3`,
+        params,
+      );
+      res.json({ data: rows.rows, meta: { limit, offset } });
+    } catch (error) {
+      logger.error({ err: error }, "Error fetching delivery history");
+      res.status(500).json({ error: "Failed to fetch deliveries" });
+    }
+  },
+);
+
+// GET /notifications/deliveries/:id/retry - force an immediate retry of a failed delivery
+router.get(
+  "/deliveries/:id/retry",
+  authenticate,
+  validate({ params: idParamSchema }),
+  async (req: AuthRequest, res: Response) => {
+    const userId = req.userId!;
+    const id = (req.params as any).id as number;
+
+    try {
+      const result = await pool.query(
+        `SELECT nd.*, nr.channels
+         FROM notification_deliveries nd
+         JOIN notification_rules nr ON nr.id = nd.rule_id
+         WHERE nd.id = $1 AND nd.user_id = $2`,
+        [id, userId],
+      );
+      if (result.rowCount === 0) {
+        res.status(404).json({ error: "Delivery not found" });
+        return;
+      }
+
+      const delivery = result.rows[0];
+      if (delivery.status !== "failed" && delivery.status !== "retrying") {
+        res.status(400).json({ error: `Cannot retry a delivery with status '${delivery.status}'` });
+        return;
+      }
+
+      const channels = (delivery.channels ?? []) as StoredNotificationChannel[];
+      const channel = channels.find((c) => c.type === delivery.channel_type);
+      if (!channel) {
+        res.status(410).json({ error: "Delivery channel no longer exists on the rule" });
+        return;
+      }
+
+      const ruleResult = await pool.query(`SELECT * FROM notification_rules WHERE id = $1`, [
+        delivery.rule_id,
+      ]);
+      const rule = rowToRule(ruleResult.rows[0]);
+      const event = {
+        id: 0,
+        event_type: delivery.event_type,
+        ledger: 0,
+        transaction_hash: null,
+        contract_address: "",
+        payload: delivery.event_payload,
+        indexed_at: new Date().toISOString(),
+      };
+      const message = renderNotification(rule.trigger_type, event);
+      const outcome = await notificationEngine.attemptDelivery(id, rule, event, channel, message);
+
+      res.json(outcome);
+    } catch (error) {
+      logger.error({ err: error }, "Error retrying notification delivery");
+      res.status(500).json({ error: "Failed to retry delivery" });
     }
   },
 );

--- a/packages/indexer/migrations/006_add_notification_event_log.sql
+++ b/packages/indexer/migrations/006_add_notification_event_log.sql
@@ -1,0 +1,18 @@
+-- Up Migration
+
+CREATE TABLE event_log (
+    id BIGSERIAL PRIMARY KEY,
+    event_type VARCHAR(64) NOT NULL,
+    ledger INTEGER NOT NULL,
+    transaction_hash VARCHAR(64),
+    contract_address VARCHAR(56) NOT NULL,
+    payload JSONB NOT NULL,
+    indexed_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_event_log_type_ledger ON event_log(event_type, ledger);
+CREATE INDEX idx_event_log_indexed_at ON event_log(indexed_at);
+
+-- Down Migration
+
+DROP TABLE IF EXISTS event_log;

--- a/packages/indexer/src/events.ts
+++ b/packages/indexer/src/events.ts
@@ -137,6 +137,12 @@ export async function processEvents(
       );
 
       try {
+        await logToEventLog(eventType, ledger, contractId, event, topics);
+      } catch (err) {
+        console.error(`Failed to write event_log entry for ${eventType}:`, err);
+      }
+
+      try {
         if (isTreasury) {
           switch (eventType) {
             case "bat_xfer":
@@ -266,6 +272,32 @@ export async function processEvents(
   }
 
   return latestLedger;
+}
+
+/**
+ * Persists every parsed governance event to `event_log`, independent of
+ * whether a dedicated handler exists for its type. This is the durable feed
+ * the backend's notification engine polls to evaluate user-defined rules
+ * (issue #774) without needing its own RPC subscription.
+ */
+async function logToEventLog(
+  eventType: string,
+  ledger: number,
+  contractAddress: string | undefined,
+  event: SorobanRpc.Api.EventResponse,
+  topics: unknown[],
+): Promise<void> {
+  const payload = {
+    topics,
+    value: scValToNative(event.value),
+    tx_hash: event.txHash,
+  };
+
+  await pool.query(
+    `INSERT INTO event_log (event_type, ledger, transaction_hash, contract_address, payload)
+     VALUES ($1, $2, $3, $4, $5)`,
+    [eventType, ledger, event.txHash ?? null, contractAddress ?? "", stringifyJson(payload)],
+  );
 }
 
 async function handleProposalCreated(


### PR DESCRIPTION
Closes #774.

## Summary

Governance participants currently have no way to be notified about proposal/vote/delegation events other than manually polling the dashboard. This adds a rule-based notification engine spanning the indexer, backend, and frontend.

- **Indexer**: new `event_log` table (migration `006_add_notification_event_log.sql`), populated for every parsed governance event so the backend can react without its own RPC subscription.
- **Backend**: `notification_rules` / `notification_deliveries` / `in_app_notifications` schema (migration `008_add_notification_engine.sql`); a `NotificationEngine` that matches rules against events (proposer / voter / to_state / delegatee / proposal_id filters, per-rule cooldown) and delivers via in-app, email, HMAC-signed webhook, or Telegram, with exponential-backoff retries; rules CRUD + test endpoint + inbox + delivery-history API under `/notifications/*`; two background jobs (`notification-processor`, `delivery-retry`) wired into `bootstrap()`.
- **Frontend**: `NotificationBell` in the nav header, a step-by-step `NotificationRuleBuilder` wizard, and a `/notifications/rules` management page.

## Scope boundaries (documented, not faked)

`guardian_veto`, `treasury_stream_spend`, and `contract_paused` are valid, storable trigger types, but nothing currently emits those events on-chain/indexed, so rules using them won't fire yet. `proposal_vote_threshold` and `quorum_reached` are similarly accepted but not evaluated by the periodic scanner — computing "% of quorum" needs total-voting-supply data the indexed schema doesn't currently snapshot. Documented inline in `rules.ts` and `notification-processor.ts` rather than approximated with fabricated numbers.

## Testing

- `tsc --noEmit` passes clean across `backend`, `packages/indexer`, and `app`.
- `eslint` passes clean on the new/changed frontend files.
- New pure-logic unit tests (`backend/src/__tests__/notification-engine.test.ts`) covering rule-matching and template rendering: 21/21 passing locally.
- New integration tests for the rules/inbox/deliveries endpoints added to `backend/src/__tests__/notifications.test.ts`, following the existing file's conventions — these need the Postgres service CI already provisions for backend tests to run; I didn't have a local Postgres/Docker available to execute them myself, so please give the CI run a look.

## Test plan

- [ ] CI: indexer + backend migrations apply cleanly
- [ ] CI: backend test suite (including new rules/inbox/deliveries tests) passes
- [ ] Manual: create a rule via the UI wizard, hit "Test", confirm it lands in the in-app inbox and the bell badge updates