### PR TITLE
fix(frontend,indexer): treasury stream UX fixes and draft-expiry persistence

### DIFF
--- a/app/src/app/treasury/streams/[id]/page.tsx
+++ b/app/src/app/treasury/streams/[id]/page.tsx
@@ -13,6 +13,8 @@ import {
 } from "../../../../lib/treasury-client";
 import { StreamUtilizationBar } from "../../../../components/StreamUtilizationBar";
 import { StreamSpendModal } from "../../../../components/StreamSpendModal";
+import { ExtendStreamModal } from "../../../../components/ExtendStreamModal";
+import { TopUpStreamModal } from "../../../../components/TopUpStreamModal";
 
 type StellarNetwork = "mainnet" | "testnet" | "futurenet";
 
@@ -26,6 +28,9 @@ export default function StreamDetailPage() {
   const [loading, setLoading] = useState(true);
   const [isGovernor, setIsGovernor] = useState(false);
   const [showSpend, setShowSpend] = useState(false);
+  const [showExtend, setShowExtend] = useState(false);
+  const [showTopUp, setShowTopUp] = useState(false);
+  const [actionBusy, setActionBusy] = useState(false);
   const [client, setClient] = useState<TreasuryClient | null>(null);
 
   const network: StellarNetwork = (process.env.NEXT_PUBLIC_NETWORK as StellarNetwork) ?? "testnet";
@@ -70,40 +75,17 @@ export default function StreamDetailPage() {
   };
 
   const handleRevoke = async () => {
-    if (!client || !publicKey || !stream) return;
+    if (!client || !publicKey || !stream || actionBusy) return;
     if (!confirm("Are you sure you want to revoke this stream?")) return;
+    setActionBusy(true);
     try {
       await client.revokeStream(publicKey, streamId, handleSignXdr);
       toast.success("Stream revoked");
       fetchData();
     } catch (err) {
       toast.error(`Revoke failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  };
-
-  const handleExtend = async () => {
-    if (!client || !publicKey || !stream) return;
-    const newEnd = prompt("Enter new end ledger:", String(stream.endLedger + 50000));
-    if (!newEnd) return;
-    try {
-      await client.extendStream(publicKey, streamId, Number(newEnd), handleSignXdr);
-      toast.success("Stream extended");
-      fetchData();
-    } catch (err) {
-      toast.error(`Extend failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  };
-
-  const handleTopUp = async () => {
-    if (!client || !publicKey || !stream) return;
-    const amount = prompt("Enter additional allocation amount:");
-    if (!amount) return;
-    try {
-      await client.topUpStream(publicKey, streamId, BigInt(amount), handleSignXdr);
-      toast.success("Stream topped up");
-      fetchData();
-    } catch (err) {
-      toast.error(`Top-up failed: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setActionBusy(false);
     }
   };
 
@@ -234,28 +216,29 @@ export default function StreamDetailPage() {
               {isOwner && stream.isActive && (
                 <button
                   onClick={() => setShowSpend(true)}
-                  className="bg-indigo-600 text-white rounded-md px-3 py-1.5 text-xs hover:bg-indigo-700"
+                  disabled={actionBusy}
+                  className="bg-indigo-600 text-white rounded-md px-3 py-1.5 text-xs hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Spend
                 </button>
               )}
               <button
-                onClick={handleExtend}
-                disabled={!isGovernor || stream.isRevoked}
+                onClick={() => setShowExtend(true)}
+                disabled={!isGovernor || stream.isRevoked || actionBusy}
                 className="border border-gray-300 text-gray-700 rounded-md px-3 py-1.5 text-xs hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-white"
               >
                 Extend
               </button>
               <button
-                onClick={handleTopUp}
-                disabled={!isGovernor || stream.isRevoked}
+                onClick={() => setShowTopUp(true)}
+                disabled={!isGovernor || stream.isRevoked || actionBusy}
                 className="border border-gray-300 text-gray-700 rounded-md px-3 py-1.5 text-xs hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-white"
               >
                 Top Up
               </button>
               <button
                 onClick={handleRevoke}
-                disabled={!isGovernor || stream.isRevoked}
+                disabled={!isGovernor || stream.isRevoked || actionBusy}
                 className="border border-red-300 text-red-600 rounded-md px-3 py-1.5 text-xs hover:bg-red-50 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-white"
               >
                 Revoke
@@ -292,6 +275,32 @@ export default function StreamDetailPage() {
           signUnsignedXdr={handleSignXdr}
           onClose={() => setShowSpend(false)}
           onSpent={fetchData}
+        />
+      )}
+
+      {showExtend && client && publicKey && stream && (
+        <ExtendStreamModal
+          client={client}
+          stream={stream}
+          signerPublicKey={publicKey}
+          signUnsignedXdr={handleSignXdr}
+          busy={actionBusy}
+          setBusy={setActionBusy}
+          onClose={() => setShowExtend(false)}
+          onExtended={fetchData}
+        />
+      )}
+
+      {showTopUp && client && publicKey && stream && (
+        <TopUpStreamModal
+          client={client}
+          stream={stream}
+          signerPublicKey={publicKey}
+          signUnsignedXdr={handleSignXdr}
+          busy={actionBusy}
+          setBusy={setActionBusy}
+          onClose={() => setShowTopUp(false)}
+          onToppedUp={fetchData}
         />
       )}
     </div>

--- a/app/src/components/ExtendStreamModal.tsx
+++ b/app/src/components/ExtendStreamModal.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState } from "react";
+import toast from "react-hot-toast";
+import type { TreasuryClient, TreasuryBudgetStream } from "../lib/treasury-client";
+
+interface ExtendStreamModalProps {
+  client: TreasuryClient;
+  stream: TreasuryBudgetStream;
+  signerPublicKey: string;
+  signUnsignedXdr: (xdr: string) => Promise<string>;
+  busy: boolean;
+  setBusy: (busy: boolean) => void;
+  onClose: () => void;
+  onExtended: () => void;
+}
+
+export function ExtendStreamModal({
+  client,
+  stream,
+  signerPublicKey,
+  signUnsignedXdr,
+  busy,
+  setBusy,
+  onClose,
+  onExtended,
+}: ExtendStreamModalProps) {
+  const [newEndLedger, setNewEndLedger] = useState(String(stream.endLedger + 50000));
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const parsed = Number(newEndLedger);
+    if (!newEndLedger || !Number.isInteger(parsed) || parsed <= 0) {
+      setError("Enter a valid whole ledger number.");
+      return;
+    }
+    if (parsed <= stream.endLedger) {
+      setError(`New end ledger must be greater than the current end ledger (${stream.endLedger}).`);
+      return;
+    }
+
+    setBusy(true);
+    try {
+      await client.extendStream(signerPublicKey, Number(stream.id), parsed, signUnsignedXdr);
+      toast.success("Stream extended");
+      onExtended();
+      onClose();
+    } catch (err) {
+      toast.error(`Extend failed: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg p-6 w-full max-w-md">
+        <h2 className="text-lg font-semibold mb-1">Extend Stream</h2>
+        <p className="text-xs text-gray-500 mb-4">
+          {stream.name} — Current End Ledger: {stream.endLedger}
+        </p>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label className="text-xs text-gray-500">New End Ledger</label>
+            <input
+              type="number"
+              value={newEndLedger}
+              onChange={(e) => { setNewEndLedger(e.target.value); setError(""); }}
+              placeholder={String(stream.endLedger + 50000)}
+              className={`w-full border rounded-md px-3 py-2 text-sm ${
+                error ? "border-red-400" : "border-gray-300"
+              }`}
+              required
+            />
+            {error && <p className="text-xs text-red-500 mt-1">{error}</p>}
+          </div>
+          <div className="flex gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 border border-gray-300 text-gray-700 rounded-md py-2 text-sm hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={busy || !!error}
+              className="flex-1 bg-indigo-600 text-white rounded-md py-2 text-sm hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {busy ? "Extending..." : "Extend Stream"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/TopUpStreamModal.tsx
+++ b/app/src/components/TopUpStreamModal.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState } from "react";
+import toast from "react-hot-toast";
+import type { TreasuryClient, TreasuryBudgetStream } from "../lib/treasury-client";
+
+interface TopUpStreamModalProps {
+  client: TreasuryClient;
+  stream: TreasuryBudgetStream;
+  signerPublicKey: string;
+  signUnsignedXdr: (xdr: string) => Promise<string>;
+  busy: boolean;
+  setBusy: (busy: boolean) => void;
+  onClose: () => void;
+  onToppedUp: () => void;
+}
+
+export function TopUpStreamModal({
+  client,
+  stream,
+  signerPublicKey,
+  signUnsignedXdr,
+  busy,
+  setBusy,
+  onClose,
+  onToppedUp,
+}: TopUpStreamModalProps) {
+  const [amount, setAmount] = useState("");
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    let parsed: bigint;
+    try {
+      parsed = BigInt(amount);
+    } catch {
+      setError("Enter a valid whole number amount.");
+      return;
+    }
+    if (parsed <= 0n) {
+      setError("Amount must be greater than zero.");
+      return;
+    }
+
+    setBusy(true);
+    try {
+      await client.topUpStream(signerPublicKey, Number(stream.id), parsed, signUnsignedXdr);
+      toast.success("Stream topped up");
+      onToppedUp();
+      onClose();
+    } catch (err) {
+      toast.error(`Top-up failed: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg p-6 w-full max-w-md">
+        <h2 className="text-lg font-semibold mb-1">Top Up Stream</h2>
+        <p className="text-xs text-gray-500 mb-4">{stream.name} — Additional Allocation</p>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label className="text-xs text-gray-500">Amount</label>
+            <input
+              type="text"
+              value={amount}
+              onChange={(e) => { setAmount(e.target.value); setError(""); }}
+              placeholder="1000"
+              className={`w-full border rounded-md px-3 py-2 text-sm ${
+                error ? "border-red-400" : "border-gray-300"
+              }`}
+              required
+            />
+            {error && <p className="text-xs text-red-500 mt-1">{error}</p>}
+          </div>
+          <div className="flex gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 border border-gray-300 text-gray-700 rounded-md py-2 text-sm hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={busy || !!error}
+              className="flex-1 bg-indigo-600 text-white rounded-md py-2 text-sm hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {busy ? "Topping Up..." : "Top Up Stream"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/packages/indexer/migrations/008_add_draft_expired_column.sql
+++ b/packages/indexer/migrations/008_add_draft_expired_column.sql
@@ -1,0 +1,10 @@
+-- Up Migration
+
+ALTER TABLE drafts ADD COLUMN IF NOT EXISTS expired BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_drafts_expired ON drafts(expired);
+
+-- Down Migration
+
+DROP INDEX IF EXISTS idx_drafts_expired;
+ALTER TABLE drafts DROP COLUMN IF EXISTS expired;

--- a/packages/indexer/src/api.ts
+++ b/packages/indexer/src/api.ts
@@ -1323,11 +1323,19 @@ export function createApp(server: SorobanRpc.Server): express.Application {
     try {
       const conditions: string[] = [];
       if (status === "active") {
-        conditions.push("finalized = false AND cancelled = false");
+        // expired = false is a defense-in-depth backstop: DraftExpired is emitted
+        // lazily on-chain (only when a stale draft is next read), so it can lag
+        // behind reality. Also require expiry_ledger to still be in the future
+        // relative to the indexer's last-seen ledger.
+        conditions.push(
+          "finalized = false AND cancelled = false AND expired = false AND expiry_ledger > (SELECT last_ledger FROM indexer_state WHERE id = 1)",
+        );
       } else if (status === "finalized") {
         conditions.push("finalized = true");
       } else if (status === "cancelled") {
         conditions.push("cancelled = true");
+      } else if (status === "expired") {
+        conditions.push("expired = true");
       }
       const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 

--- a/packages/indexer/src/events.ts
+++ b/packages/indexer/src/events.ts
@@ -772,6 +772,138 @@ async function handleStreamExhausted(
   );
 }
 
+// --- Co-sponsorship / draft events (#767) ---
+
+async function handleDraftCreated(
+  event: SorobanRpc.Api.EventResponse,
+  topics: unknown[],
+): Promise<void> {
+  const creator = topics[1] as string;
+  const data = scValToNative(event.value) as Record<string, unknown>;
+  const draftId = String(data.draft_id as bigint);
+  const descriptionHashRaw = data.description_hash as Uint8Array | undefined;
+  const descriptionHash = descriptionHashRaw
+    ? Buffer.from(descriptionHashRaw).toString("hex")
+    : null;
+  const metadataUri = (data.metadata_uri as string) ?? null;
+  const createdLedger = Number(data.created_ledger);
+  const expiryLedger = Number(data.expiry_ledger);
+
+  await pool.query(
+    `INSERT INTO drafts (draft_id, creator_address, description_hash, metadata_uri, created_ledger, expiry_ledger)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     ON CONFLICT (draft_id) DO NOTHING`,
+    [draftId, creator, descriptionHash, metadataUri, createdLedger, expiryLedger],
+  );
+  invalidatePattern("drafts:");
+  broadcast({
+    type: "draft_created",
+    data: { draft_id: draftId, creator, metadata_uri: metadataUri, ledger: event.ledger },
+  });
+}
+
+async function handleCoSponsored(
+  event: SorobanRpc.Api.EventResponse,
+  topics: unknown[],
+): Promise<void> {
+  const sponsor = topics[1] as string;
+  const data = scValToNative(event.value) as unknown[];
+  const draftId = String(data[0] as bigint);
+  const power = String(data[1] as bigint);
+  const totalPower = String(data[2] as bigint);
+
+  await pool.query(
+    `INSERT INTO draft_co_sponsors (draft_id, sponsor_address, pledged_power, pledged_at_ledger)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (draft_id, sponsor_address)
+     DO UPDATE SET pledged_power = EXCLUDED.pledged_power, withdrawn = FALSE`,
+    [draftId, sponsor, power, event.ledger],
+  );
+  await pool.query(`UPDATE drafts SET total_power = $1 WHERE draft_id = $2`, [
+    totalPower,
+    draftId,
+  ]);
+  invalidatePattern("drafts:");
+  broadcast({
+    type: "co_sponsored",
+    data: { draft_id: draftId, sponsor, power, total_power: totalPower, ledger: event.ledger },
+  });
+}
+
+async function handleCoSponsorshipWithdrawn(
+  event: SorobanRpc.Api.EventResponse,
+  topics: unknown[],
+): Promise<void> {
+  const sponsor = topics[1] as string;
+  const data = scValToNative(event.value) as unknown[];
+  const draftId = String(data[0] as bigint);
+  const totalPower = String(data[2] as bigint);
+
+  await pool.query(
+    `UPDATE draft_co_sponsors SET withdrawn = TRUE WHERE draft_id = $1 AND sponsor_address = $2`,
+    [draftId, sponsor],
+  );
+  await pool.query(`UPDATE drafts SET total_power = $1 WHERE draft_id = $2`, [
+    totalPower,
+    draftId,
+  ]);
+  invalidatePattern("drafts:");
+  broadcast({
+    type: "co_sponsorship_withdrawn",
+    data: { draft_id: draftId, sponsor, total_power: totalPower, ledger: event.ledger },
+  });
+}
+
+async function handleDraftFinalized(
+  event: SorobanRpc.Api.EventResponse,
+): Promise<void> {
+  const data = scValToNative(event.value) as unknown[];
+  const draftId = String(data[0] as bigint);
+  const proposalId = String(data[1] as bigint);
+
+  await pool.query(
+    `UPDATE drafts SET finalized = TRUE, resulting_proposal_id = $1 WHERE draft_id = $2`,
+    [proposalId, draftId],
+  );
+  invalidatePattern("drafts:");
+  broadcast({
+    type: "draft_finalized",
+    data: { draft_id: draftId, proposal_id: proposalId, ledger: event.ledger },
+  });
+}
+
+async function handleDraftCancelled(
+  event: SorobanRpc.Api.EventResponse,
+): Promise<void> {
+  const data = scValToNative(event.value) as unknown[];
+  const draftId = String(data[0] as bigint);
+
+  await pool.query(`UPDATE drafts SET cancelled = TRUE WHERE draft_id = $1`, [
+    draftId,
+  ]);
+  invalidatePattern("drafts:");
+  broadcast({
+    type: "draft_cancelled",
+    data: { draft_id: draftId, ledger: event.ledger },
+  });
+}
+
+async function handleDraftExpired(
+  event: SorobanRpc.Api.EventResponse,
+): Promise<void> {
+  const data = scValToNative(event.value) as unknown[];
+  const draftId = String(data[0] as bigint);
+
+  await pool.query(`UPDATE drafts SET expired = TRUE WHERE draft_id = $1`, [
+    draftId,
+  ]);
+  invalidatePattern("drafts:");
+  broadcast({
+    type: "draft_expired",
+    data: { draft_id: draftId, ledger: event.ledger },
+  });
+}
+
 interface GovernorSettings {
   voting_delay: number;
   voting_period: number;


### PR DESCRIPTION
## Summary

Closes #931
Closes #932 
Closes #930 
Closes #918

- **#932** — `ExtendStreamModal` / `TopUpStreamModal` replace the native `prompt()` dialogs on the stream detail page, following the existing `CreateStreamModal`/`StreamSpendModal` pattern with proper numeric validation (new end ledger must be a valid integer greater than the current one; top-up amount must be a valid positive whole number).
- **#931** — Added a shared `actionBusy` state on the stream detail page. Revoke sets it directly around its async call; the new Extend/Top-Up modals receive it as a controlled prop instead of local state. All four action buttons (Spend/Extend/Top Up/Revoke) are disabled while any one is in flight, preventing duplicate concurrent transactions.
- **#918** — `handleDraftExpired` now persists to a new `drafts.expired` column (migration `008_add_draft_expired_column.sql`) instead of only broadcasting over the websocket. `GET /drafts?status=active` now excludes `expired = true` rows and, as defense-in-depth (since `DraftExpired` is emitted lazily on-chain and can lag reality), also requires `expiry_ledger > indexer_state.last_ledger`. Added a `status=expired` filter option.
- **#930** — Investigated and found this was already fixed on `main` by an unrelated commit (`5b14c80`, closing issues #878–881 under different numbers) before #930 was filed against the same code. The streams list already shows a distinct error banner + Retry button instead of the empty state on fetch failure. No code change needed; verified against current `main`.

### Pre-existing breakage found and fixed along the way (required for #918)

`packages/indexer/src/events.ts`'s `isCoSponsorship` switch branch called `handleDraftCreated`, `handleCoSponsored`, `handleCoSponsorshipWithdrawn`, `handleDraftFinalized`, `handleDraftCancelled`, and `handleDraftExpired` — none of which were defined anywhere in the file. The package didn't even type-check on `main`. This traces back to an earlier merge that silently dropped these handler bodies (confirmed by diffing against the last commit where they existed intact, `1cd4de9`). Restored all six from that commit, cross-checked against the current co-sponsorship contract's event shapes (`contracts/co-sponsorship/src/events.rs`) and the `drafts`/`draft_co_sponsors` table schema — both still match. Without this, `#918`'s fix to `handleDraftExpired` would be dead code, since `handleDraftCreated` never existing meant no rows ever landed in `drafts` to begin with.

### Known pre-existing issues left out of scope

The same file has further breakage from what looks like the same bad merge, untouched by this PR since it's unrelated to streams/drafts:
- Liquidity (`handleLiquidityAdded`/`Removed`/`Swap`/`PoolFeeUpdated`) and Timelock (13 handlers) event handlers are similarly referenced but undefined.
- `handleReputationUpdated` and `handleEffectiveThresholdChanged` are each defined twice with diverging logic (different `proposer_reputation` column names in the two versions).
- `index.ts` imports a `maybeTakeGovernanceSnapshot` export that doesn't exist.

There's no CI workflow for `packages/indexer`, which is how this sat undetected. Worth a maintainer follow-up/tracking issue.

## Test plan
- [x] `tsc --noEmit` on `packages/indexer`: the co-sponsorship/draft handler errors are fully resolved; only the pre-existing, unrelated errors listed above remain (confirmed unchanged before/after this PR's diff).
- [x] `tsc --noEmit` on `app`: no new errors from the changed files; remaining errors are pre-existing (missing `@testing-library/user-event` devDependency, stale SDK analytics exports — same gaps documented in prior PRs against this repo).
- [x] `eslint` clean on the changed frontend files.
- [ ] No Postgres/RPC available in this sandbox to run the indexer against a live chain — the migration and query changes are reviewed but not integration-tested end-to-end.