### PR TITLE
fix(sim): fix governor mock error codes and validation (issues #882-885)

### DIFF
--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -18,7 +18,7 @@
  * code you receive matches what is written in the Rust contract.
  */
 export enum GovernorErrorCode {
-  // On-chain contract errors (match contracts/governor/src/lib.rs)
+  // On-chain contract errors (match contracts/governor/src/error.rs exactly)
   UnauthorizedCancel = 1,
   InvalidSupport = 2,
   ProposalExpired = 3,
@@ -46,7 +46,21 @@ export enum GovernorErrorCode {
   VotesTokenNotSet = 25,
   PauserNotSet = 26,
   ArithmeticOverflow = 27,
-  ProposalNotActive = 28,
+  VotePeriodTooShort = 28,
+  ExecutionWindowZero = 29,
+  TooManyCalldataEntries = 30,
+  ProposalNotActive = 31,
+  AlreadyInitialized = 32,
+  InvalidVotingDelay = 33,
+  InvalidVotingPeriod = 34,
+  InvalidQuorumNumerator = 35,
+  InvalidProposalThreshold = 36,
+  InvalidMaxCalldataSize = 37,
+  InvalidMaxProposalsPerPeriod = 38,
+  InvalidProposalPeriodDuration = 39,
+  EmptyBatch = 40,
+  BatchProposalNotQueued = 41,
+  ProposalAlreadyCancelled = 42,
   InvalidVoteChoice = 43,
   UnauthorizedRegistry = 44,
 
@@ -101,8 +115,36 @@ const GOVERNOR_MESSAGES: Record<GovernorErrorCode, string> = {
   [GovernorErrorCode.PauserNotSet]: "Pauser address is not configured",
   [GovernorErrorCode.ArithmeticOverflow]:
     "Arithmetic overflow while computing governance state",
+  [GovernorErrorCode.VotePeriodTooShort]:
+    "Voting period is shorter than the minimum required",
+  [GovernorErrorCode.ExecutionWindowZero]:
+    "Execution window must be greater than zero",
+  [GovernorErrorCode.TooManyCalldataEntries]:
+    "Proposal exceeds the maximum number of calldata entries (10)",
   [GovernorErrorCode.ProposalNotActive]:
     "Voting has ended for this proposal",
+  [GovernorErrorCode.AlreadyInitialized]:
+    "Contract is already initialized",
+  [GovernorErrorCode.InvalidVotingDelay]:
+    "Voting delay must be greater than zero",
+  [GovernorErrorCode.InvalidVotingPeriod]:
+    "Voting period must be greater than zero",
+  [GovernorErrorCode.InvalidQuorumNumerator]:
+    "Quorum numerator must be between 0 and 100",
+  [GovernorErrorCode.InvalidProposalThreshold]:
+    "Proposal threshold must be non-negative",
+  [GovernorErrorCode.InvalidMaxCalldataSize]:
+    "Max calldata size must be greater than zero",
+  [GovernorErrorCode.InvalidMaxProposalsPerPeriod]:
+    "Max proposals per period must be greater than zero",
+  [GovernorErrorCode.InvalidProposalPeriodDuration]:
+    "Proposal period duration must be greater than zero",
+  [GovernorErrorCode.EmptyBatch]:
+    "Batch proposal cannot be empty",
+  [GovernorErrorCode.BatchProposalNotQueued]:
+    "Batch proposal is not queued",
+  [GovernorErrorCode.ProposalAlreadyCancelled]:
+    "Proposal has already been cancelled",
   [GovernorErrorCode.InvalidVoteChoice]:
     "Invalid vote choice: must be 0 (Against), 1 (For), or 2 (Abstain)",
   [GovernorErrorCode.UnauthorizedRegistry]:

--- a/tools/simulation/src/harness.ts
+++ b/tools/simulation/src/harness.ts
@@ -29,6 +29,10 @@ export interface GovernorSimulationSettings {
   maxProposalsPerPeriod?: number;
   /** Period length in ledgers for the max-proposals-per-period cap. Defaults to 10_000. */
   proposalPeriodDuration?: number;
+  /** Maximum calldata size per action in bytes. Defaults to 10_000. */
+  maxCalldataSize?: number;
+  /** Address authorized to pause/unpause the contract. Defaults to the guardian. */
+  pauser?: string;
 }
 
 export interface SimulationConfig {
@@ -67,6 +71,7 @@ const DEFAULT_GRACE_PERIOD = 120_960; // ~7 days at 5s/ledger.
 const DEFAULT_COOLDOWN = 100;
 const DEFAULT_MAX_PER_PERIOD = 5;
 const DEFAULT_PERIOD_DURATION = 10_000;
+const DEFAULT_MAX_CALLDATA_SIZE = 10_000;
 const DEFAULT_GUARDIAN = Keypair.fromRawEd25519Seed(
   createHash("sha256").update("nebgov-simulation-actor:default-guardian").digest(),
 ).publicKey();
@@ -113,17 +118,21 @@ export class SimulationHarness {
 
   private buildSettingsState(): GovernorSettingsState {
     const s = this.config.settings;
+    const guardian = s.guardian ?? DEFAULT_GUARDIAN;
     return {
       votingDelay: s.votingDelay,
       votingPeriod: s.votingPeriod,
       quorumNumerator: s.quorumNumerator,
       proposalThreshold: s.proposalThreshold,
-      guardian: s.guardian ?? DEFAULT_GUARDIAN,
+      guardian,
       voteType: s.voteType,
       proposalGracePeriod: s.proposalGracePeriod ?? DEFAULT_GRACE_PERIOD,
       proposalCooldown: s.proposalCooldown ?? DEFAULT_COOLDOWN,
       maxProposalsPerPeriod: s.maxProposalsPerPeriod ?? DEFAULT_MAX_PER_PERIOD,
       proposalPeriodDuration: s.proposalPeriodDuration ?? DEFAULT_PERIOD_DURATION,
+      maxCalldataSize: s.maxCalldataSize ?? DEFAULT_MAX_CALLDATA_SIZE,
+      isPaused: false,
+      pauser: s.pauser ?? guardian,
     };
   }
 

--- a/tools/simulation/src/mock/governor-executor.ts
+++ b/tools/simulation/src/mock/governor-executor.ts
@@ -87,11 +87,36 @@ export const governorExecutor = {
     if (caller !== proposer) {
       throw new MockContractError(100, "propose: proposer must authorize this call");
     }
-    if (targets.length === 0 || targets.length !== fnNames.length || targets.length !== calldatas.length) {
-      throw new MockContractError(GovernorErrorCode.InvalidVectorLengths, "propose: targets/fnNames/calldatas length mismatch");
-    }
 
     const gov = store.governor;
+
+    // Check if contract is paused (Issue #885)
+    if (gov.settings.isPaused) {
+      throw new MockContractError(GovernorErrorCode.ContractPaused, "propose: contract is paused");
+    }
+
+    // Split vector validation to match real contract behavior (Issue #883)
+    // First check: length mismatch
+    if (targets.length !== fnNames.length || targets.length !== calldatas.length) {
+      throw new MockContractError(GovernorErrorCode.InvalidVectorLengths, "propose: length mismatch");
+    }
+    // Second check: empty targets (must come AFTER length check)
+    if (targets.length === 0) {
+      throw new MockContractError(GovernorErrorCode.NoTargets, "propose: no targets");
+    }
+
+    // Validate calldata size and count (Issue #884)
+    const maxCalldataSize = gov.settings.maxCalldataSize;
+    for (let i = 0; i < calldatas.length; i++) {
+      if (calldatas[i].length > maxCalldataSize) {
+        throw new MockContractError(GovernorErrorCode.CalldataTooLarge, "propose: calldata exceeds maximum size");
+      }
+    }
+
+    const MAX_CALLDATA_COUNT = 10;
+    if (calldatas.length > MAX_CALLDATA_COUNT) {
+      throw new MockContractError(GovernorErrorCode.TooManyCalldataEntries, "propose: too many calldata entries");
+    }
     const proposerVotes = tokenVotesExecutor.get_votes(store.votes, clock, proposer, [proposer]);
     if (proposerVotes < gov.settings.proposalThreshold) {
       throw new MockContractError(GovernorErrorCode.ProposalThresholdNotMet, "propose: proposal threshold not met");
@@ -146,8 +171,15 @@ export const governorExecutor = {
     if (caller !== voter) {
       throw new MockContractError(100, "cast_vote: voter must authorize this call");
     }
-    const support = supportVariant[0];
+
     const gov = store.governor;
+
+    // Check if contract is paused (Issue #885)
+    if (gov.settings.isPaused) {
+      throw new MockContractError(GovernorErrorCode.ContractPaused, "cast_vote: contract is paused");
+    }
+
+    const support = supportVariant[0];
     const proposal = mustGetProposal(store, proposalId);
 
     if (proposal.hasVoted[voter]) {
@@ -314,6 +346,24 @@ export const governorExecutor = {
 
   proposal_count(store: MockLedgerStore): bigint {
     return store.governor.proposalCount;
+  },
+
+  pause(store: MockLedgerStore, _clock: LedgerClock, caller: string, _args: unknown[]): null {
+    const gov = store.governor;
+    if (caller !== gov.settings.pauser) {
+      throw new MockContractError(GovernorErrorCode.UnauthorizedPause, "pause: only pauser can pause");
+    }
+    gov.settings.isPaused = true;
+    return null;
+  },
+
+  unpause(store: MockLedgerStore, _clock: LedgerClock, caller: string, _args: unknown[]): null {
+    const gov = store.governor;
+    if (caller !== gov.settings.pauser) {
+      throw new MockContractError(GovernorErrorCode.UnauthorizedPause, "unpause: only pauser can unpause");
+    }
+    gov.settings.isPaused = false;
+    return null;
   },
 };
 

--- a/tools/simulation/src/mock/store.ts
+++ b/tools/simulation/src/mock/store.ts
@@ -38,6 +38,9 @@ export interface GovernorSettingsState {
   proposalCooldown: number;
   maxProposalsPerPeriod: number;
   proposalPeriodDuration: number;
+  maxCalldataSize: number;
+  isPaused: boolean;
+  pauser: string;
 }
 
 export interface GovernorState {

--- a/tools/simulation/tests/governor-mock-validation.sim.ts
+++ b/tools/simulation/tests/governor-mock-validation.sim.ts
@@ -1,0 +1,308 @@
+import { GovernorErrorCode, VoteSupport } from "@nebgov/sdk";
+import { MockContractError } from "../src/mock/errors";
+import { SimulationHarness, DeployedContracts } from "../src";
+import { buildTestSetup, PLACEHOLDER_CALLDATA } from "./helpers";
+
+describe("Governor mock validation (issues #882-885)", () => {
+  let harness: SimulationHarness;
+  let addresses: DeployedContracts;
+  let setup: ReturnType<typeof buildTestSetup>;
+
+  beforeAll(async () => {
+    setup = buildTestSetup({ proposers: 1, voters: 2 });
+    harness = new SimulationHarness(setup.config);
+    harness.registerActors(setup.actors);
+    addresses = await harness.boot();
+  });
+
+  afterAll(async () => {
+    await harness.teardown();
+  });
+
+  beforeEach(async () => {
+    await harness.advanceLedgers(200);
+  });
+
+  describe("Issue #882: Error code mapping (ProposalNotActive)", () => {
+    it("ProposalNotActive should map to error code #31, not #28", async () => {
+      const proposalId = await harness.governorClient.propose(
+        setup.actors.proposers[0].keypair,
+        "Test error codes",
+        "0".repeat(64),
+        "ipfs://test",
+        [addresses.governor],
+        ["noop"],
+        [PLACEHOLDER_CALLDATA],
+      );
+
+      const settings = await harness.governorClient.getSettings();
+
+      // Advance past the voting window
+      await harness.advanceLedgers(settings.votingDelay + settings.votingPeriod + 10);
+
+      // Try to vote after voting period ends
+      try {
+        await harness.governorClient.castVote(
+          setup.actors.voters[0].keypair,
+          proposalId,
+          VoteSupport.For,
+        );
+        fail("Should have thrown ProposalNotActive");
+      } catch (err: unknown) {
+        const error = err as any;
+        expect(error.code).toBe(GovernorErrorCode.ProposalNotActive);
+        expect(error.code).toBe(31); // Verify numeric value
+      }
+    });
+
+    it("VotePeriodTooShort should be available as error code #28", () => {
+      // Verify the enum has the correct value
+      expect(GovernorErrorCode.VotePeriodTooShort).toBe(28);
+    });
+
+    it("TooManyCalldataEntries should be available as error code #30", () => {
+      expect(GovernorErrorCode.TooManyCalldataEntries).toBe(30);
+    });
+  });
+
+  describe("Issue #883: NoTargets vs InvalidVectorLengths", () => {
+    it("should throw NoTargets (#10) when all three vectors are empty", async () => {
+      try {
+        await harness.governorClient.propose(
+          setup.actors.proposers[0].keypair,
+          "Empty targets",
+          "0".repeat(64),
+          "ipfs://empty",
+          [], // empty targets
+          [], // empty fnNames
+          [], // empty calldatas
+        );
+        fail("Should have thrown NoTargets");
+      } catch (err: unknown) {
+        const error = err as any;
+        if (error instanceof MockContractError) {
+          expect(error.code).toBe(GovernorErrorCode.NoTargets);
+        } else {
+          expect((err as any).code).toBe(GovernorErrorCode.NoTargets);
+        }
+      }
+    });
+
+    it("should throw InvalidVectorLengths (#9) when fnNames length doesn't match", async () => {
+      try {
+        await harness.governorClient.propose(
+          setup.actors.proposers[0].keypair,
+          "Length mismatch",
+          "0".repeat(64),
+          "ipfs://mismatch",
+          [addresses.governor, addresses.timelock], // 2 targets
+          ["noop"], // 1 fnName (mismatch!)
+          [PLACEHOLDER_CALLDATA, PLACEHOLDER_CALLDATA], // 2 calldatas
+        );
+        fail("Should have thrown InvalidVectorLengths");
+      } catch (err: unknown) {
+        const error = err as any;
+        if (error instanceof MockContractError) {
+          expect(error.code).toBe(GovernorErrorCode.InvalidVectorLengths);
+        } else {
+          expect((err as any).code).toBe(GovernorErrorCode.InvalidVectorLengths);
+        }
+      }
+    });
+
+    it("should throw InvalidVectorLengths (#9) when calldatas length doesn't match", async () => {
+      try {
+        await harness.governorClient.propose(
+          setup.actors.proposers[0].keypair,
+          "Calldata mismatch",
+          "0".repeat(64),
+          "ipfs://mismatch2",
+          [addresses.governor], // 1 target
+          ["noop"], // 1 fnName
+          [PLACEHOLDER_CALLDATA, PLACEHOLDER_CALLDATA], // 2 calldatas (mismatch!)
+        );
+        fail("Should have thrown InvalidVectorLengths");
+      } catch (err: unknown) {
+        const error = err as any;
+        if (error instanceof MockContractError) {
+          expect(error.code).toBe(GovernorErrorCode.InvalidVectorLengths);
+        } else {
+          expect((err as any).code).toBe(GovernorErrorCode.InvalidVectorLengths);
+        }
+      }
+    });
+  });
+
+  describe("Issue #884: Calldata size and count validation", () => {
+    it("should throw CalldataTooLarge (#4) when calldata exceeds maxCalldataSize", async () => {
+      const oversizedCalldata = Buffer.alloc(11_000); // exceeds default 10_000
+      try {
+        await harness.governorClient.propose(
+          setup.actors.proposers[0].keypair,
+          "Oversized calldata",
+          "0".repeat(64),
+          "ipfs://oversized",
+          [addresses.governor],
+          ["noop"],
+          [oversizedCalldata],
+        );
+        fail("Should have thrown CalldataTooLarge");
+      } catch (err: unknown) {
+        const error = err as any;
+        if (error instanceof MockContractError) {
+          expect(error.code).toBe(GovernorErrorCode.CalldataTooLarge);
+        } else {
+          expect((err as any).code).toBe(GovernorErrorCode.CalldataTooLarge);
+        }
+      }
+    });
+
+    it("should throw TooManyCalldataEntries (#30) when more than 10 entries", async () => {
+      const entries = Array(11).fill(PLACEHOLDER_CALLDATA);
+      const targets = Array(11).fill(addresses.governor);
+      const fnNames = Array(11).fill("noop");
+
+      try {
+        await harness.governorClient.propose(
+          setup.actors.proposers[0].keypair,
+          "Too many entries",
+          "0".repeat(64),
+          "ipfs://toomany",
+          targets,
+          fnNames,
+          entries,
+        );
+        fail("Should have thrown TooManyCalldataEntries");
+      } catch (err: unknown) {
+        const error = err as any;
+        if (error instanceof MockContractError) {
+          expect(error.code).toBe(GovernorErrorCode.TooManyCalldataEntries);
+        } else {
+          expect((err as any).code).toBe(GovernorErrorCode.TooManyCalldataEntries);
+        }
+      }
+    });
+
+    it("should allow exactly 10 calldata entries", async () => {
+      const entries = Array(10).fill(PLACEHOLDER_CALLDATA);
+      const targets = Array(10).fill(addresses.governor);
+      const fnNames = Array(10).fill("noop");
+
+      // This should succeed (10 is the max)
+      const proposalId = await harness.governorClient.propose(
+        setup.actors.proposers[0].keypair,
+        "Max entries",
+        "0".repeat(64),
+        "ipfs://maxentries",
+        targets,
+        fnNames,
+        entries,
+      );
+
+      expect(proposalId).toBeDefined();
+    });
+  });
+
+  describe("Issue #885: Pause/unpause modeling", () => {
+    it("should throw ContractPaused (#7) when trying to propose on paused contract", async () => {
+      // First, pause the contract
+      const pauserKeypair = setup.actors.guardian?.keypair;
+      if (!pauserKeypair) {
+        throw new Error("No guardian for pausing test");
+      }
+
+      // Pause (this will be mocked through the harness)
+      const mockStore = (harness as any).store;
+      if (mockStore && mockStore.governor) {
+        mockStore.governor.settings.isPaused = true;
+      }
+
+      // Try to propose on paused contract
+      try {
+        await harness.governorClient.propose(
+          setup.actors.proposers[0].keypair,
+          "Should fail - paused",
+          "0".repeat(64),
+          "ipfs://paused",
+          [addresses.governor],
+          ["noop"],
+          [PLACEHOLDER_CALLDATA],
+        );
+        fail("Should have thrown ContractPaused");
+      } catch (err: unknown) {
+        const error = err as any;
+        if (error instanceof MockContractError) {
+          expect(error.code).toBe(GovernorErrorCode.ContractPaused);
+        } else {
+          // RPC error from SDK
+          expect(error.message).toContain("paused");
+        }
+      }
+    });
+
+    it("should allow proposal after unpausing", async () => {
+      const mockStore = (harness as any).store;
+      if (mockStore && mockStore.governor) {
+        // Ensure contract is unpaused
+        mockStore.governor.settings.isPaused = false;
+      }
+
+      // This should succeed
+      const proposalId = await harness.governorClient.propose(
+        setup.actors.proposers[0].keypair,
+        "After unpause",
+        "0".repeat(64),
+        "ipfs://unpaused",
+        [addresses.governor],
+        ["noop"],
+        [PLACEHOLDER_CALLDATA],
+      );
+
+      expect(proposalId).toBeDefined();
+    });
+
+    it("should throw ContractPaused (#7) when trying to vote on paused contract", async () => {
+      // Create and queue a proposal first (while unpaused)
+      const mockStore = (harness as any).store;
+      if (mockStore && mockStore.governor) {
+        mockStore.governor.settings.isPaused = false;
+      }
+
+      const proposalId = await harness.governorClient.propose(
+        setup.actors.proposers[0].keypair,
+        "Vote pause test",
+        "0".repeat(64),
+        "ipfs://votepause",
+        [addresses.governor],
+        ["noop"],
+        [PLACEHOLDER_CALLDATA],
+      );
+
+      const settings = await harness.governorClient.getSettings();
+      await harness.advanceLedgers(settings.votingDelay + 1);
+
+      // Now pause the contract
+      if (mockStore && mockStore.governor) {
+        mockStore.governor.settings.isPaused = true;
+      }
+
+      // Try to vote while paused
+      try {
+        await harness.governorClient.castVote(
+          setup.actors.voters[0].keypair,
+          proposalId,
+          VoteSupport.For,
+        );
+        fail("Should have thrown ContractPaused");
+      } catch (err: unknown) {
+        const error = err as any;
+        if (error instanceof MockContractError) {
+          expect(error.code).toBe(GovernorErrorCode.ContractPaused);
+        } else {
+          // RPC error from SDK
+          expect(error.message).toContain("paused");
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes four critical issues in the mock governor executor where the TypeScript harness diverges from the real Soroban contract behavior, preventing tests from validating error conditions correctly:

- **#882**: GovernorErrorCode.ProposalNotActive mapped to wrong value (28 vs real 31)
- **#883**: propose() always throws InvalidVectorLengths, never NoTargets
- **#884**: propose() never enforces max_calldata_size or 10-entry calldata cap  
- **#885**: Mock governor has no pause()/unpause()/IsPaused modeling

## Changes Made

### Issue #882: Error Code Mapping
Fixed inconsistency between SDK enum and on-chain contract values.

**Files**: `sdk/src/errors.ts`

- Updated `GovernorErrorCode` enum to match `contracts/governor/src/error.rs` exactly
- Corrected: `ProposalNotActive = 31` (was 28)
- Added missing codes 28-42:
  - VotePeriodTooShort = 28
  - ExecutionWindowZero = 29
  - TooManyCalldataEntries = 30
  - ProposalNotActive = 31 (corrected)
  - AlreadyInitialized = 32
  - InvalidVotingDelay = 33
  - InvalidVotingPeriod = 34
  - InvalidQuorumNumerator = 35
  - InvalidProposalThreshold = 36
  - InvalidMaxCalldataSize = 37
  - InvalidMaxProposalsPerPeriod = 38
  - InvalidProposalPeriodDuration = 39
  - EmptyBatch = 40
  - BatchProposalNotQueued = 41
  - ProposalAlreadyCancelled = 42
- Added error messages for all new codes in `GOVERNOR_MESSAGES`

### Issue #883: NoTargets vs InvalidVectorLengths
Split validation to match real contract's two-check approach.

**Files**: `tools/simulation/src/mock/governor-executor.ts`

Changed from:
```ts
if (targets.length === 0 || targets.length !== fnNames.length || targets.length !== calldatas.length) {
  throw new MockContractError(GovernorErrorCode.InvalidVectorLengths, ...);
}
```

To:
```ts
// Check 1: length mismatch
if (targets.length !== fnNames.length || targets.length !== calldatas.length) {
  throw new MockContractError(GovernorErrorCode.InvalidVectorLengths, ...);
}
// Check 2: empty targets (must come AFTER length check)
if (targets.length === 0) {
  throw new MockContractError(GovernorErrorCode.NoTargets, ...);
}
```

Now correctly throws NoTargets (#10) when all vectors are empty, matching contract behavior.

### Issue #884: Calldata Size & Count Validation
Added enforcement of max_calldata_size and 10-entry limit.

**Files**: 
- `tools/simulation/src/mock/store.ts`
- `tools/simulation/src/mock/governor-executor.ts`
- `tools/simulation/src/harness.ts`

**Changes**:
1. Added `maxCalldataSize: number` to `GovernorSettingsState`
2. Added validation in `propose()`:
   ```ts
   const maxCalldataSize = gov.settings.maxCalldataSize;
   for (let i = 0; i < calldatas.length; i++) {
     if (calldatas[i].length > maxCalldataSize) {
       throw new MockContractError(GovernorErrorCode.CalldataTooLarge, ...);
     }
   }
   const MAX_CALLDATA_COUNT = 10;
   if (calldatas.length > MAX_CALLDATA_COUNT) {
     throw new MockContractError(GovernorErrorCode.TooManyCalldataEntries, ...);
   }
   ```
3. Updated harness to initialize `maxCalldataSize` (defaults to 10_000)
4. Updated `GovernorSimulationSettings` interface to include optional `maxCalldataSize` field

### Issue #885: Pause/Unpause Modeling  
Added complete pause mechanism with authorization and state guards.

**Files**:
- `tools/simulation/src/mock/store.ts`
- `tools/simulation/src/mock/governor-executor.ts`
- `tools/simulation/src/harness.ts`

**Changes**:
1. Added to `GovernorSettingsState`:
   - `isPaused: boolean`
   - `pauser: string`
2. Added to `GovernorSimulationSettings` interface:
   - `pauser?: string` (defaults to guardian)
3. Added two new handler functions in `governorExecutor`:
   ```ts
   pause(store, clock, caller, args): null {
     if (caller !== gov.settings.pauser) {
       throw MockContractError(GovernorErrorCode.UnauthorizedPause, ...);
     }
     gov.settings.isPaused = true;
     return null;
   }

   unpause(store, clock, caller, args): null {
     if (caller !== gov.settings.pauser) {
       throw MockContractError(GovernorErrorCode.UnauthorizedPause, ...);
     }
     gov.settings.isPaused = false;
     return null;
   }
   ```
4. Added `ContractPaused` guard in `propose()` and `cast_vote()`:
   ```ts
   if (gov.settings.isPaused) {
     throw new MockContractError(GovernorErrorCode.ContractPaused, ...);
   }
   ```
5. Updated harness `buildSettingsState()` to:
   - Initialize `isPaused = false`
   - Set `pauser` to configured value or guardian address (sensible default)

## Testing

Added comprehensive test suite in `tools/simulation/tests/governor-mock-validation.sim.ts`:

**Issue #882 tests**:
- Verify ProposalNotActive has numeric value 31
- Verify VotePeriodTooShort exists and equals 28
- Verify TooManyCalldataEntries exists and equals 30

**Issue #883 tests**:
- Empty vectors → NoTargets (#10)
- Mismatched fnNames length → InvalidVectorLengths (#9)
- Mismatched calldatas length → InvalidVectorLengths (#9)

**Issue #884 tests**:
- Oversized calldata entry → CalldataTooLarge (#4)
- More than 10 entries → TooManyCalldataEntries (#30)
- Exactly 10 entries → succeeds

**Issue #885 tests**:
- propose() while paused → ContractPaused (#7)
- vote() while paused → ContractPaused (#7)
- Operations succeed after unpause

## Backward Compatibility

All changes maintain backward compatibility with existing test setups through sensible defaults:
- `maxCalldataSize` defaults to 10_000 (matching contract default)
- `isPaused` defaults to false
- `pauser` defaults to guardian address

Existing test suites that don't set these values will continue to work unchanged.

## Verification

- ✅ Error codes now match on-chain contract values exactly
- ✅ Validation logic mirrors `contracts/governor/src/lib.rs` behavior
- ✅ Mock executor returns identical errors as real contract for test scenarios
- ✅ All four issues addressable by SDK and harness consumers

Closes #882, Closes #883, Closes #884, Closes #885