### PR TITLE
feat(co-sponsorship): add spam/rate-limit protection to create_draft (closes #856)

### DIFF
--- a/contracts/co-sponsorship/src/error.rs
+++ b/contracts/co-sponsorship/src/error.rs
@@ -18,4 +18,8 @@ pub enum CoSponsorshipError {
     NoTargets = 12,
     CalldataTooLarge = 13,
     TooManyCalldataEntries = 14,
+    /// Creator attempted a new draft before their cooldown elapsed (#856).
+    CooldownActive = 15,
+    /// Creator exceeded the max drafts allowed within the period (#856).
+    TooManyDraftsInPeriod = 16,
 }

--- a/contracts/co-sponsorship/src/lib.rs
+++ b/contracts/co-sponsorship/src/lib.rs
@@ -71,10 +71,30 @@ pub enum DataKey {
     DraftCoSponsor(u64, Address),
     DraftToProposal(u64),
     DraftExpiredEmitted(u64),
+    /// Last ledger at which an address created a draft (for cooldown). (#856)
+    LastDraftLedger(Address),
+    /// Draft count for an address within a rate-limit period. (#856)
+    DraftsInPeriod(Address, u32),
+    /// Minimum ledgers between drafts from the same creator (cooldown). (#856)
+    DraftCooldown,
+    /// Maximum drafts per creator per period. (#856)
+    MaxDraftsPerPeriod,
+    /// Period duration in ledgers for draft rate limiting. (#856)
+    DraftPeriodDuration,
 }
 
 const MAX_CALLDATA_SIZE: u32 = 10_000;
 const MAX_CALLDATA_COUNT: u32 = 10;
+
+/// Rate-limit defaults for create_draft (Issue #856). Drafts are lighter,
+/// pre-proposal artifacts expected to be created more frequently than full
+/// governor proposals, so these are somewhat more permissive than the
+/// governor's proposal rate limit (cooldown 100 / max 5 per period) while
+/// still bounding spam: a shorter 50-ledger cooldown and up to 10 drafts per
+/// creator per (unchanged) 10_000-ledger period.
+const DEFAULT_DRAFT_COOLDOWN: u32 = 50;
+const DEFAULT_MAX_DRAFTS_PER_PERIOD: u32 = 10;
+const DEFAULT_DRAFT_PERIOD_DURATION: u32 = 10_000;
 
 #[contract]
 pub struct CoSponsorshipContract;
@@ -108,6 +128,17 @@ impl CoSponsorshipContract {
         env.storage()
             .persistent()
             .set(&DataKey::DraftList, &Vec::<u64>::new(&env));
+        // Rate-limit config defaults (Issue #856), governance-tunable via
+        // instance storage. See the DEFAULT_DRAFT_* constants for rationale.
+        env.storage()
+            .instance()
+            .set(&DataKey::DraftCooldown, &DEFAULT_DRAFT_COOLDOWN);
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxDraftsPerPeriod, &DEFAULT_MAX_DRAFTS_PER_PERIOD);
+        env.storage()
+            .instance()
+            .set(&DataKey::DraftPeriodDuration, &DEFAULT_DRAFT_PERIOD_DURATION);
     }
 
     fn must_get_draft(env: &Env, draft_id: u64) -> ProposalDraft {
@@ -190,6 +221,46 @@ impl CoSponsorshipContract {
             env.panic_with_error(CoSponsorshipError::TooManyCalldataEntries);
         }
 
+        // Spam / rate-limit protection (Issue #856), mirroring the governor's
+        // create_proposal_internal cooldown + per-period cap, scoped to this
+        // contract's own storage and keyed by the draft creator.
+        let current_ledger = env.ledger().sequence();
+
+        let cooldown: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::DraftCooldown)
+            .unwrap_or(DEFAULT_DRAFT_COOLDOWN);
+        let last_draft_ledger: Option<u32> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LastDraftLedger(creator.clone()));
+        if let Some(last) = last_draft_ledger {
+            if current_ledger < last.saturating_add(cooldown) {
+                env.panic_with_error(CoSponsorshipError::CooldownActive);
+            }
+        }
+
+        let period_duration: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::DraftPeriodDuration)
+            .unwrap_or(DEFAULT_DRAFT_PERIOD_DURATION);
+        let max_drafts: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxDraftsPerPeriod)
+            .unwrap_or(DEFAULT_MAX_DRAFTS_PER_PERIOD);
+        let current_period = current_ledger / period_duration;
+        let drafts_in_period: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::DraftsInPeriod(creator.clone(), current_period))
+            .unwrap_or(0);
+        if drafts_in_period >= max_drafts {
+            env.panic_with_error(CoSponsorshipError::TooManyDraftsInPeriod);
+        }
+
         let count: u64 = env
             .storage()
             .instance()
@@ -241,6 +312,31 @@ impl CoSponsorshipContract {
         env.storage()
             .persistent()
             .set(&DataKey::DraftList, &draft_list);
+
+        // Update rate-limit storage (Issue #856), mirroring the governor.
+        env.storage()
+            .persistent()
+            .set(&DataKey::LastDraftLedger(creator.clone()), &current);
+        env.storage().persistent().extend_ttl(
+            &DataKey::LastDraftLedger(creator.clone()),
+            cooldown.saturating_add(1000),
+            cooldown.saturating_add(1000),
+        );
+        // Prune the previous period's count to avoid unbounded storage growth.
+        if current_period > 0 {
+            env.storage()
+                .persistent()
+                .remove(&DataKey::DraftsInPeriod(creator.clone(), current_period - 1));
+        }
+        env.storage().persistent().set(
+            &DataKey::DraftsInPeriod(creator.clone(), current_period),
+            &(drafts_in_period + 1),
+        );
+        env.storage().persistent().extend_ttl(
+            &DataKey::DraftsInPeriod(creator.clone(), current_period),
+            period_duration.saturating_add(1000),
+            period_duration.saturating_add(1000),
+        );
 
         events::emit_draft_created(&env, &draft);
 

--- a/contracts/co-sponsorship/src/tests.rs
+++ b/contracts/co-sponsorship/src/tests.rs
@@ -333,8 +333,12 @@ fn test_get_active_drafts_pagination() {
     let (env, client, _votes, _admin) = setup(1_000);
     let creator = Address::generate(&env);
 
+    // Advance the ledger past the draft cooldown (#856) between creations so
+    // the same creator can create several drafts without tripping the limit.
     for _ in 0..5 {
         create_draft(&env, &client, &creator);
+        env.ledger()
+            .set_sequence_number(env.ledger().sequence() + 100);
     }
 
     let page1 = client.get_active_drafts(&0, &2);
@@ -362,8 +366,13 @@ fn test_get_active_drafts_excludes_finalized_and_cancelled() {
     let sponsor = Address::generate(&env);
     votes.set_power(&sponsor, &2_000);
 
+    // Advance past the draft cooldown (#856) between creations.
     let open_id = create_draft(&env, &client, &creator);
+    env.ledger()
+        .set_sequence_number(env.ledger().sequence() + 100);
     let finalized_id = create_draft(&env, &client, &creator);
+    env.ledger()
+        .set_sequence_number(env.ledger().sequence() + 100);
     let cancelled_id = create_draft(&env, &client, &creator);
 
     client.co_sponsor(&sponsor, &finalized_id);
@@ -409,6 +418,59 @@ fn test_finalize_draft_rejects_non_creator() {
     let draft_id = create_draft(&env, &client, &creator);
     client.co_sponsor(&sponsor, &draft_id);
     client.finalize_draft(&attacker, &draft_id);
+}
+
+// ---------------------------------------------------------------------------
+// Draft rate-limiting tests (Issue #856)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "Error(Contract, #15)")]
+fn test_create_draft_cooldown_rejects_immediate_second() {
+    let (env, client, _votes, _admin) = setup(1_000);
+    let creator = Address::generate(&env);
+    create_draft(&env, &client, &creator);
+    // Second draft at the same ledger is within the cooldown window.
+    create_draft(&env, &client, &creator);
+}
+
+#[test]
+fn test_create_draft_after_cooldown_succeeds() {
+    let (env, client, _votes, _admin) = setup(1_000);
+    let creator = Address::generate(&env);
+    create_draft(&env, &client, &creator);
+    // Advance past the 50-ledger cooldown; the same creator may create again.
+    env.ledger()
+        .set_sequence_number(env.ledger().sequence() + 50);
+    let id2 = create_draft(&env, &client, &creator);
+    assert_eq!(id2, 2);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #16)")]
+fn test_create_draft_period_cap_rejects_excess() {
+    let (env, client, _votes, _admin) = setup(1_000);
+    let creator = Address::generate(&env);
+    // Create the max (10) allowed within the period, advancing past the
+    // cooldown but staying inside the 10_000-ledger period each time.
+    for _ in 0..10 {
+        create_draft(&env, &client, &creator);
+        env.ledger()
+            .set_sequence_number(env.ledger().sequence() + 60);
+    }
+    // The 11th draft within the same period must be rejected.
+    create_draft(&env, &client, &creator);
+}
+
+#[test]
+fn test_create_draft_rate_limit_is_per_creator() {
+    let (env, client, _votes, _admin) = setup(1_000);
+    let creator_a = Address::generate(&env);
+    let creator_b = Address::generate(&env);
+    create_draft(&env, &client, &creator_a);
+    // A different creator at the same ledger is unaffected by A's cooldown.
+    let id = create_draft(&env, &client, &creator_b);
+    assert_eq!(id, 2);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
`create_draft` had no cooldown or per-period cap, unlike the governor's own `create_proposal_internal`, so any address could spam-grow the persistent `DraftList` at only the base tx fee. Mirrored the governor's cooldown/rate-limit pattern (`LastDraftLedger`, `DraftsInPeriod`, `DraftCooldown`, `MaxDraftsPerPeriod`, plus a `DraftPeriodDuration`), scoped to co-sponsorship's own storage, with new `CooldownActive`/`TooManyDraftsInPeriod` errors.

**Defaults: 50-ledger cooldown, 10 drafts per 10,000-ledger period per creator** — more permissive than the governor's 100/5, since drafts are lighter pre-proposal artifacts expected to be created more frequently.

Closes #856

## Test plan
- [ ] `cargo test -p co-sponsorship` — could not be run in my environment (no working linker)
- [x] Added tests: immediate second draft rejected by cooldown; succeeds after cooldown elapses; 11th draft within a period rejected; a different creator is unaffected by another's cooldown/cap