### PR TITLE
fix(co-sponsorship): TTL-extend draft child keys and dedup co_sponsor (closes #858)

### DIFF
--- a/contracts/co-sponsorship/src/lib.rs
+++ b/contracts/co-sponsorship/src/lib.rs
@@ -154,6 +154,19 @@ impl CoSponsorshipContract {
             env.storage()
                 .persistent()
                 .set(&DataKey::DraftExpiredEmitted(draft.id), &true);
+            // Extend the "expired emitted" flag TTL so the one-shot guard is
+            // not lost to archival, which would let the event re-emit on a
+            // later read (Issue #858).
+            let expiry_ledgers: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::DraftExpiryLedgers)
+                .unwrap_or(7_200);
+            env.storage().persistent().extend_ttl(
+                &DataKey::DraftExpiredEmitted(draft.id),
+                expiry_ledgers.saturating_add(1000),
+                expiry_ledgers.saturating_add(1000),
+            );
         }
     }
 
@@ -241,6 +254,15 @@ impl CoSponsorshipContract {
         env.storage()
             .persistent()
             .set(&DataKey::DraftList, &draft_list);
+        // The DraftList is read and rewritten on every create_draft, but its
+        // TTL was never bumped, so it could archive out from under a live set
+        // of drafts (Issue #858). Bump it on every write using the instance
+        // expiry config (this key is not draft-scoped).
+        env.storage().persistent().extend_ttl(
+            &DataKey::DraftList,
+            expiry_ledgers.saturating_add(1000),
+            expiry_ledgers.saturating_add(1000),
+        );
 
         events::emit_draft_created(&env, &draft);
 
@@ -268,6 +290,18 @@ impl CoSponsorshipContract {
             env.panic_with_error(CoSponsorshipError::AlreadyCoSponsored);
         }
 
+        // Defense-in-depth (Issue #858): the DraftCoSponsor map entry above
+        // could, in principle, archive and read back as "never pledged" (0),
+        // which would bypass the map-based guard. Independently verify the
+        // address is not already present in the draft's own `co_sponsors` Vec
+        // (the authoritative membership record) so a double-pledge is rejected
+        // even if the map entry alone would have missed it.
+        for i in 0..draft.co_sponsors.len() {
+            if draft.co_sponsors.get(i).unwrap() == sponsor {
+                env.panic_with_error(CoSponsorshipError::AlreadyCoSponsored);
+            }
+        }
+
         let max_co_sponsors: u32 = env
             .storage()
             .instance()
@@ -293,6 +327,19 @@ impl CoSponsorshipContract {
         env.storage().persistent().set(
             &DataKey::DraftCoSponsor(draft_id, sponsor.clone()),
             &power,
+        );
+        // Extend the per-sponsor pledge key's TTL so it does not archive
+        // before the draft itself expires (Issue #858), using the same
+        // instance expiry config the Draft key is bumped with in create_draft.
+        let expiry_ledgers: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::DraftExpiryLedgers)
+            .unwrap_or(7_200);
+        env.storage().persistent().extend_ttl(
+            &DataKey::DraftCoSponsor(draft_id, sponsor.clone()),
+            expiry_ledgers.saturating_add(1000),
+            expiry_ledgers.saturating_add(1000),
         );
         env.storage()
             .persistent()
@@ -393,6 +440,18 @@ impl CoSponsorshipContract {
         env.storage()
             .persistent()
             .set(&DataKey::DraftToProposal(draft_id), &proposal_id);
+        // Extend the draft->proposal mapping TTL so the promoted-proposal link
+        // survives as long as the draft lifecycle window (Issue #858).
+        let expiry_ledgers: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::DraftExpiryLedgers)
+            .unwrap_or(7_200);
+        env.storage().persistent().extend_ttl(
+            &DataKey::DraftToProposal(draft_id),
+            expiry_ledgers.saturating_add(1000),
+            expiry_ledgers.saturating_add(1000),
+        );
 
         events::emit_draft_finalized(&env, draft_id, proposal_id);
 

--- a/contracts/co-sponsorship/src/tests.rs
+++ b/contracts/co-sponsorship/src/tests.rs
@@ -183,6 +183,35 @@ fn test_co_sponsor_same_address_twice_reverts() {
     client.co_sponsor(&sponsor, &draft_id);
 }
 
+/// Issue #858 defense-in-depth: even if the `DraftCoSponsor` map entry
+/// archived away and read back as "never pledged" (0), the same address must
+/// still not be pushable into `co_sponsors` twice, because `co_sponsor` now
+/// independently checks Vec membership. We simulate the archived map entry by
+/// removing it directly from contract storage, then re-pledging — which must
+/// still revert with AlreadyCoSponsored (#5).
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_co_sponsor_vec_membership_blocks_double_pledge_when_map_entry_missing() {
+    let (env, client, votes, _admin) = setup(1_000);
+    let creator = Address::generate(&env);
+    let sponsor = Address::generate(&env);
+    votes.set_power(&sponsor, &400);
+
+    let draft_id = create_draft(&env, &client, &creator);
+    client.co_sponsor(&sponsor, &draft_id);
+
+    // Simulate the map-based guard being defeated (entry gone / archived).
+    let contract_id = client.address.clone();
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .remove(&crate::DataKey::DraftCoSponsor(draft_id, sponsor.clone()));
+    });
+
+    // Second pledge must still be rejected by the Vec-membership check.
+    client.co_sponsor(&sponsor, &draft_id);
+}
+
 #[test]
 fn test_withdraw_co_sponsorship_reduces_total_power() {
     let (env, client, votes, _admin) = setup(1_000);


### PR DESCRIPTION
## Summary
`DraftList`, `DraftCoSponsor(draft_id, sponsor)`, `DraftToProposal(draft_id)`, and `DraftExpiredEmitted(draft_id)` were never explicitly TTL-extended, risking archival-driven bricking of `create_draft` (via `DraftList`) and double-counted pledges if a `DraftCoSponsor` entry archived before its parent `Draft` (the duplicate-pledge guard's `unwrap_or(0)` fallback would then read "never pledged"). Added explicit `extend_ttl` calls on all four, using the same `expiry_ledgers`-derived bump `Draft(draft_id)` already gets. As defense-in-depth, `co_sponsor` now also checks `draft.co_sponsors` Vec membership directly, so a double-pledge is rejected even if the map-based guard alone would have missed it.

Closes #858

## Test plan
- [ ] `cargo test -p co-sponsorship` — could not be run in my environment (no working linker); written by close reading of the existing TTL/storage patterns in this file
- [x] Added a test simulating a stale/archived `DraftCoSponsor` entry and confirming the Vec-membership guard still rejects the double-pledge