### PR TITLE
feat(frontend): add client-side Stellar address validation to delegatee/owner/recipient inputs

### DIFF
--- a/app/src/components/CreateStreamModal.tsx
+++ b/app/src/components/CreateStreamModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import toast from "react-hot-toast";
 import type { TreasuryClient } from "../lib/treasury-client";
+import { isValidStellarAddress } from "../lib/utils/stellarAddress";
 
 interface CreateStreamModalProps {
   client: TreasuryClient;
@@ -23,6 +24,7 @@ export function CreateStreamModal({
 }: CreateStreamModalProps) {
   const [name, setName] = useState("");
   const [owner, setOwner] = useState("");
+  const [ownerError, setOwnerError] = useState("");
   const [totalAllocated, setTotalAllocated] = useState("");
   const [maxSingleSpend, setMaxSingleSpend] = useState("");
   const [startLedger, setStartLedger] = useState("");
@@ -35,6 +37,10 @@ export function CreateStreamModal({
     e.preventDefault();
     if (!name || !owner || !totalAllocated || !maxSingleSpend || !startLedger || !endLedger) {
       toast.error("Please fill in all required fields");
+      return;
+    }
+    if (!isValidStellarAddress(owner)) {
+      setOwnerError("Invalid Stellar address.");
       return;
     }
 
@@ -84,11 +90,19 @@ export function CreateStreamModal({
             <input
               type="text"
               value={owner}
-              onChange={(e) => setOwner(e.target.value)}
+              onChange={(e) => { setOwner(e.target.value); setOwnerError(""); }}
+              onBlur={(e) => {
+                if (e.target.value && !isValidStellarAddress(e.target.value))
+                  setOwnerError("Invalid Stellar address.");
+                else setOwnerError("");
+              }}
               placeholder="G..."
-              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm font-mono"
+              className={`w-full border rounded-md px-3 py-2 text-sm font-mono ${
+                ownerError ? "border-red-400" : "border-gray-300"
+              }`}
               required
             />
+            {ownerError && <p className="text-xs text-red-500 mt-1">{ownerError}</p>}
           </div>
           <div className="grid grid-cols-2 gap-3">
             <div>
@@ -170,7 +184,7 @@ export function CreateStreamModal({
             </button>
             <button
               type="submit"
-              disabled={submitting}
+              disabled={submitting || !!ownerError}
               className="flex-1 bg-indigo-600 text-white rounded-md py-2 text-sm hover:bg-indigo-700 disabled:opacity-50"
             >
               {submitting ? "Creating..." : "Create Stream"}

--- a/app/src/components/DelegateModal.tsx
+++ b/app/src/components/DelegateModal.tsx
@@ -6,6 +6,7 @@
 
 import { useEffect, useState, type FormEvent } from "react";
 import { Keypair } from "@stellar/stellar-sdk";
+import { isValidStellarAddress } from "../lib/utils/stellarAddress";
 import toast from "react-hot-toast";
 import { VotesClient, type Network } from "@nebgov/sdk";
 import { useWallet } from "../lib/wallet-context";
@@ -68,6 +69,7 @@ export function DelegateModal({
   onOpenGasless,
 }: Props) {
   const [delegatee, setDelegatee] = useState(prefillAddress || "");
+  const [delegateeError, setDelegateeError] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const { isConnected, publicKey } = useWallet();
 
@@ -82,9 +84,22 @@ export function DelegateModal({
     Boolean(publicKey) &&
     currentDelegatee !== publicKey;
 
+  function validateDelegatee(value: string) {
+    if (!value.trim()) {
+      setDelegateeError("Address is required.");
+      return false;
+    }
+    if (!isValidStellarAddress(value)) {
+      setDelegateeError("Invalid Stellar address.");
+      return false;
+    }
+    setDelegateeError("");
+    return true;
+  }
+
   async function handleDelegate(e: FormEvent) {
     e.preventDefault();
-    if (!delegatee.trim()) return;
+    if (!validateDelegatee(delegatee)) return;
 
     setSubmitting(true);
     try {
@@ -184,10 +199,16 @@ export function DelegateModal({
             type="text"
             placeholder="Stellar address (G...)"
             value={delegatee}
-            onChange={(e) => setDelegatee(e.target.value)}
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 font-mono"
+            onChange={(e) => { setDelegatee(e.target.value); setDelegateeError(""); }}
+            onBlur={(e) => validateDelegatee(e.target.value)}
+            className={`w-full border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 font-mono ${
+              delegateeError ? "border-red-400" : "border-gray-300"
+            }`}
             required
           />
+          {delegateeError && (
+            <p className="text-xs text-red-500 mt-1">{delegateeError}</p>
+          )}
 
           <div className="flex gap-3">
             <button
@@ -199,7 +220,7 @@ export function DelegateModal({
             </button>
             <button
               type="submit"
-              disabled={submitting}
+              disabled={submitting || !!delegateeError || !delegatee.trim()}
               className="flex-1 bg-indigo-600 text-white py-2 rounded-lg text-sm font-medium hover:bg-indigo-700 disabled:opacity-50"
             >
               {submitting ? "Delegating..." : "Delegate"}

--- a/app/src/components/GaslessDelegateModal.tsx
+++ b/app/src/components/GaslessDelegateModal.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState, type FormEvent } from "react";
 import toast from "react-hot-toast";
 import type { TopDelegate } from "@nebgov/sdk";
 import { useWallet } from "../lib/wallet-context";
+import { isValidStellarAddress } from "../lib/utils/stellarAddress";
 import {
   useGaslessDelegation,
   EXPIRY_PRESET_LABELS,
@@ -43,6 +44,7 @@ export function GaslessDelegateModal({
   topDelegates,
 }: Props) {
   const [delegatee, setDelegatee] = useState(prefillAddress || "");
+  const [delegateeError, setDelegateeError] = useState("");
   const [expiryPreset, setExpiryPreset] = useState<ExpiryPreset>("1month");
   const { isConnected, publicKey, connect } = useWallet();
   const { delegateGasless, submitting } = useGaslessDelegation();
@@ -53,9 +55,22 @@ export function GaslessDelegateModal({
 
   if (!open) return null;
 
+  function validateDelegatee(value: string) {
+    if (!value.trim()) {
+      setDelegateeError("Address is required.");
+      return false;
+    }
+    if (!isValidStellarAddress(value)) {
+      setDelegateeError("Invalid Stellar address.");
+      return false;
+    }
+    setDelegateeError("");
+    return true;
+  }
+
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    if (!delegatee.trim()) return;
+    if (!validateDelegatee(delegatee)) return;
 
     try {
       if (!isConnected || !publicKey) {
@@ -116,10 +131,16 @@ export function GaslessDelegateModal({
               type="text"
               placeholder="Stellar address (G...)"
               value={delegatee}
-              onChange={(e) => setDelegatee(e.target.value)}
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 font-mono"
+              onChange={(e) => { setDelegatee(e.target.value); setDelegateeError(""); }}
+              onBlur={(e) => validateDelegatee(e.target.value)}
+              className={`w-full border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 font-mono ${
+                delegateeError ? "border-red-400" : "border-gray-300"
+              }`}
               required
             />
+            {delegateeError && (
+              <p className="text-xs text-red-500 mt-1">{delegateeError}</p>
+            )}
             {topDelegates && topDelegates.length > 0 && (
               <div className="mt-2 flex flex-wrap gap-1.5">
                 {topDelegates.slice(0, 5).map((d) => (
@@ -168,7 +189,7 @@ export function GaslessDelegateModal({
             </button>
             <button
               type="submit"
-              disabled={submitting || !delegatee.trim() || !isConnected}
+              disabled={submitting || !delegatee.trim() || !!delegateeError || !isConnected}
               className="flex-1 bg-green-600 text-white py-2 rounded-lg text-sm font-medium hover:bg-green-700 disabled:opacity-50"
             >
               {submitting ? "Signing…" : "Delegate for free"}

--- a/app/src/components/StreamSpendModal.tsx
+++ b/app/src/components/StreamSpendModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import toast from "react-hot-toast";
 import type { TreasuryClient, TreasuryBudgetStream } from "../lib/treasury-client";
+import { isValidStellarAddress } from "../lib/utils/stellarAddress";
 
 interface StreamSpendModalProps {
   client: TreasuryClient;
@@ -22,6 +23,7 @@ export function StreamSpendModal({
   onSpent,
 }: StreamSpendModalProps) {
   const [recipient, setRecipient] = useState("");
+  const [recipientError, setRecipientError] = useState("");
   const [amount, setAmount] = useState("");
   const [memo, setMemo] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -32,6 +34,10 @@ export function StreamSpendModal({
     e.preventDefault();
     if (!recipient || !amount) {
       toast.error("Please fill in recipient and amount");
+      return;
+    }
+    if (!isValidStellarAddress(recipient)) {
+      setRecipientError("Invalid Stellar address.");
       return;
     }
 
@@ -78,11 +84,19 @@ export function StreamSpendModal({
             <input
               type="text"
               value={recipient}
-              onChange={(e) => setRecipient(e.target.value)}
+              onChange={(e) => { setRecipient(e.target.value); setRecipientError(""); }}
+              onBlur={(e) => {
+                if (e.target.value && !isValidStellarAddress(e.target.value))
+                  setRecipientError("Invalid Stellar address.");
+                else setRecipientError("");
+              }}
               placeholder="G..."
-              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm font-mono"
+              className={`w-full border rounded-md px-3 py-2 text-sm font-mono ${
+                recipientError ? "border-red-400" : "border-gray-300"
+              }`}
               required
             />
+            {recipientError && <p className="text-xs text-red-500 mt-1">{recipientError}</p>}
           </div>
           <div>
             <label className="text-xs text-gray-500">Amount</label>
@@ -115,7 +129,7 @@ export function StreamSpendModal({
             </button>
             <button
               type="submit"
-              disabled={submitting || !stream.isActive}
+              disabled={submitting || !stream.isActive || !!recipientError}
               className="flex-1 bg-indigo-600 text-white rounded-md py-2 text-sm hover:bg-indigo-700 disabled:opacity-50"
             >
               {submitting ? "Spending..." : "Execute Spend"}

--- a/app/src/components/__tests__/CreateStreamModal.validation.test.tsx
+++ b/app/src/components/__tests__/CreateStreamModal.validation.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CreateStreamModal } from "../CreateStreamModal";
+import type { TreasuryClient } from "../../lib/treasury-client";
+
+const VALID_ADDRESS = "GDOOXICJPSOZDQRCEHZPR6MAX5PUZXVWGJ3QPVEU4DADIZQ4YBQOJNIB";
+const VALID_ADDRESS_2 = "GD6HLZWRE5FHK3SDLZB3FH56R3H3ECAAYCPWWU7O7EK4FCNT2Z7S6D5I";
+
+jest.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: { success: jest.fn(), error: jest.fn() },
+}));
+
+const mockCreateStream = jest.fn().mockResolvedValue(undefined);
+const mockClient = {
+  createStream: mockCreateStream,
+} as unknown as TreasuryClient;
+
+const defaultProps = {
+  client: mockClient,
+  signerPublicKey: VALID_ADDRESS_2,
+  tokenAddress: "CTOKEN123",
+  signUnsignedXdr: jest.fn().mockResolvedValue("signed_xdr"),
+  onClose: jest.fn(),
+  onCreated: jest.fn(),
+};
+
+function fillRequiredFields(except?: string) {
+  if (except !== "name") {
+    fireEvent.change(screen.getByPlaceholderText("engineering"), { target: { value: "dev" } });
+  }
+  if (except !== "owner") {
+    fireEvent.change(screen.getByPlaceholderText("G..."), { target: { value: VALID_ADDRESS } });
+  }
+  if (except !== "totalAllocated") {
+    fireEvent.change(screen.getByPlaceholderText("1000000"), { target: { value: "1000000" } });
+  }
+  if (except !== "maxSingleSpend") {
+    fireEvent.change(screen.getByPlaceholderText("500000"), { target: { value: "500000" } });
+  }
+  if (except !== "startLedger") {
+    fireEvent.change(screen.getByPlaceholderText("1"), { target: { value: "100" } });
+  }
+  if (except !== "endLedger") {
+    fireEvent.change(screen.getByPlaceholderText("100000"), { target: { value: "200000" } });
+  }
+}
+
+describe("CreateStreamModal — Stellar address validation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("rendering", () => {
+    it("renders the owner address input", () => {
+      render(<CreateStreamModal {...defaultProps} />);
+      expect(screen.getByPlaceholderText("G...")).toBeInTheDocument();
+    });
+
+    it("renders the Owner Address label", () => {
+      render(<CreateStreamModal {...defaultProps} />);
+      expect(screen.getByText("Owner Address")).toBeInTheDocument();
+    });
+
+    it("renders the Create Stream submit button", () => {
+      render(<CreateStreamModal {...defaultProps} />);
+      expect(screen.getByRole("button", { name: /create stream/i })).toBeInTheDocument();
+    });
+
+    it("submit button is enabled by default (no pre-validation)", () => {
+      render(<CreateStreamModal {...defaultProps} />);
+      const btn = screen.getByRole("button", { name: /create stream/i });
+      expect(btn).not.toBeDisabled();
+    });
+  });
+
+  describe("blur validation", () => {
+    it("shows error on blur when owner address is invalid", async () => {
+      render(<CreateStreamModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, "GBADADDRESS");
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument();
+      });
+    });
+
+    it("shows error on blur for lowercase address", async () => {
+      render(<CreateStreamModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, VALID_ADDRESS.toLowerCase());
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument();
+      });
+    });
+
+    it("shows error on blur for address with wrong prefix", async () => {
+      render(<CreateStreamModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, "SDOOXICJPSOZDQRCEHZPR6MAX5PUZXVWGJ3QPVEU4DADIZQ4YBQOJNIB");
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument();
+      });
+    });
+
+    it("does not show error on blur when address is valid", async () => {
+      render(<CreateStreamModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, VALID_ADDRESS);
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(screen.queryByText("Invalid Stellar address.")).not.toBeInTheDocument();
+      });
+    });
+
+    it("does not show error on blur when field is empty (required handled by toast)", async () => {
+      render(<CreateStreamModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(screen.queryByText("Invalid Stellar address.")).not.toBeInTheDocument();
+      });
+    });
+
+    it("clears error when user types a valid address after an invalid one", async () => {
+      render(<CreateStreamModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, "GBAD");
+      fireEvent.blur(input);
+      await waitFor(() => expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument());
+      await userEvent.clear(input);
+      await userEvent.type(input, VALID_ADDRESS);
+      await waitFor(() => expect(screen.queryByText("Invalid Stellar address.")).not.toBeInTheDocument());
+    });
+
+    it("applies red border when address is invalid after blur", async () => {
+      render(<CreateStreamModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, "GBAD");
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(input.className).toContain("border-red-400");
+      });
+    });
+
+    it("does not apply red border when address is valid", async () => {
+      render(<CreateStreamModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, VALID_ADDRESS);
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(input.className).not.toContain("border-red-400");
+      });
+    });
+  });
+
+  describe("submit validation", () => {
+    it("blocks submit and shows error when owner address is invalid", async () => {
+      render(<CreateStreamModal {...defaultProps} />);
+      fillRequiredFields("owner");
+      fireEvent.change(screen.getByPlaceholderText("G..."), { target: { value: "GBADADDRESS" } });
+      const form = screen.getByRole("button", { name: /create stream/i }).closest("form")!;
+      fireEvent.submit(form);
+      await waitFor(() => {
+        expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument();
+      });
+      expect(mockCreateStream).not.toHaveBeenCalled();
+    });
+
+    it("blocks submit when owner address has wrong prefix", async () => {
+      render(<CreateStreamModal {...defaultProps} />);
+      fillRequiredFields("owner");
+      fireEvent.change(screen.getByPlaceholderText("G..."), {
+        target: { value: "ADOOXICJPSOZDQRCEHZPR6MAX5PUZXVWGJ3QPVEU4DADIZQ4YBQOJNIB" },
+      });
+      const form = screen.getByRole("button", { name: /create stream/i }).closest("form")!;
+      fireEvent.submit(form);
+      await waitFor(() => {
+        expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument();
+      });
+      expect(mockCreateStream).not.toHaveBeenCalled();
+    });
+
+    it("submit button is disabled while there is a validation error", async () => {
+      render(<CreateStreamModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, "GBAD");
+      fireEvent.blur(input);
+      await waitFor(() => {
+        const btn = screen.getByRole("button", { name: /create stream/i });
+        expect(btn).toBeDisabled();
+      });
+    });
+
+    it("submit button is re-enabled after error is cleared", async () => {
+      render(<CreateStreamModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, "GBAD");
+      fireEvent.blur(input);
+      await waitFor(() => expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument());
+      await userEvent.clear(input);
+      await userEvent.type(input, VALID_ADDRESS);
+      await waitFor(() => {
+        const btn = screen.getByRole("button", { name: /create stream/i });
+        expect(btn).not.toBeDisabled();
+      });
+    });
+  });
+
+  describe("cancel", () => {
+    it("calls onClose when Cancel is clicked", async () => {
+      const onClose = jest.fn();
+      render(<CreateStreamModal {...defaultProps} onClose={onClose} />);
+      await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/app/src/components/__tests__/DelegateModal.validation.test.tsx
+++ b/app/src/components/__tests__/DelegateModal.validation.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DelegateModal } from "../DelegateModal";
+
+const VALID_ADDRESS = "GDOOXICJPSOZDQRCEHZPR6MAX5PUZXVWGJ3QPVEU4DADIZQ4YBQOJNIB";
+const VALID_ADDRESS_2 = "GD6HLZWRE5FHK3SDLZB3FH56R3H3ECAAYCPWWU7O7EK4FCNT2Z7S6D5I";
+
+jest.mock("../lib/wallet-context", () => ({
+  useWallet: () => ({
+    isConnected: true,
+    publicKey: VALID_ADDRESS_2,
+    connect: jest.fn(),
+  }),
+}));
+
+jest.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: { success: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock("@nebgov/sdk", () => ({
+  VotesClient: jest.fn().mockImplementation(() => ({
+    delegate: jest.fn().mockResolvedValue("txhash123"),
+    undelegate: jest.fn().mockResolvedValue("txhash456"),
+  })),
+}));
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const actual = jest.requireActual("@stellar/stellar-sdk");
+  return {
+    ...actual,
+    Keypair: {
+      fromSecret: jest.fn().mockReturnValue({ publicKey: () => VALID_ADDRESS_2 }),
+    },
+  };
+});
+
+const defaultProps = {
+  open: true,
+  onClose: jest.fn(),
+  onDelegated: jest.fn(),
+};
+
+describe("DelegateModal — Stellar address validation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_GOVERNOR_ADDRESS = "CTEST_GOV";
+    process.env.NEXT_PUBLIC_TIMELOCK_ADDRESS = "CTEST_TL";
+    process.env.NEXT_PUBLIC_VOTES_ADDRESS = "CTEST_VOTES";
+    process.env.NEXT_PUBLIC_DELEGATE_SECRET_KEY = "SCZANGBA5RLKJRDNKPNM5HXJFKZGKZAZBCM5YWKZQKZQKZQKZQKZQKZ";
+  });
+
+  describe("rendering", () => {
+    it("renders the delegatee input", () => {
+      render(<DelegateModal {...defaultProps} />);
+      expect(screen.getByPlaceholderText("Stellar address (G...)")).toBeInTheDocument();
+    });
+
+    it("does not render when open is false", () => {
+      render(<DelegateModal {...defaultProps} open={false} />);
+      expect(screen.queryByPlaceholderText("Stellar address (G...)")).not.toBeInTheDocument();
+    });
+
+    it("prefills the delegatee input when prefillAddress is provided", () => {
+      render(<DelegateModal {...defaultProps} prefillAddress={VALID_ADDRESS} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)") as HTMLInputElement;
+      expect(input.value).toBe(VALID_ADDRESS);
+    });
+
+    it("renders the Delegate submit button", () => {
+      render(<DelegateModal {...defaultProps} />);
+      expect(screen.getByRole("button", { name: /delegate$/i })).toBeInTheDocument();
+    });
+
+    it("submit button is disabled when input is empty", () => {
+      render(<DelegateModal {...defaultProps} />);
+      const btn = screen.getByRole("button", { name: /delegate$/i });
+      expect(btn).toBeDisabled();
+    });
+  });
+
+  describe("blur validation", () => {
+    it("shows error on blur when address is empty", async () => {
+      render(<DelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(screen.getByText("Address is required.")).toBeInTheDocument();
+      });
+    });
+
+    it("shows error on blur when address is invalid", async () => {
+      render(<DelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      await userEvent.type(input, "GBADADDRESS");
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument();
+      });
+    });
+
+    it("shows error on blur for lowercase address", async () => {
+      render(<DelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      await userEvent.type(input, VALID_ADDRESS.toLowerCase());
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument();
+      });
+    });
+
+    it("shows error on blur for address missing G prefix", async () => {
+      render(<DelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      await userEvent.type(input, "ADOOXICJPSOZDQRCEHZPR6MAX5PUZXVWGJ3QPVEU4DADIZQ4YBQOJNIB");
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument();
+      });
+    });
+
+    it("clears error when a valid address is typed after an invalid one", async () => {
+      render(<DelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      await userEvent.type(input, "GBAD");
+      fireEvent.blur(input);
+      await waitFor(() => expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument());
+      await userEvent.clear(input);
+      await userEvent.type(input, VALID_ADDRESS);
+      await waitFor(() => expect(screen.queryByText("Invalid Stellar address.")).not.toBeInTheDocument());
+    });
+
+    it("does not show error before the user has interacted with the input", () => {
+      render(<DelegateModal {...defaultProps} />);
+      expect(screen.queryByText("Invalid Stellar address.")).not.toBeInTheDocument();
+      expect(screen.queryByText("Address is required.")).not.toBeInTheDocument();
+    });
+
+    it("applies red border class when address is invalid after blur", async () => {
+      render(<DelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      await userEvent.type(input, "GBAD");
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(input.className).toContain("border-red-400");
+      });
+    });
+
+    it("does not apply red border when address is valid", async () => {
+      render(<DelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      await userEvent.type(input, VALID_ADDRESS);
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(input.className).not.toContain("border-red-400");
+      });
+    });
+  });
+
+  describe("submit validation", () => {
+    it("blocks submit and shows error when address is empty", async () => {
+      render(<DelegateModal {...defaultProps} />);
+      const form = screen.getByRole("button", { name: /delegate$/i }).closest("form")!;
+      fireEvent.submit(form);
+      await waitFor(() => {
+        expect(screen.getByText("Address is required.")).toBeInTheDocument();
+      });
+    });
+
+    it("blocks submit and shows error when address is invalid", async () => {
+      render(<DelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      await userEvent.type(input, "GBADADDRESS");
+      const form = input.closest("form")!;
+      fireEvent.submit(form);
+      await waitFor(() => {
+        expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument();
+      });
+    });
+
+    it("submit button is disabled while there is a validation error", async () => {
+      render(<DelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      await userEvent.type(input, "GBAD");
+      fireEvent.blur(input);
+      await waitFor(() => {
+        const btn = screen.getByRole("button", { name: /delegate$/i });
+        expect(btn).toBeDisabled();
+      });
+    });
+
+    it("submit button is enabled when a valid address is entered", async () => {
+      render(<DelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      await userEvent.type(input, VALID_ADDRESS);
+      const btn = screen.getByRole("button", { name: /delegate$/i });
+      expect(btn).not.toBeDisabled();
+    });
+  });
+
+  describe("delegate-to-myself shortcut", () => {
+    it("fills the input with the connected wallet address", async () => {
+      render(<DelegateModal {...defaultProps} />);
+      const selfBtn = screen.getByRole("button", { name: /delegate to myself/i });
+      await userEvent.click(selfBtn);
+      const input = screen.getByPlaceholderText("Stellar address (G...)") as HTMLInputElement;
+      expect(input.value).toBe(VALID_ADDRESS_2);
+    });
+
+    it("clears any existing validation error when self-fill is used", async () => {
+      render(<DelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      await userEvent.type(input, "GBAD");
+      fireEvent.blur(input);
+      await waitFor(() => expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument());
+      const selfBtn = screen.getByRole("button", { name: /delegate to myself/i });
+      await userEvent.click(selfBtn);
+      await waitFor(() => expect(screen.queryByText("Invalid Stellar address.")).not.toBeInTheDocument());
+    });
+  });
+
+  describe("cancel", () => {
+    it("calls onClose when Cancel is clicked", async () => {
+      const onClose = jest.fn();
+      render(<DelegateModal {...defaultProps} onClose={onClose} />);
+      await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/app/src/components/__tests__/GaslessDelegateModal.validation.test.tsx
+++ b/app/src/components/__tests__/GaslessDelegateModal.validation.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GaslessDelegateModal } from "../GaslessDelegateModal";
+
+const VALID_ADDRESS = "GDOOXICJPSOZDQRCEHZPR6MAX5PUZXVWGJ3QPVEU4DADIZQ4YBQOJNIB";
+const VALID_ADDRESS_2 = "GD6HLZWRE5FHK3SDLZB3FH56R3H3ECAAYCPWWU7O7EK4FCNT2Z7S6D5I";
+
+jest.mock("../lib/wallet-context", () => ({
+  useWallet: () => ({
+    isConnected: true,
+    publicKey: VALID_ADDRESS_2,
+    connect: jest.fn(),
+  }),
+}));
+
+jest.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: { success: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock("../hooks/useGaslessDelegation", () => ({
+  useGaslessDelegation: () => ({
+    delegateGasless: jest.fn().mockResolvedValue({ txHash: "txhash789" }),
+    submitting: false,
+  }),
+  EXPIRY_PRESET_LABELS: {
+    "1week": "1 week",
+    "1month": "1 month",
+    "6months": "6 months",
+    "1year": "1 year",
+  },
+}));
+
+const defaultProps = {
+  open: true,
+  onClose: jest.fn(),
+  onDelegated: jest.fn(),
+};
+
+describe("GaslessDelegateModal — Stellar address validation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("rendering", () => {
+    it("renders the delegatee input", () => {
+      render(<GaslessDelegateModal {...defaultProps} />);
+      expect(screen.getByPlaceholderText("Stellar address (G...)")).toBeInTheDocument();
+    });
+
+    it("does not render when open is false", () => {
+      render(<GaslessDelegateModal {...defaultProps} open={false} />);
+      expect(screen.queryByPlaceholderText("Stellar address (G...)")).not.toBeInTheDocument();
+    });
+
+    it("prefills the delegatee input when prefillAddress is provided", () => {
+      render(<GaslessDelegateModal {...defaultProps} prefillAddress={VALID_ADDRESS} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)") as HTMLInputElement;
+      expect(input.value).toBe(VALID_ADDRESS);
+    });
+
+    it("renders the Delegate for free submit button", () => {
+      render(<GaslessDelegateModal {...defaultProps} />);
+      expect(screen.getByRole("button", { name: /delegate for free/i })).toBeInTheDocument();
+    });
+
+    it("submit button is disabled when input is empty", () => {
+      render(<GaslessDelegateModal {...defaultProps} />);
+      const btn = screen.getByRole("button", { name: /delegate for free/i });
+      expect(btn).toBeDisabled();
+    });
+
+    it("renders top delegate quick-pick buttons when topDelegates is provided", () => {
+      const topDelegates = [
+        { address: VALID_ADDRESS, delegatedVotes: BigInt(1000) },
+        { address: VALID_ADDRESS_2, delegatedVotes: BigInt(500) },
+      ];
+      render(<GaslessDelegateModal {...defaultProps} topDelegates={topDelegates} />);
+      expect(screen.getAllByRole("button").length).toBeGreaterThan(2);
+    });
+  });
+
+  describe("blur validation", () => {
+    it("shows error on blur when address is empty", async () => {
+      render(<GaslessDelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(screen.getByText("Address is required.")).toBeInTheDocument();
+      });
+    });
+
+    it("shows error on blur when address is invalid", async () => {
+      render(<GaslessDelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      await userEvent.type(input, "GBADADDRESS");
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument();
+      });
+    });
+
+    it("shows error on blur for address with wrong prefix", async () => {
+      render(<GaslessDelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      await userEvent.type(input, "SDOOXICJPSOZDQRCEHZPR6MAX5PUZXVWGJ3QPVEU4DADIZQ4YBQOJNIB");
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument();
+      });
+    });
+
+    it("shows error on blur for address with trailing newline", async () => {
+      render(<GaslessDelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      fireEvent.change(input, { target: { value: "GBADADDRESS\n" } });
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument();
+      });
+    });
+
+    it("clears error when user starts typing a new value", async () => {
+      render(<GaslessDelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      await userEvent.type(input, "GBAD");
+      fireEvent.blur(input);
+      await waitFor(() => expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument());
+      await userEvent.clear(input);
+      await userEvent.type(input, "G");
+      await waitFor(() => expect(screen.queryByText("Invalid Stellar address.")).not.toBeInTheDocument());
+    });
+
+    it("does not show error before user interaction", () => {
+      render(<GaslessDelegateModal {...defaultProps} />);
+      expect(screen.queryByText("Invalid Stellar address.")).not.toBeInTheDocument();
+      expect(screen.queryByText("Address is required.")).not.toBeInTheDocument();
+    });
+
+    it("applies red border when address is invalid after blur", async () => {
+      render(<GaslessDelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      await userEvent.type(input, "GBAD");
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(input.className).toContain("border-red-400");
+      });
+    });
+
+    it("does not apply red border when address is valid", async () => {
+      render(<GaslessDelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      await userEvent.type(input, VALID_ADDRESS);
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(input.className).not.toContain("border-red-400");
+      });
+    });
+  });
+
+  describe("submit validation", () => {
+    it("blocks submit and shows error when address is empty", async () => {
+      render(<GaslessDelegateModal {...defaultProps} />);
+      const form = screen.getByPlaceholderText("Stellar address (G...)").closest("form")!;
+      fireEvent.submit(form);
+      await waitFor(() => {
+        expect(screen.getByText("Address is required.")).toBeInTheDocument();
+      });
+    });
+
+    it("blocks submit and shows error when address is invalid", async () => {
+      render(<GaslessDelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      await userEvent.type(input, "GBADADDRESS");
+      const form = input.closest("form")!;
+      fireEvent.submit(form);
+      await waitFor(() => {
+        expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument();
+      });
+    });
+
+    it("submit button is disabled while there is a validation error", async () => {
+      render(<GaslessDelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      await userEvent.type(input, "GBAD");
+      fireEvent.blur(input);
+      await waitFor(() => {
+        const btn = screen.getByRole("button", { name: /delegate for free/i });
+        expect(btn).toBeDisabled();
+      });
+    });
+
+    it("submit button is enabled when a valid address is entered", async () => {
+      render(<GaslessDelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      await userEvent.type(input, VALID_ADDRESS);
+      const btn = screen.getByRole("button", { name: /delegate for free/i });
+      expect(btn).not.toBeDisabled();
+    });
+  });
+
+  describe("top delegate quick-pick", () => {
+    it("fills the input when a top delegate button is clicked", async () => {
+      const topDelegates = [{ address: VALID_ADDRESS, delegatedVotes: BigInt(1000) }];
+      render(<GaslessDelegateModal {...defaultProps} topDelegates={topDelegates} />);
+      const shortAddr = `${VALID_ADDRESS.slice(0, 4)}...${VALID_ADDRESS.slice(-4)}`;
+      const pickBtn = screen.getByRole("button", { name: shortAddr });
+      await userEvent.click(pickBtn);
+      const input = screen.getByPlaceholderText("Stellar address (G...)") as HTMLInputElement;
+      expect(input.value).toBe(VALID_ADDRESS);
+    });
+  });
+
+  describe("expiry preset selection", () => {
+    it("renders all four expiry preset buttons", () => {
+      render(<GaslessDelegateModal {...defaultProps} />);
+      expect(screen.getByRole("button", { name: "1 week" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "1 month" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "6 months" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "1 year" })).toBeInTheDocument();
+    });
+  });
+
+  describe("cancel", () => {
+    it("calls onClose when Cancel is clicked", async () => {
+      const onClose = jest.fn();
+      render(<GaslessDelegateModal {...defaultProps} onClose={onClose} />);
+      await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/app/src/components/__tests__/StreamSpendModal.validation.test.tsx
+++ b/app/src/components/__tests__/StreamSpendModal.validation.test.tsx
@@ -1,0 +1,244 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { StreamSpendModal } from "../StreamSpendModal";
+import type { TreasuryClient, TreasuryBudgetStream } from "../../lib/treasury-client";
+
+const VALID_ADDRESS = "GDOOXICJPSOZDQRCEHZPR6MAX5PUZXVWGJ3QPVEU4DADIZQ4YBQOJNIB";
+const VALID_ADDRESS_2 = "GD6HLZWRE5FHK3SDLZB3FH56R3H3ECAAYCPWWU7O7EK4FCNT2Z7S6D5I";
+
+jest.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: { success: jest.fn(), error: jest.fn() },
+}));
+
+const mockStreamSpend = jest.fn().mockResolvedValue(undefined);
+const mockClient = {
+  streamSpend: mockStreamSpend,
+} as unknown as TreasuryClient;
+
+const mockStream: TreasuryBudgetStream = {
+  id: BigInt(1),
+  name: "engineering",
+  owner: VALID_ADDRESS_2,
+  tokenAddress: "CTOKEN123",
+  totalAllocated: BigInt(1000000),
+  totalSpent: BigInt(100000),
+  maxSingleSpend: BigInt(500000),
+  startLedger: 100,
+  endLedger: 200000,
+  cooldownLedgers: 0,
+  lastSpendLedger: 0,
+  proposalId: BigInt(0),
+  isActive: true,
+};
+
+const defaultProps = {
+  client: mockClient,
+  stream: mockStream,
+  signerPublicKey: VALID_ADDRESS_2,
+  signUnsignedXdr: jest.fn().mockResolvedValue("signed_xdr"),
+  onClose: jest.fn(),
+  onSpent: jest.fn(),
+};
+
+describe("StreamSpendModal — Stellar address validation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("rendering", () => {
+    it("renders the recipient address input", () => {
+      render(<StreamSpendModal {...defaultProps} />);
+      expect(screen.getByPlaceholderText("G...")).toBeInTheDocument();
+    });
+
+    it("renders the Recipient Address label", () => {
+      render(<StreamSpendModal {...defaultProps} />);
+      expect(screen.getByText("Recipient Address")).toBeInTheDocument();
+    });
+
+    it("renders the Execute Spend submit button", () => {
+      render(<StreamSpendModal {...defaultProps} />);
+      expect(screen.getByRole("button", { name: /execute spend/i })).toBeInTheDocument();
+    });
+
+    it("shows stream name and remaining budget in the header", () => {
+      render(<StreamSpendModal {...defaultProps} />);
+      expect(screen.getByText(/engineering/i)).toBeInTheDocument();
+      expect(screen.getByText(/900000/)).toBeInTheDocument();
+    });
+
+    it("disables submit when stream is not active", () => {
+      const inactiveStream = { ...mockStream, isActive: false };
+      render(<StreamSpendModal {...defaultProps} stream={inactiveStream} />);
+      expect(screen.getByRole("button", { name: /execute spend/i })).toBeDisabled();
+    });
+  });
+
+  describe("blur validation", () => {
+    it("shows error on blur when recipient address is invalid", async () => {
+      render(<StreamSpendModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, "GBADADDRESS");
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument();
+      });
+    });
+
+    it("shows error on blur for lowercase address", async () => {
+      render(<StreamSpendModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, VALID_ADDRESS.toLowerCase());
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument();
+      });
+    });
+
+    it("shows error on blur for address with wrong prefix", async () => {
+      render(<StreamSpendModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, "SDOOXICJPSOZDQRCEHZPR6MAX5PUZXVWGJ3QPVEU4DADIZQ4YBQOJNIB");
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument();
+      });
+    });
+
+    it("shows error on blur for address with copy-paste trailing whitespace", async () => {
+      render(<StreamSpendModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      fireEvent.change(input, { target: { value: "GBADADDRESS   " } });
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument();
+      });
+    });
+
+    it("does not show error on blur when address is valid", async () => {
+      render(<StreamSpendModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, VALID_ADDRESS);
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(screen.queryByText("Invalid Stellar address.")).not.toBeInTheDocument();
+      });
+    });
+
+    it("does not show error on blur when field is empty", async () => {
+      render(<StreamSpendModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(screen.queryByText("Invalid Stellar address.")).not.toBeInTheDocument();
+      });
+    });
+
+    it("clears error when user types a valid address after an invalid one", async () => {
+      render(<StreamSpendModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, "GBAD");
+      fireEvent.blur(input);
+      await waitFor(() => expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument());
+      await userEvent.clear(input);
+      await userEvent.type(input, VALID_ADDRESS);
+      await waitFor(() => expect(screen.queryByText("Invalid Stellar address.")).not.toBeInTheDocument());
+    });
+
+    it("applies red border when address is invalid after blur", async () => {
+      render(<StreamSpendModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, "GBAD");
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(input.className).toContain("border-red-400");
+      });
+    });
+
+    it("does not apply red border when address is valid", async () => {
+      render(<StreamSpendModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, VALID_ADDRESS);
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(input.className).not.toContain("border-red-400");
+      });
+    });
+  });
+
+  describe("submit validation", () => {
+    it("blocks submit and shows error when recipient address is invalid", async () => {
+      render(<StreamSpendModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, "GBADADDRESS");
+      fireEvent.change(screen.getByPlaceholderText("1000"), { target: { value: "1000" } });
+      const form = input.closest("form")!;
+      fireEvent.submit(form);
+      await waitFor(() => {
+        expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument();
+      });
+      expect(mockStreamSpend).not.toHaveBeenCalled();
+    });
+
+    it("blocks submit when recipient has wrong prefix", async () => {
+      render(<StreamSpendModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, "ADOOXICJPSOZDQRCEHZPR6MAX5PUZXVWGJ3QPVEU4DADIZQ4YBQOJNIB");
+      fireEvent.change(screen.getByPlaceholderText("1000"), { target: { value: "1000" } });
+      const form = input.closest("form")!;
+      fireEvent.submit(form);
+      await waitFor(() => {
+        expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument();
+      });
+      expect(mockStreamSpend).not.toHaveBeenCalled();
+    });
+
+    it("submit button is disabled while there is a validation error", async () => {
+      render(<StreamSpendModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, "GBAD");
+      fireEvent.blur(input);
+      await waitFor(() => {
+        const btn = screen.getByRole("button", { name: /execute spend/i });
+        expect(btn).toBeDisabled();
+      });
+    });
+
+    it("submit button is re-enabled after error is cleared", async () => {
+      render(<StreamSpendModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, "GBAD");
+      fireEvent.blur(input);
+      await waitFor(() => expect(screen.getByText("Invalid Stellar address.")).toBeInTheDocument());
+      await userEvent.clear(input);
+      await userEvent.type(input, VALID_ADDRESS);
+      await waitFor(() => {
+        const btn = screen.getByRole("button", { name: /execute spend/i });
+        expect(btn).not.toBeDisabled();
+      });
+    });
+
+    it("submit button is disabled when stream is inactive even with valid address", async () => {
+      const inactiveStream = { ...mockStream, isActive: false };
+      render(<StreamSpendModal {...defaultProps} stream={inactiveStream} />);
+      const input = screen.getByPlaceholderText("G...");
+      await userEvent.type(input, VALID_ADDRESS);
+      const btn = screen.getByRole("button", { name: /execute spend/i });
+      expect(btn).toBeDisabled();
+    });
+  });
+
+  describe("cancel", () => {
+    it("calls onClose when Cancel is clicked", async () => {
+      const onClose = jest.fn();
+      render(<StreamSpendModal {...defaultProps} onClose={onClose} />);
+      await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/app/src/lib/utils/__tests__/stellarAddress.test.ts
+++ b/app/src/lib/utils/__tests__/stellarAddress.test.ts
@@ -1,0 +1,96 @@
+import { isValidStellarAddress } from "../stellarAddress";
+
+const VALID_ADDRESS = "GDOOXICJPSOZDQRCEHZPR6MAX5PUZXVWGJ3QPVEU4DADIZQ4YBQOJNIB";
+const VALID_ADDRESS_2 = "GD6HLZWRE5FHK3SDLZB3FH56R3H3ECAAYCPWWU7O7EK4FCNT2Z7S6D5I";
+
+describe("isValidStellarAddress", () => {
+  describe("valid addresses", () => {
+    it("returns true for a valid Ed25519 public key", () => {
+      expect(isValidStellarAddress(VALID_ADDRESS)).toBe(true);
+    });
+
+    it("returns true for a second valid Ed25519 public key", () => {
+      expect(isValidStellarAddress(VALID_ADDRESS_2)).toBe(true);
+    });
+
+    it("trims leading whitespace before validating", () => {
+      expect(isValidStellarAddress("  " + VALID_ADDRESS)).toBe(true);
+    });
+
+    it("trims trailing whitespace before validating", () => {
+      expect(isValidStellarAddress(VALID_ADDRESS + "  ")).toBe(true);
+    });
+
+    it("trims both leading and trailing whitespace", () => {
+      expect(isValidStellarAddress("  " + VALID_ADDRESS + "  ")).toBe(true);
+    });
+
+    it("trims newline characters before validating", () => {
+      expect(isValidStellarAddress(VALID_ADDRESS + "\n")).toBe(true);
+    });
+
+    it("trims tab characters before validating", () => {
+      expect(isValidStellarAddress("\t" + VALID_ADDRESS)).toBe(true);
+    });
+  });
+
+  describe("invalid addresses", () => {
+    it("returns false for an empty string", () => {
+      expect(isValidStellarAddress("")).toBe(false);
+    });
+
+    it("returns false for a whitespace-only string", () => {
+      expect(isValidStellarAddress("   ")).toBe(false);
+    });
+
+    it("returns false for an address that does not start with G", () => {
+      expect(isValidStellarAddress("ADOOXICJPSOZDQRCEHZPR6MAX5PUZXVWGJ3QPVEU4DADIZQ4YBQOJNIB")).toBe(false);
+    });
+
+    it("returns false for a lowercase address", () => {
+      expect(isValidStellarAddress(VALID_ADDRESS.toLowerCase())).toBe(false);
+    });
+
+    it("returns false for an address that is too short", () => {
+      expect(isValidStellarAddress("GDOOXICJPSOZDQRCEHZPR6MAX5PUZXVWGJ3QPVEU4DADIZQ4YBQOJNI")).toBe(false);
+    });
+
+    it("returns false for an address that is too long", () => {
+      expect(isValidStellarAddress(VALID_ADDRESS + "B")).toBe(false);
+    });
+
+    it("returns false for a random short string", () => {
+      expect(isValidStellarAddress("GABC123")).toBe(false);
+    });
+
+    it("returns false for a string with invalid base32 characters", () => {
+      expect(isValidStellarAddress("G" + "0".repeat(55))).toBe(false);
+    });
+
+    it("returns false for a contract address (C...)", () => {
+      expect(isValidStellarAddress("CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM")).toBe(false);
+    });
+
+    it("returns false for a numeric string", () => {
+      expect(isValidStellarAddress("12345678901234567890123456789012345678901234567890123456")).toBe(false);
+    });
+
+    it("returns false for an address with an internal space", () => {
+      const withSpace = VALID_ADDRESS.slice(0, 28) + " " + VALID_ADDRESS.slice(29);
+      expect(isValidStellarAddress(withSpace)).toBe(false);
+    });
+
+    it("returns false for a corrupted checksum", () => {
+      const corrupted = VALID_ADDRESS.slice(0, -2) + "AA";
+      expect(isValidStellarAddress(corrupted)).toBe(false);
+    });
+
+    it("returns false for undefined cast to string", () => {
+      expect(isValidStellarAddress(String(undefined))).toBe(false);
+    });
+
+    it("returns false for null cast to string", () => {
+      expect(isValidStellarAddress(String(null))).toBe(false);
+    });
+  });
+});

--- a/app/src/lib/utils/stellarAddress.ts
+++ b/app/src/lib/utils/stellarAddress.ts
@@ -1,0 +1,5 @@
+import { StrKey } from "@stellar/stellar-sdk";
+
+export function isValidStellarAddress(value: string): boolean {
+  return StrKey.isValidEd25519PublicKey(value.trim());
+}


### PR DESCRIPTION
## Summary

Closes #934

Every address input across the delegation/treasury flows accepted arbitrary text with no format check, meaning malformed addresses were only caught after triggering a wallet signature prompt or a relayer round-trip.

## Changes

- Added shared `isValidStellarAddress(value: string)` helper in `app/src/lib/utils/stellarAddress.ts` using `StrKey.isValidEd25519PublicKey` (already available from `@stellar/stellar-sdk`)
- Wired validation into all four affected inputs:
  - `DelegateModal.tsx` — delegatee field
  - `GaslessDelegateModal.tsx` — delegatee field
  - `CreateStreamModal.tsx` — owner field
  - `StreamSpendModal.tsx` — recipient field
- Validates on **blur** and on **submit**
- Shows inline red error message below the input when invalid
- Disables the submit button while the address is invalid