### PR TITLE
fix(indexer): GET /drafts?status=active never filters by expiry_ledger (closes #854)

### DIFF
--- a/packages/indexer/src/__tests__/api.test.ts
+++ b/packages/indexer/src/__tests__/api.test.ts
@@ -309,6 +309,57 @@ describe("GET /proposals with cursor pagination", () => {
     });
   });
 
+  describe("GET /drafts?status=... (expiry filtering, issue #854)", () => {
+    const activeDraft = { draft_id: 2, expiry_ledger: 5000, finalized: false, cancelled: false };
+    const expiredDraft = { draft_id: 1, expiry_ledger: 900, finalized: false, cancelled: false };
+
+    it("status=active includes a non-expired draft and filters by last_ledger", async () => {
+      (mockPool.query as jest.Mock)
+        // indexer_state last_ledger lookup
+        .mockResolvedValueOnce({ rows: [{ last_ledger: 1000 }] })
+        // drafts select
+        .mockResolvedValueOnce({ rows: [activeDraft], rowCount: 1 });
+
+      const response = await request(app).get("/drafts?status=active");
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toEqual([activeDraft]);
+      // Second query is the drafts SELECT; assert it carries the ledger bound.
+      const draftsCall = (mockPool.query as jest.Mock).mock.calls[1];
+      expect(draftsCall[0]).toContain("expiry_ledger >= $3");
+      expect(draftsCall[0]).toContain("finalized = false AND cancelled = false");
+      expect(draftsCall[1]).toEqual([20, 0, 1000]);
+    });
+
+    it("status=active excludes an expired-but-not-finalized draft (empty result)", async () => {
+      // The DB applies the WHERE clause; with the expired draft filtered out
+      // the SELECT returns no rows.
+      (mockPool.query as jest.Mock)
+        .mockResolvedValueOnce({ rows: [{ last_ledger: 1000 }] })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const response = await request(app).get("/drafts?status=active");
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toEqual([]);
+    });
+
+    it("status=expired returns the expired-but-not-finalized draft", async () => {
+      (mockPool.query as jest.Mock)
+        .mockResolvedValueOnce({ rows: [{ last_ledger: 1000 }] })
+        .mockResolvedValueOnce({ rows: [expiredDraft], rowCount: 1 });
+
+      const response = await request(app).get("/drafts?status=expired");
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toEqual([expiredDraft]);
+      const draftsCall = (mockPool.query as jest.Mock).mock.calls[1];
+      expect(draftsCall[0]).toContain("expiry_ledger < $3");
+      expect(draftsCall[0]).toContain("finalized = false AND cancelled = false");
+      expect(draftsCall[1]).toEqual([20, 0, 1000]);
+    });
+  });
+
   describe("GET /timelock endpoints", () => {
     it("GET /timelock/operations/:opId returns operation", async () => {
       const mockOp = { op_id: "010203", target: "G123", fn_name: "test", ready_at: "100", expires_at: "200", status: "scheduled", ledger: 50 };

--- a/packages/indexer/src/api.ts
+++ b/packages/indexer/src/api.ts
@@ -1321,20 +1321,45 @@ export function createApp(server: SorobanRpc.Server): express.Application {
     const key = `drafts:list:${status ?? ""}:${page}:${limit}`;
 
     try {
-      const conditions: string[] = [];
-      if (status === "active") {
-        conditions.push("finalized = false AND cancelled = false");
-      } else if (status === "finalized") {
-        conditions.push("finalized = true");
-      } else if (status === "cancelled") {
-        conditions.push("cancelled = true");
-      }
-      const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
-
       const data = await cached(key, TTL.proposals, async () => {
+        // Params start with limit/offset ($1/$2); an optional ledger bound is
+        // appended as $3 for the expiry-aware `active`/`expired` filters.
+        const params: (number | string)[] = [limit, (page - 1) * limit];
+        const conditions: string[] = [];
+
+        if (status === "active" || status === "expired") {
+          // Mirror the on-chain `get_active_drafts` exclusion
+          // (`current > expiry_ledger` => expired). Use the indexer's own
+          // `last_ledger` as the "current ledger" reference so the API and
+          // chain agree on which drafts have lapsed. See the `/stats`
+          // handler for the same `indexer_state` read.
+          const stateRes = await pool.query(
+            "SELECT last_ledger::int AS last_ledger FROM indexer_state WHERE id = 1",
+          );
+          const lastLedger: number = stateRes.rows[0]?.last_ledger ?? 0;
+          params.push(lastLedger);
+          if (status === "active") {
+            // Not finalized, not cancelled, and not past its expiry ledger.
+            conditions.push(
+              `finalized = false AND cancelled = false AND expiry_ledger >= $${params.length}`,
+            );
+          } else {
+            // Expired-but-never-finalized-or-cancelled.
+            conditions.push(
+              `finalized = false AND cancelled = false AND expiry_ledger < $${params.length}`,
+            );
+          }
+        } else if (status === "finalized") {
+          conditions.push("finalized = true");
+        } else if (status === "cancelled") {
+          conditions.push("cancelled = true");
+        }
+        const whereClause =
+          conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
         const result = await pool.query(
           `SELECT * FROM drafts ${whereClause} ORDER BY draft_id DESC LIMIT $1 OFFSET $2`,
-          [limit, (page - 1) * limit],
+          params,
         );
         return {
           data: result.rows,


### PR DESCRIPTION
## Summary
`GET /drafts?status=active` never compared against `expiry_ledger`, so an expired-but-unfinalized/uncancelled draft was reported as active forever (no reliance on the unreliable `DraftExpired` event). Added the `expiry_ledger >= last_ledger` condition (reading the same `indexer_state.last_ledger` used elsewhere in the indexer), and exposed a new `status=expired` option.

No schema migration needed — `expiry_ledger` already exists on the `drafts` table.

Closes #854

## Test plan
- [x] `npx jest api.test`: 29/29 pass, including 3 new cases (active-non-expired appears under `active`; expired-unfinalized does NOT appear under `active` but DOES under `expired`)