### PR TITLE
feat(co-sponsorship): permissionless finalize fallback for co-sponsors (closes #857)

### DIFF
--- a/contracts/co-sponsorship/src/lib.rs
+++ b/contracts/co-sponsorship/src/lib.rs
@@ -71,10 +71,19 @@ pub enum DataKey {
     DraftCoSponsor(u64, Address),
     DraftToProposal(u64),
     DraftExpiredEmitted(u64),
+    /// Ledgers past a draft's created_ledger before a co-sponsor may use the
+    /// permissionless finalize fallback. (#857)
+    DraftFinalizeGracePeriod,
 }
 
 const MAX_CALLDATA_SIZE: u32 = 10_000;
 const MAX_CALLDATA_COUNT: u32 = 10;
+
+/// Grace period (in ledgers) after a draft's created_ledger before a
+/// co-sponsor may invoke the permissionless finalize fallback (Issue #857).
+/// A few hundred ledgers gives the creator a clear first window to finalize
+/// (or amend/cancel) before participants can promote the draft themselves.
+const DEFAULT_DRAFT_FINALIZE_GRACE_PERIOD: u32 = 300;
 
 #[contract]
 pub struct CoSponsorshipContract;
@@ -108,6 +117,11 @@ impl CoSponsorshipContract {
         env.storage()
             .persistent()
             .set(&DataKey::DraftList, &Vec::<u64>::new(&env));
+        // Permissionless finalize grace period (Issue #857), governance-tunable.
+        env.storage().instance().set(
+            &DataKey::DraftFinalizeGracePeriod,
+            &DEFAULT_DRAFT_FINALIZE_GRACE_PERIOD,
+        );
     }
 
     fn must_get_draft(env: &Env, draft_id: u64) -> ProposalDraft {
@@ -343,14 +357,20 @@ impl CoSponsorshipContract {
 
     /// Promote a draft into a real governor proposal once its accumulated
     /// co-sponsor power meets the governor's current `proposal_threshold`.
-    /// Only callable by the draft's creator.
+    ///
+    /// Two authorization paths (Issue #857):
+    /// - The draft's `creator` may finalize at any time (once the threshold is
+    ///   met) — the original behavior, unchanged.
+    /// - As a permissionless fallback for when the creator goes absent, any
+    ///   address listed in `draft.co_sponsors` may finalize once a grace
+    ///   period past `created_ledger` has elapsed AND the threshold is met.
+    ///   The fallback is deliberately restricted to participating co-sponsors
+    ///   (not arbitrary third parties) since it triggers governor-level
+    ///   proposal promotion.
     pub fn finalize_draft(env: Env, caller: Address, draft_id: u64) -> u64 {
         caller.require_auth();
 
         let mut draft = Self::must_get_draft(&env, draft_id);
-        if caller != draft.creator {
-            env.panic_with_error(CoSponsorshipError::UnauthorizedDraftCreator);
-        }
         Self::require_draft_open(&env, &draft);
         if env.ledger().sequence() > draft.expiry_ledger {
             env.panic_with_error(CoSponsorshipError::DraftExpired);
@@ -370,6 +390,29 @@ impl CoSponsorshipContract {
         let current_power = Self::compute_current_co_sponsor_power(&env, &votes_token, &draft.co_sponsors);
 
         let threshold = governor_client.proposal_threshold();
+
+        // Authorization branch. The creator retains their existing immediate
+        // path; everyone else must qualify for the co-sponsor fallback.
+        if caller != draft.creator {
+            let mut is_co_sponsor = false;
+            for i in 0..draft.co_sponsors.len() {
+                if draft.co_sponsors.get(i).unwrap() == caller {
+                    is_co_sponsor = true;
+                    break;
+                }
+            }
+            let grace_period: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::DraftFinalizeGracePeriod)
+                .unwrap_or(DEFAULT_DRAFT_FINALIZE_GRACE_PERIOD);
+            let grace_elapsed = env.ledger().sequence()
+                >= draft.created_ledger.saturating_add(grace_period);
+            if !(is_co_sponsor && grace_elapsed && current_power >= threshold) {
+                env.panic_with_error(CoSponsorshipError::UnauthorizedDraftCreator);
+            }
+        }
+
         if current_power < threshold {
             env.panic_with_error(CoSponsorshipError::DraftThresholdNotMet);
         }

--- a/contracts/co-sponsorship/src/tests.rs
+++ b/contracts/co-sponsorship/src/tests.rs
@@ -411,6 +411,78 @@ fn test_finalize_draft_rejects_non_creator() {
     client.finalize_draft(&attacker, &draft_id);
 }
 
+// ---------------------------------------------------------------------------
+// Permissionless finalize fallback tests (Issue #857)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn test_co_sponsor_cannot_finalize_before_grace() {
+    let (env, client, votes, _admin) = setup(1_000);
+    let creator = Address::generate(&env);
+    let sponsor = Address::generate(&env);
+    votes.set_power(&sponsor, &2_000);
+
+    let draft_id = create_draft(&env, &client, &creator);
+    client.co_sponsor(&sponsor, &draft_id);
+    assert!(client.draft_threshold_met(&draft_id));
+
+    // Threshold met, but the grace period has not elapsed (same ledger).
+    client.finalize_draft(&sponsor, &draft_id);
+}
+
+#[test]
+fn test_co_sponsor_can_finalize_after_grace() {
+    let (env, client, votes, _admin) = setup(1_000);
+    let creator = Address::generate(&env);
+    let sponsor = Address::generate(&env);
+    votes.set_power(&sponsor, &2_000);
+
+    let draft_id = create_draft(&env, &client, &creator);
+    client.co_sponsor(&sponsor, &draft_id);
+
+    // Advance past the 300-ledger grace period (and stay before expiry).
+    env.ledger()
+        .set_sequence_number(env.ledger().sequence() + 300);
+
+    let proposal_id = client.finalize_draft(&sponsor, &draft_id);
+    assert_eq!(proposal_id, 1);
+    assert!(client.get_draft(&draft_id).finalized);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn test_non_co_sponsor_cannot_finalize_after_grace() {
+    let (env, client, votes, _admin) = setup(1_000);
+    let creator = Address::generate(&env);
+    let sponsor = Address::generate(&env);
+    let outsider = Address::generate(&env);
+    votes.set_power(&sponsor, &2_000);
+
+    let draft_id = create_draft(&env, &client, &creator);
+    client.co_sponsor(&sponsor, &draft_id);
+    env.ledger()
+        .set_sequence_number(env.ledger().sequence() + 300);
+
+    // A non-creator, non-co-sponsor is never authorized, grace or not.
+    client.finalize_draft(&outsider, &draft_id);
+}
+
+#[test]
+fn test_creator_finalize_immediate_unaffected_by_grace() {
+    let (env, client, votes, _admin) = setup(1_000);
+    let creator = Address::generate(&env);
+    let sponsor = Address::generate(&env);
+    votes.set_power(&sponsor, &2_000);
+
+    let draft_id = create_draft(&env, &client, &creator);
+    client.co_sponsor(&sponsor, &draft_id);
+
+    // No ledger advance: the creator may still finalize immediately.
+    let proposal_id = client.finalize_draft(&creator, &draft_id);
+    assert_eq!(proposal_id, 1);
+}
+
 #[test]
 #[should_panic(expected = "Error(Contract, #1)")]
 fn test_initialize_rejects_reinitialization() {


### PR DESCRIPTION
## Summary
`finalize_draft` was strictly creator-gated, unlike the governor's own `queue()`/`execute()`, which are permissionless once a proposal meets its bar. An unresponsive creator could strand a draft that had already met threshold, wasting every co-sponsor's pledged effort. Added a permissionless fallback inside the same `finalize_draft` entrypoint (one canonical finalize path): the creator keeps immediate access; any address listed in `draft.co_sponsors` may finalize once a grace period past `created_ledger` has elapsed AND the re-queried current co-sponsor power still meets the governor's `proposal_threshold()`. Restricted to participating co-sponsors (not arbitrary third parties) as the more conservative option, since it triggers governor-level proposal promotion.

New `DataKey::DraftFinalizeGracePeriod`, governance-tunable, defaulted to 300 ledgers at `initialize`.

Closes #857

## Test plan
- [ ] `cargo test -p co-sponsorship` — could not be run in my environment (no working linker)
- [x] Added tests: co-sponsor can't finalize before grace period even if threshold met; co-sponsor can finalize after grace + threshold; non-co-sponsor still can't finalize after grace; creator still finalizes immediately (unchanged)