### PR TITLE
fix(sim): enforce budget checks and scale storage estimates

### DIFF
--- a/scripts/simulate.ts
+++ b/scripts/simulate.ts
@@ -395,7 +395,9 @@ async function main() {
       console.log(
         `${report.scenario_name}: ${report.passed_steps}/${report.total_steps} steps passed, final ledger ${report.final_ledger}`,
       );
-      if (report.failed_steps > 0) process.exitCode = 1;
+      if (report.failed_steps > 0 || report.compute_budget_warnings.some(w => w.utilization_pct >= 100)) {
+        process.exitCode = 1;
+      }
       break;
     }
     case "generate": {

--- a/tools/sim/README.md
+++ b/tools/sim/README.md
@@ -1,0 +1,350 @@
+# nebgov-sim: Governance Simulation Harness
+
+A Rust simulation runner for NebGov's governance contracts. This tool exercises the full proposal lifecycle (propose - vote - queue - execute) without deploying to the Stellar network, tracking compute budget and storage write patterns as regression signals.
+
+## Quick Start
+
+Build the simulator:
+
+```bash
+cargo build --manifest-path tools/sim/Cargo.toml --release
+```
+
+Run a scenario:
+
+```bash
+cargo run --manifest-path tools/sim/Cargo.toml -- run --scenario tools/sim/src/scenarios/basic.json --output report.json
+```
+
+Run all scenarios:
+
+```bash
+cargo run --manifest-path tools/sim/Cargo.toml -- run-all
+```
+
+## CLI Subcommands
+
+### `run`
+
+Run a single scenario file and output a JSON report.
+
+```bash
+cargo run --manifest-path tools/sim/Cargo.toml -- run \
+  --scenario <path.json> \
+  [--output report.json] \
+  [--verbose]
+```
+
+**Options:**
+- `--scenario` (required): Path to a scenario JSON file
+- `--output`: Path where the JSON report is written (default: `report.json`)
+- `--verbose`: Print per-step details instead of just the summary
+
+**Exit codes:**
+- 0: All steps passed and no critical budget warnings (utilization >= 100%)
+- 1: Any step failed or any budget warning reached the critical threshold
+
+### `run-all`
+
+Run every `*.json` scenario in a directory, writing reports for each.
+
+```bash
+cargo run --manifest-path tools/sim/Cargo.toml -- run-all \
+  [--scenarios-dir tools/sim/src/scenarios] \
+  [--output-dir tools/sim/reports]
+```
+
+**Options:**
+- `--scenarios-dir`: Directory containing scenario files (default: `tools/sim/src/scenarios`)
+- `--output-dir`: Directory where JSON reports are written (default: `tools/sim/reports`)
+
+**Exit codes:**
+- 0: All scenarios passed with no critical budget warnings
+- 1: Any scenario failed or had a critical budget warning
+
+### `validate`
+
+Structurally validate a scenario file without running it.
+
+```bash
+cargo run --manifest-path tools/sim/Cargo.toml -- validate <scenario.json>
+```
+
+**Exit codes:**
+- 0: Scenario is valid
+- 1: Scenario structure is invalid
+
+### `list-scenarios`
+
+List all scenario files in a directory.
+
+```bash
+cargo run --manifest-path tools/sim/Cargo.toml -- list-scenarios \
+  [--scenarios-dir tools/sim/src/scenarios]
+```
+
+## Scenario Schema
+
+A scenario is a JSON file describing a sequence of governance steps to execute. See `tools/sim/src/scenarios/*.json` for examples.
+
+### Structure
+
+```json
+{
+  "name": "scenario_name",
+  "description": "Human-readable description",
+  "seed": 1,
+  "governor_settings": { ... },
+  "actors": [ ... ],
+  "steps": [ ... ]
+}
+```
+
+### Governor Settings
+
+Configure governance parameters (voting delay, quorum, vote type, etc.). This is merged with contract initialization defaults — only override what your scenario needs.
+
+### Actors
+
+A list of participants with roles:
+
+```json
+{
+  "name": "alice",
+  "initial_balance": 1000,
+  "delegate_to": null,
+  "role": "Proposer"  // or "TokenHolder", "Guardian", "Pauser", "Admin"
+}
+```
+
+### Steps
+
+Each step is one action in the governance lifecycle:
+
+**Propose**
+```json
+{
+  "type": "Propose",
+  "actor": "proposer_name",
+  "targets": ["treasury", "target"],
+  "fn_names": ["transfer", "noop"],
+  "description": "Proposal description"
+}
+```
+
+The `targets` list can be:
+- `"treasury"`: The deployed treasury contract
+- `"governor"`: The deployed governor contract
+- `"target"`: A placeholder no-op contract for testing
+- Any actor name: That actor's address
+
+**Vote**
+```json
+{
+  "type": "Vote",
+  "actor": "voter_name",
+  "proposal_id": 1,
+  "support": "For"  // or "Against", "Abstain"
+}
+```
+
+**Queue / Execute / Cancel**
+```json
+{
+  "type": "Queue",
+  "actor": "actor_name",
+  "proposal_id": 1
+}
+```
+
+**Delegate**
+```json
+{
+  "type": "Delegate",
+  "actor": "delegator_name",
+  "delegatee": "delegatee_name"
+}
+```
+
+**Mint / Burn Tokens**
+```json
+{
+  "type": "MintTokens",
+  "actor": "actor_name",
+  "amount": 500
+}
+```
+
+**Update Config**
+```json
+{
+  "type": "UpdateConfig",
+  "actor": "admin_name",
+  "settings": { ... }
+}
+```
+
+**Pause / Unpause Contract**
+```json
+{
+  "type": "PauseContract",
+  "actor": "pauser_name"
+}
+```
+
+**Advance Ledger**
+```json
+{
+  "type": "AdvanceLedger",
+  "ledgers": 10
+}
+```
+
+**Assert Proposal State**
+```json
+{
+  "type": "ExpectState",
+  "proposal_id": 1,
+  "expected_state": "Active"  // or "Pending", "Defeated", "Succeeded", "Queued", "Executed", "Cancelled", "Expired"
+}
+```
+
+**Expect Step Error**
+```json
+{
+  "type": "ExpectError",
+  "step_index": 5,
+  "expected_error": "proposal below quorum"
+}
+```
+When a step is expected to fail, mark it with an `ExpectError` that references its index. This prevents the failure from being counted against the scenario's success.
+
+**Assert Participation**
+```json
+{
+  "type": "AssertParticipation",
+  "proposal_id": 1,
+  "min_bps": 1000  // minimum basis points (1000 = 10%)
+}
+```
+
+**Assert Quorum**
+```json
+{
+  "type": "AssertQuorumReached",
+  "proposal_id": 1
+}
+```
+
+**Take Analytics Snapshot**
+```json
+{
+  "type": "TakeAnalyticsSnapshot"
+}
+```
+Records proposal counts by state in the report.
+
+## Simulation Report
+
+Each run produces a JSON report with per-step results and aggregate metrics:
+
+```json
+{
+  "scenario_name": "basic",
+  "total_steps": 15,
+  "passed_steps": 14,
+  "failed_steps": 1,
+  "final_ledger": 50,
+  "proposals_created": 1,
+  "proposals_executed": 0,
+  "proposals_defeated": 0,
+  "total_votes_cast": 3,
+  "step_results": [
+    {
+      "step_index": 0,
+      "step_type": "Propose",
+      "ledger": 1,
+      "success": true,
+      "error": null,
+      "cpu_insns": 5_000_000,
+      "mem_bytes": 200_000,
+      "storage_entries_read": 3,
+      "storage_entries_written": 5,
+      "duration_ms": 42,
+      "anticipated_failure": false
+    }
+    // ... more results
+  ],
+  "compute_budget_warnings": [
+    {
+      "step_index": 5,
+      "cpu_insns": 100_000_000,
+      "budget_limit": 100_000_000,
+      "utilization_pct": 100.0
+    }
+  ],
+  "storage_warnings": [
+    {
+      "step_index": 7,
+      "entries_written": 75,
+      "utilization_pct": 150.0
+    }
+  ]
+}
+```
+
+### Budget Warnings
+
+A `BudgetWarning` is emitted when a single step uses >= 80% of the CPU instruction budget (configured in `report.rs` as `BUDGET_WARNING_THRESHOLD_PCT = 80.0`). Critical warnings (>= 100%) indicate the step would fail on-chain.
+
+### Storage Warnings
+
+A `StorageWarning` is emitted when a single step writes >= 50 storage entries (configured as `STORAGE_WRITE_WARNING_THRESHOLD = 50`), a proxy for unbounded-growth patterns like `DraftList` or `ProposalList`.
+
+The storage write count is estimated per step-kind based on the step's shape (see `runner.rs:estimated_storage_touches()`):
+- `Propose`: 5 base writes + 1 per target
+- `Vote`: 2 writes
+- `Queue` / `Execute` / `Cancel`: 2 writes
+- `UpdateConfig`: 14 writes
+- All others: 0 writes
+
+## CI Integration
+
+The simulator is run as part of `.github/workflows/simulation.yml`:
+
+1. `cargo run -- run-all` runs all scenarios and outputs reports
+2. `python3 scripts/check_budget_warnings.py` reads the reports and fails the job if any scenario has a critical budget warning (>= 100% utilization)
+
+The `scripts/simulate.ts` harness wraps the simulator for use in TypeScript/Node.js tooling and mirrors the Python script's budget check.
+
+## Development
+
+### Adding a New Scenario
+
+1. Create `tools/sim/src/scenarios/my_scenario.json`
+2. Define actors, governor settings, and steps
+3. Run `cargo run --manifest-path tools/sim/Cargo.toml -- validate tools/sim/src/scenarios/my_scenario.json`
+4. Test with `cargo run --manifest-path tools/sim/Cargo.toml -- run --scenario tools/sim/src/scenarios/my_scenario.json --verbose`
+
+### Debugging
+
+Use `--verbose` to see per-step CPU/memory/storage metrics:
+
+```bash
+cargo run --manifest-path tools/sim/Cargo.toml -- run \
+  --scenario tools/sim/src/scenarios/my_scenario.json \
+  --verbose
+```
+
+Read the JSON report with `jq`:
+
+```bash
+jq '.compute_budget_warnings' report.json
+jq '.step_results[] | select(.success == false)' report.json
+```
+
+### Testing the Simulator
+
+```bash
+cargo test --manifest-path tools/sim/Cargo.toml
+```

--- a/tools/sim/src/main.rs
+++ b/tools/sim/src/main.rs
@@ -93,6 +93,9 @@ fn run_one(scenario_path: &Path, output: &Path, verbose: bool) {
     if report.failed_steps > 0 {
         std::process::exit(1);
     }
+    if report.compute_budget_warnings.iter().any(|w| w.utilization_pct >= 100.0) {
+        std::process::exit(1);
+    }
 }
 
 fn run_all(scenarios_dir: &Path, output_dir: &Path) {
@@ -127,7 +130,7 @@ fn run_all(scenarios_dir: &Path, output_dir: &Path) {
         let report = runner.get_report().clone();
 
         print_summary(&report, false);
-        if report.failed_steps > 0 {
+        if report.failed_steps > 0 || report.compute_budget_warnings.iter().any(|w| w.utilization_pct >= 100.0) {
             any_failed = true;
         }
 

--- a/tools/sim/src/runner.rs
+++ b/tools/sim/src/runner.rs
@@ -537,7 +537,12 @@ fn merge_settings(current: &GovernorSettings, overrides: &SimGovernorSettings) -
 
 fn estimated_storage_touches(step: &SimStep) -> (u32, u32) {
     match step {
-        SimStep::Propose { .. } => (3, 5),
+        SimStep::Propose { targets, .. } => {
+            let target_count = targets.len() as u32;
+            let reads = 3;
+            let writes = 5 + target_count;
+            (reads, writes)
+        }
         SimStep::Vote { .. } => (2, 2),
         SimStep::Queue { .. } | SimStep::Execute { .. } | SimStep::Cancel { .. } => (2, 2),
         SimStep::UpdateConfig { .. } => (1, 14),


### PR DESCRIPTION
## What

Adds missing compute budget enforcement to the Rust simulation runner and TypeScript harness, scales storage write estimates with proposal size, and documents the simulator's CLI and schema.

## Issues Resolved

Closes #900
Closes #899
Closes #901
Closes #898

## Changes

### #900 - cargo run exits 0 when over budget

Updated `tools/sim/src/main.rs`:
- `run_one()` now exits non-zero when any `BudgetWarning` has `utilization_pct >= 100.0`
- `run_all()` similarly treats critical budget warnings as failure, matching the Python script's behavior
- Ensures direct invocation of `cargo run --manifest-path tools/sim/Cargo.toml -- run-all` catches budget overages without requiring the separate Python CI step

### #899 - storage estimates are fixed constants

Updated `tools/sim/src/runner.rs`:
- `estimated_storage_touches()` now scales the write estimate for `Propose` steps with `targets.len()`
- Base writes remain 5, but now add 1 per target to reflect real proposal shape
- Allows storage warnings to detect actual regressions in per-target costs instead of remaining a static false negative

### #901 - scripts/simulate.ts never checks budget warnings

Updated `scripts/simulate.ts`:
- The `run` subcommand now mirrors `check_budget_warnings.py`'s logic
- Checks `report.compute_budget_warnings.some(w => w.utilization_pct >= 100)` and exits 1 if any warning is critical
- Ensures TypeScript tooling and local testing surfaces the same signal as CI

### #898 - missing README

Created `tools/sim/README.md`:
- Comprehensive guide covering all four CLI subcommands (`run`, `run-all`, `validate`, `list-scenarios`)
- Complete scenario schema with examples for all step types
- Explanation of budget and storage warning thresholds and semantics
- CI integration notes and development guidance