### PR TITLE
fix(frontend): resolve treasury/delegates/draft wallet UX bugs

### DIFF
--- a/app/src/app/delegates/page.tsx
+++ b/app/src/app/delegates/page.tsx
@@ -61,6 +61,8 @@ export default function DelegatesPage() {
   const [currentDelegatee, setCurrentDelegatee] = useState<string | null>(null);
   const [offset, setOffset] = useState(0);
   const [hasMore, setHasMore] = useState(false);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [delegationMap, setDelegationMap] = useState<Map<string, string> | undefined>(undefined);
   const [client, setClient] = useState<VotesClient | null>(null);
   const { publicKey } = useWallet();
 
@@ -93,6 +95,10 @@ export default function DelegatesPage() {
         const result = await votesClient.getTopDelegates({ limit: PAGE_SIZE, offset: 0 });
         const page = Array.isArray(result) ? result : result.delegates;
         setDelegates(page);
+        if (!Array.isArray(result)) {
+          setCursor(result.nextCursor);
+          setDelegationMap(result.delegationMap);
+        }
         let total = 0n;
         for (const d of page) {
           total += d.votingPower;
@@ -123,9 +129,18 @@ export default function DelegatesPage() {
     if (!client || loadingMore) return;
     setLoadingMore(true);
     try {
-      const result = await client.getTopDelegates({ limit: PAGE_SIZE, offset });
+      const result = await client.getTopDelegates({
+        limit: PAGE_SIZE,
+        offset,
+        cursor: cursor ?? undefined,
+        delegationMap,
+      });
       const page = Array.isArray(result) ? result : result.delegates;
       setDelegates((prev) => [...prev, ...page]);
+      if (!Array.isArray(result)) {
+        setCursor(result.nextCursor);
+        setDelegationMap(result.delegationMap);
+      }
       setOffset((prev) => prev + PAGE_SIZE);
       setHasMore(page.length === PAGE_SIZE);
     } catch (err) {

--- a/app/src/app/drafts/[id]/page.tsx
+++ b/app/src/app/drafts/[id]/page.tsx
@@ -40,18 +40,19 @@ export default function DraftDetailPage() {
     !!publicKey && !!draft && draft.coSponsors.includes(publicKey);
 
   async function withWallet(action: (publicKey: string) => Promise<void>) {
-    if (!isConnected || !publicKey) {
+    let pk = publicKey;
+    if (!isConnected || !pk) {
       try {
-        await connect();
+        pk = await connect();
       } catch {
         toast.error("Please connect your wallet to continue.");
         return;
       }
     }
-    if (!publicKey) return;
+    if (!pk) return;
     setBusy(true);
     try {
-      await action(publicKey);
+      await action(pk);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : String(err));
     } finally {

--- a/app/src/app/treasury/streams/[id]/page.tsx
+++ b/app/src/app/treasury/streams/[id]/page.tsx
@@ -32,7 +32,10 @@ export default function StreamDetailPage() {
   const treasuryAddress = process.env.NEXT_PUBLIC_TREASURY_ADDRESS ?? "";
 
   const fetchData = useCallback(async () => {
-    if (!client || !publicKey) return;
+    if (!client || !publicKey) {
+      setLoading(false);
+      return;
+    }
     try {
       const [s, r, sp, gov] = await Promise.all([
         client.getStream(publicKey, streamId),
@@ -111,6 +114,17 @@ export default function StreamDetailPage() {
     return (
       <div className="max-w-4xl mx-auto p-4">
         <p className="text-gray-400">Loading stream...</p>
+      </div>
+    );
+  }
+
+  if (!publicKey) {
+    return (
+      <div className="max-w-4xl mx-auto p-4">
+        <Link href="/treasury/streams" className="text-xs text-gray-400 hover:text-gray-600">
+          ← Back to Streams
+        </Link>
+        <p className="text-gray-500 mt-4">Connect your wallet to view this stream</p>
       </div>
     );
   }

--- a/app/src/app/treasury/streams/page.tsx
+++ b/app/src/app/treasury/streams/page.tsx
@@ -29,7 +29,10 @@ export default function StreamsPage() {
   const tokenAddress = process.env.NEXT_PUBLIC_TREASURY_TOKEN_ADDRESS ?? "";
 
   const fetchData = useCallback(async () => {
-    if (!client || !publicKey) return;
+    if (!client || !publicKey) {
+      setLoading(false);
+      return;
+    }
     try {
       const [streamList, budgetSummary] = await Promise.all([
         client.getStreams(publicKey, 0, 50),
@@ -92,6 +95,10 @@ export default function StreamsPage() {
         <div className="md:col-span-2">
           {loading ? (
             <div className="text-center py-8 text-gray-400">Loading streams...</div>
+          ) : !publicKey ? (
+            <div className="border border-dashed border-gray-200 rounded-lg p-8 text-center">
+              <p className="text-sm text-gray-400">Connect your wallet to view streams</p>
+            </div>
           ) : error ? (
             <div className="border border-red-200 bg-red-50 rounded-lg p-8 text-center">
               <p className="text-sm text-red-600">Failed to load streams</p>

--- a/app/src/components/CoSponsorModal.tsx
+++ b/app/src/components/CoSponsorModal.tsx
@@ -26,15 +26,16 @@ export function CoSponsorModal({ draftId, onClose, onSuccess }: Props) {
   const [submitting, setSubmitting] = useState(false);
 
   async function handleConfirm() {
-    if (!isConnected || !publicKey) {
+    let pk = publicKey;
+    if (!isConnected || !pk) {
       try {
-        await connect();
+        pk = await connect();
       } catch {
         toast.error("Please connect your wallet to continue.");
         return;
       }
     }
-    if (!publicKey) return;
+    if (!pk) return;
 
     const config = readGovernorConfig();
     if (!config || !config.coSponsorshipAddress) {
@@ -45,7 +46,7 @@ export function CoSponsorModal({ draftId, onClose, onSuccess }: Props) {
     setSubmitting(true);
     try {
       const client = new CoSponsorshipClient(config);
-      const txHash = await client.coSponsorWithSign(publicKey, draftId, signTransaction);
+      const txHash = await client.coSponsorWithSign(pk, draftId, signTransaction);
       toast.success(
         <div>
           Co-sponsorship submitted!{" "}

--- a/app/src/components/StreamSpendModal.tsx
+++ b/app/src/components/StreamSpendModal.tsx
@@ -41,7 +41,13 @@ export function StreamSpendModal({
       return;
     }
 
-    const amt = BigInt(amount);
+    let amt: bigint;
+    try {
+      amt = BigInt(amount);
+    } catch {
+      toast.error("Enter a whole-number amount");
+      return;
+    }
     if (amt > remaining) {
       toast.error("Amount exceeds remaining budget");
       return;

--- a/app/src/lib/wallet-context.tsx
+++ b/app/src/lib/wallet-context.tsx
@@ -43,8 +43,8 @@ interface WalletContextValue {
   isConnected: boolean;
   isConnecting: boolean;
   error: string | null;
-  /** Opens the StellarWalletsKit modal */
-  connect: () => Promise<void>;
+  /** Opens the StellarWalletsKit modal. Resolves with the connected public key, or null if cancelled/failed. */
+  connect: () => Promise<string | null>;
   disconnect: () => void;
   /** Sign a prepared Soroban transaction XDR (fee-bump / classic TX). */
   signTransaction: (unsignedXdr: string) => Promise<string>;
@@ -88,7 +88,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     });
   }, []);
 
-  const connect = useCallback(async () => {
+  const connect = useCallback(async (): Promise<string | null> => {
     // E2E test mock — skip the Freighter modal and inject directly
     if (typeof window !== "undefined") {
       const mock = (window as unknown as Record<string, unknown>).__E2E_MOCK_WALLET__ as
@@ -97,15 +97,17 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
       if (mock) {
         setPublicKey(mock.publicKey);
         setAddress(mock.address);
-        return;
+        return mock.publicKey;
       }
     }
 
     const kit = kitRef.current;
-    if (!kit) return;
+    if (!kit) return null;
 
     setError(null);
     setIsConnecting(true);
+
+    let connectedPublicKey: string | null = null;
 
     try {
       await kit.openModal({
@@ -113,6 +115,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
           try {
             kit.setWallet(option.id);
             const { address: rawAddress } = await kit.getAddress();
+            connectedPublicKey = rawAddress;
             setAddress(truncateAddress(rawAddress));
             setPublicKey(rawAddress);
             if (typeof window !== "undefined" && "Notification" in window) {
@@ -144,6 +147,8 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     } finally {
       setIsConnecting(false);
     }
+
+    return connectedPublicKey;
   }, []);
 
   const disconnect = useCallback(async () => {


### PR DESCRIPTION
## Summary

- **#929** — Treasury stream list (`/treasury/streams`) and detail (`/treasury/streams/[id]`) pages got stuck in a permanent "Loading..." state when no wallet was connected, because the early return in `fetchData` skipped the `finally` block that clears `loading`. Both pages now clear loading and show a "Connect your wallet" prompt instead.
- **#928** — `StreamSpendModal`'s `BigInt(amount)` parse ran outside the surrounding try/catch, so any non-integer amount (e.g. `"100.50"`) threw an unhandled `SyntaxError` instead of showing a validation toast. Now wrapped in try/catch with a friendly `toast.error`.
- **#927** — The Delegates page's "Load More" called `getTopDelegates({ limit, offset })` without forwarding the SDK's `nextCursor`/`delegationMap`, forcing a full re-scan of chain history on every click. Now stores and forwards both between calls for true incremental pagination.
- **#926** — `drafts/[id]` page and `CoSponsorModal` shared a "connect wallet then act" helper that read `publicKey` from a closure captured before `connect()` resolved, so the very first click after connecting silently no-op'd (state update from `connect()` lands on the next render, too late for the closure). `connect()` in `wallet-context.tsx` now resolves with the freshly connected public key directly, and both callers use that returned value instead of the stale closed-over state.

## Test plan

- [x] `tsc --noEmit` on `app/` — no new errors introduced by these changes (pre-existing unrelated errors confirmed present on `origin/main` baseline: missing `@testing-library/user-event` dependency, stale SDK analytics type exports)
- [x] `eslint` clean on all 7 changed files
- [x] Verified in browser via local dev server (placeholder contract addresses, no live chain):
  - `/treasury/streams` and `/treasury/streams/1` now render "Connect your wallet..." instead of hanging on "Loading..." with no wallet connected
  - `/delegates` renders without crashing (RPC error shown is expected — placeholder contract address, not a real deployed contract)
  - `/drafts/1` renders without crashing
- [ ] Full wallet-connect flow (#926) and StreamSpendModal submit flow (#928) require a real wallet extension + deployed contracts to exercise end-to-end; not available in this environment, so verified by code inspection and type-checking only


Closes #929
Closes #928
Closes #927 
Closes #926