### PR TITLE
test(co-sponsorship): add missing authorization and validation tests, fix frontend expired state

### DIFF
--- a/app/src/app/drafts/[id]/page.tsx
+++ b/app/src/app/drafts/[id]/page.tsx
@@ -7,6 +7,7 @@ import { CoSponsorshipClient } from "@nebgov/sdk";
 import { useDraft } from "../../../hooks/useDraft";
 import { useWallet } from "../../../lib/wallet-context";
 import { readGovernorConfig } from "../../../lib/nebgov-env";
+import { useLedgerClock } from "../../../lib/hooks/useLedgerClock";
 import { CoSponsorModal } from "../../../components/CoSponsorModal";
 import { Skeleton } from "../../../components/ui/Skeleton";
 
@@ -26,6 +27,7 @@ export default function DraftDetailPage() {
 
   const { draft, loading, error, refetch } = useDraft(draftId);
   const { isConnected, connect, publicKey, signTransaction } = useWallet();
+  const { currentLedger } = useLedgerClock();
   const [showCoSponsorModal, setShowCoSponsorModal] = useState(false);
   const [busy, setBusy] = useState(false);
 
@@ -38,6 +40,7 @@ export default function DraftDetailPage() {
   const isCreator = !!publicKey && !!draft && publicKey === draft.creator;
   const alreadyCoSponsored =
     !!publicKey && !!draft && draft.coSponsors.includes(publicKey);
+  const isExpired = !!draft && currentLedger > draft.expiryLedger;
 
   async function withWallet(action: (publicKey: string) => Promise<void>) {
     let pk = publicKey;
@@ -115,16 +118,23 @@ export default function DraftDetailPage() {
             <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
               Draft #{draft.id.toString()}
             </h1>
-            {draft.finalized && (
-              <span className="text-xs font-medium px-2 py-1 rounded-full bg-green-100 text-green-800">
-                Finalized
-              </span>
-            )}
-            {draft.cancelled && (
-              <span className="text-xs font-medium px-2 py-1 rounded-full bg-gray-100 text-gray-600">
-                Cancelled
-              </span>
-            )}
+            <div className="flex gap-2">
+              {draft.finalized && (
+                <span className="text-xs font-medium px-2 py-1 rounded-full bg-green-100 text-green-800">
+                  Finalized
+                </span>
+              )}
+              {draft.cancelled && (
+                <span className="text-xs font-medium px-2 py-1 rounded-full bg-gray-100 text-gray-600">
+                  Cancelled
+                </span>
+              )}
+              {isExpired && (
+                <span className="text-xs font-medium px-2 py-1 rounded-full bg-orange-100 text-orange-800">
+                  Expired
+                </span>
+              )}
+            </div>
           </div>
           <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
             Created by {formatAddress(draft.creator)}
@@ -155,7 +165,7 @@ export default function DraftDetailPage() {
             </ul>
           </div>
 
-          {!draft.finalized && !draft.cancelled && (
+          {!draft.finalized && !draft.cancelled && !isExpired && (
             <div className="flex flex-wrap gap-3">
               {!alreadyCoSponsored && (
                 <button

--- a/contracts/co-sponsorship/src/lib.rs
+++ b/contracts/co-sponsorship/src/lib.rs
@@ -232,6 +232,16 @@ impl CoSponsorshipContract {
         );
         env.storage().instance().set(&DataKey::DraftCount, &draft_id);
 
+        // Append to DraftList. This operation reads and rewrites the entire
+        // historical list of draft IDs on every create_draft call. DraftList
+        // is never pruned, even for long-finalized, cancelled, or expired
+        // drafts, so this grows unboundedly and the cost (CPU/fee) of every
+        // create_draft call increases linearly with the total number of drafts
+        // ever created. Fine at current scale; if draft volume grows this
+        // should move to an indexer-first design (the indexer already tracks
+        // every draft via events) with a bounded on-chain DraftCount for
+        // iteration only when off-chain data isn't available, or periodic
+        // compaction to drop terminal draft IDs.
         let mut draft_list: Vec<u64> = env
             .storage()
             .persistent()

--- a/contracts/co-sponsorship/src/tests.rs
+++ b/contracts/co-sponsorship/src/tests.rs
@@ -151,6 +151,97 @@ fn test_create_draft_succeeds_below_threshold() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #11)")]
+fn test_create_draft_rejects_mismatched_vector_lengths() {
+    let (env, client, _votes, _admin) = setup(1_000);
+    let creator = Address::generate(&env);
+    let targets = soroban_sdk::vec![&env, Address::generate(&env)];
+    let fn_names = soroban_sdk::vec![&env, Symbol::new(&env, "test"), Symbol::new(&env, "other")];
+    let calldatas = soroban_sdk::vec![&env, Bytes::new(&env)];
+
+    client.create_draft(
+        &creator,
+        &String::from_str(&env, "test draft"),
+        &env.crypto().sha256(&Bytes::new(&env)).into(),
+        &String::from_str(&env, "https://example.com/draft"),
+        &targets,
+        &fn_names,
+        &calldatas,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #12)")]
+fn test_create_draft_rejects_empty_targets() {
+    let (env, client, _votes, _admin) = setup(1_000);
+    let creator = Address::generate(&env);
+    let targets = soroban_sdk::vec![&env];
+    let fn_names = soroban_sdk::vec![&env];
+    let calldatas = soroban_sdk::vec![&env];
+
+    client.create_draft(
+        &creator,
+        &String::from_str(&env, "test draft"),
+        &env.crypto().sha256(&Bytes::new(&env)).into(),
+        &String::from_str(&env, "https://example.com/draft"),
+        &targets,
+        &fn_names,
+        &calldatas,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #13)")]
+fn test_create_draft_rejects_oversized_calldata() {
+    let (env, client, _votes, _admin) = setup(1_000);
+    let creator = Address::generate(&env);
+    let targets = soroban_sdk::vec![&env, Address::generate(&env)];
+    let fn_names = soroban_sdk::vec![&env, Symbol::new(&env, "test")];
+
+    // Create calldata larger than MAX_CALLDATA_SIZE (10_000 bytes)
+    const LARGE_DATA: &[u8; 10_001] = &[0x42u8; 10_001];
+    let calldata = Bytes::from_array(&env, LARGE_DATA);
+    let calldatas = soroban_sdk::vec![&env, calldata];
+
+    client.create_draft(
+        &creator,
+        &String::from_str(&env, "test draft"),
+        &env.crypto().sha256(&Bytes::new(&env)).into(),
+        &String::from_str(&env, "https://example.com/draft"),
+        &targets,
+        &fn_names,
+        &calldatas,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #14)")]
+fn test_create_draft_rejects_too_many_calldata_entries() {
+    let (env, client, _votes, _admin) = setup(1_000);
+    let creator = Address::generate(&env);
+    let mut targets = soroban_sdk::vec![&env];
+    let mut fn_names = soroban_sdk::vec![&env];
+    let mut calldatas = soroban_sdk::vec![&env];
+
+    // Create 11 entries, exceeding MAX_CALLDATA_COUNT (10)
+    for _ in 0..11 {
+        targets.push_back(Address::generate(&env));
+        fn_names.push_back(Symbol::new(&env, "test"));
+        calldatas.push_back(Bytes::new(&env));
+    }
+
+    client.create_draft(
+        &creator,
+        &String::from_str(&env, "test draft"),
+        &env.crypto().sha256(&Bytes::new(&env)).into(),
+        &String::from_str(&env, "https://example.com/draft"),
+        &targets,
+        &fn_names,
+        &calldatas,
+    );
+}
+
+#[test]
 fn test_co_sponsor_accumulates_power() {
     let (env, client, votes, _admin) = setup(1_000);
     let creator = Address::generate(&env);
@@ -269,6 +360,17 @@ fn test_cancel_draft_by_guardian() {
 
     client.cancel_draft(&admin, &draft_id);
     assert!(client.get_draft(&draft_id).cancelled);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn test_cancel_draft_rejects_unrelated_caller() {
+    let (env, client, _votes, _admin) = setup(1_000);
+    let creator = Address::generate(&env);
+    let unrelated = Address::generate(&env);
+    let draft_id = create_draft(&env, &client, &creator);
+
+    client.cancel_draft(&unrelated, &draft_id);
 }
 
 #[test]


### PR DESCRIPTION
Closes #863, Closes #860, Closes #861, Closes #864

- Add test_cancel_draft_rejects_unrelated_caller to catch regressions in cancel_draft authorization checks (neither creator nor admin)
- Add four create_draft input-validation tests covering all error paths:
  - test_create_draft_rejects_mismatched_vector_lengths (InvalidVectorLengths)
  - test_create_draft_rejects_empty_targets (NoTargets)
  - test_create_draft_rejects_oversized_calldata (CalldataTooLarge)
  - test_create_draft_rejects_too_many_calldata_entries (TooManyCalldataEntries)
- Implement Expired state on draft detail page: compute isExpired client-side, render Expired badge, and gate action buttons on !isExpired
- Add documentation comment on unbounded DraftList growth in create_draft, matching existing read-side pattern from get_active_drafts