### PR TITLE
fix(frontend,sdk): wallet-sign delegation, drop hard reloads, real token decimals

### DIFF
--- a/app/src/app/delegates/page.tsx
+++ b/app/src/app/delegates/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { VotesClient, type TopDelegate, type Network } from "@nebgov/sdk";
 import { useWallet } from "../../lib/wallet-context";
@@ -66,64 +66,66 @@ export default function DelegatesPage() {
   const [client, setClient] = useState<VotesClient | null>(null);
   const { publicKey } = useWallet();
 
-  useEffect(() => {
-    async function fetchDelegates() {
-      try {
-        const governorAddress = process.env.NEXT_PUBLIC_GOVERNOR_ADDRESS;
-        const timelockAddress = process.env.NEXT_PUBLIC_TIMELOCK_ADDRESS;
-        const votesAddress = process.env.NEXT_PUBLIC_VOTES_ADDRESS;
-        const network = (process.env.NEXT_PUBLIC_NETWORK ||
-          "testnet") as Network;
-        const rpcUrl = process.env.NEXT_PUBLIC_RPC_URL;
+  const fetchDelegates = useCallback(async () => {
+    setLoading(true);
+    try {
+      const governorAddress = process.env.NEXT_PUBLIC_GOVERNOR_ADDRESS;
+      const timelockAddress = process.env.NEXT_PUBLIC_TIMELOCK_ADDRESS;
+      const votesAddress = process.env.NEXT_PUBLIC_VOTES_ADDRESS;
+      const network = (process.env.NEXT_PUBLIC_NETWORK ||
+        "testnet") as Network;
+      const rpcUrl = process.env.NEXT_PUBLIC_RPC_URL;
 
-        if (!governorAddress || !timelockAddress || !votesAddress) {
-          throw new Error("Missing required environment variables.");
-        }
-
-        const votesClient = new VotesClient({
-          governorAddress,
-          timelockAddress,
-          votesAddress,
-          network,
-          ...(rpcUrl && { rpcUrl }),
-        });
-        setClient(votesClient);
-
-        const supply = await votesClient.getTotalSupply();
-        setTotalSupply(supply);
-
-        const result = await votesClient.getTopDelegates({ limit: PAGE_SIZE, offset: 0 });
-        const page = Array.isArray(result) ? result : result.delegates;
-        setDelegates(page);
-        if (!Array.isArray(result)) {
-          setCursor(result.nextCursor);
-          setDelegationMap(result.delegationMap);
-        }
-        let total = 0n;
-        for (const d of page) {
-          total += d.votingPower;
-        }
-        setTotalDelegated(total);
-        setOffset(PAGE_SIZE);
-        setHasMore(page.length === PAGE_SIZE);
-
-        if (publicKey) {
-          setCurrentDelegatee(await votesClient.getDelegatee(publicKey));
-        } else {
-          setCurrentDelegatee(null);
-        }
-      } catch (err) {
-        console.error("Error fetching delegates:", err);
-        setError(
-          err instanceof Error ? err.message : "Failed to load delegates",
-        );
-      } finally {
-        setLoading(false);
+      if (!governorAddress || !timelockAddress || !votesAddress) {
+        throw new Error("Missing required environment variables.");
       }
-    }
 
-    fetchDelegates();
+      const votesClient = new VotesClient({
+        governorAddress,
+        timelockAddress,
+        votesAddress,
+        network,
+        ...(rpcUrl && { rpcUrl }),
+      });
+      setClient(votesClient);
+
+      const supply = await votesClient.getTotalSupply();
+      setTotalSupply(supply);
+
+      const result = await votesClient.getTopDelegates({ limit: PAGE_SIZE, offset: 0 });
+      const page = Array.isArray(result) ? result : result.delegates;
+      setDelegates(page);
+      if (!Array.isArray(result)) {
+        setCursor(result.nextCursor);
+        setDelegationMap(result.delegationMap);
+      }
+      let total = 0n;
+      for (const d of page) {
+        total += d.votingPower;
+      }
+      setTotalDelegated(total);
+      setOffset(PAGE_SIZE);
+      setHasMore(page.length === PAGE_SIZE);
+
+      if (publicKey) {
+        setCurrentDelegatee(await votesClient.getDelegatee(publicKey));
+      } else {
+        setCurrentDelegatee(null);
+      }
+      setError(null);
+    } catch (err) {
+      console.error("Error fetching delegates:", err);
+      setError(
+        err instanceof Error ? err.message : "Failed to load delegates",
+      );
+    } finally {
+      setLoading(false);
+    }
   }, [publicKey]);
+
+  useEffect(() => {
+    fetchDelegates();
+  }, [fetchDelegates]);
 
   async function loadMore() {
     if (!client || loadingMore) return;
@@ -336,7 +338,7 @@ export default function DelegatesPage() {
       <DelegateModal
         open={modalOpen}
         onClose={() => setModalOpen(false)}
-        onDelegated={() => window.location.reload()}
+        onDelegated={fetchDelegates}
         prefillAddress={prefillAddress}
         currentDelegatee={currentDelegatee}
         onOpenGasless={() => {
@@ -348,7 +350,7 @@ export default function DelegatesPage() {
       <GaslessDelegateModal
         open={gaslessModalOpen}
         onClose={() => setGaslessModalOpen(false)}
-        onDelegated={() => window.location.reload()}
+        onDelegated={fetchDelegates}
         prefillAddress={prefillAddress}
         topDelegates={delegates}
       />

--- a/app/src/components/DelegateModal.tsx
+++ b/app/src/components/DelegateModal.tsx
@@ -5,7 +5,6 @@
  */
 
 import { useEffect, useState, type FormEvent } from "react";
-import { Keypair } from "@stellar/stellar-sdk";
 import { isValidStellarAddress } from "../lib/utils/stellarAddress";
 import toast from "react-hot-toast";
 import { VotesClient, type Network } from "@nebgov/sdk";
@@ -41,16 +40,6 @@ function getVotesClientFromEnv(): VotesClient {
   });
 }
 
-function getDelegateSigner(): Keypair {
-  const secret = process.env.NEXT_PUBLIC_DELEGATE_SECRET_KEY;
-  if (!secret) {
-    throw new Error(
-      "Missing NEXT_PUBLIC_DELEGATE_SECRET_KEY (required to sign delegation txs in this demo app).",
-    );
-  }
-  return Keypair.fromSecret(secret);
-}
-
 function explorerTxUrl(txHash: string): string {
   const network = process.env.NEXT_PUBLIC_NETWORK || "testnet";
   const base =
@@ -71,7 +60,7 @@ export function DelegateModal({
   const [delegatee, setDelegatee] = useState(prefillAddress || "");
   const [delegateeError, setDelegateeError] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const { isConnected, publicKey } = useWallet();
+  const { isConnected, publicKey, signTransaction } = useWallet();
 
   useEffect(() => {
     setDelegatee(prefillAddress ?? "");
@@ -108,8 +97,7 @@ export function DelegateModal({
       }
 
       const client = getVotesClientFromEnv();
-      const signer = getDelegateSigner();
-      const txHash = await client.delegate(signer, delegatee.trim());
+      const txHash = await client.delegateWithSign(publicKey, delegatee.trim(), signTransaction);
       toast.success(
         <div>
           Delegation submitted!{" "}
@@ -138,8 +126,7 @@ export function DelegateModal({
     setSubmitting(true);
     try {
       const client = getVotesClientFromEnv();
-      const signer = getDelegateSigner();
-      const txHash = await client.undelegate(signer);
+      const txHash = await client.undelegateWithSign(publicKey, signTransaction);
       toast.success(
         <div>
           Undelegation submitted!{" "}

--- a/app/src/components/__tests__/DelegateModal.validation.test.tsx
+++ b/app/src/components/__tests__/DelegateModal.validation.test.tsx
@@ -14,6 +14,7 @@ jest.mock("../lib/wallet-context", () => ({
     isConnected: true,
     publicKey: VALID_ADDRESS_2,
     connect: jest.fn(),
+    signTransaction: jest.fn(),
   }),
 }));
 
@@ -24,20 +25,10 @@ jest.mock("react-hot-toast", () => ({
 
 jest.mock("@nebgov/sdk", () => ({
   VotesClient: jest.fn().mockImplementation(() => ({
-    delegate: jest.fn().mockResolvedValue("txhash123"),
-    undelegate: jest.fn().mockResolvedValue("txhash456"),
+    delegateWithSign: jest.fn().mockResolvedValue("txhash123"),
+    undelegateWithSign: jest.fn().mockResolvedValue("txhash456"),
   })),
 }));
-
-jest.mock("@stellar/stellar-sdk", () => {
-  const actual = jest.requireActual("@stellar/stellar-sdk");
-  return {
-    ...actual,
-    Keypair: {
-      fromSecret: jest.fn().mockReturnValue({ publicKey: () => VALID_ADDRESS_2 }),
-    },
-  };
-});
 
 const defaultProps = {
   open: true,
@@ -51,7 +42,6 @@ describe("DelegateModal — Stellar address validation", () => {
     process.env.NEXT_PUBLIC_GOVERNOR_ADDRESS = "CTEST_GOV";
     process.env.NEXT_PUBLIC_TIMELOCK_ADDRESS = "CTEST_TL";
     process.env.NEXT_PUBLIC_VOTES_ADDRESS = "CTEST_VOTES";
-    process.env.NEXT_PUBLIC_DELEGATE_SECRET_KEY = "SCZANGBA5RLKJRDNKPNM5HXJFKZGKZAZBCM5YWKZQKZQKZQKZQKZQKZ";
   });
 
   describe("rendering", () => {

--- a/app/src/hooks/useGovernorConfig.ts
+++ b/app/src/hooks/useGovernorConfig.ts
@@ -1,24 +1,107 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import {
+  Contract,
+  SorobanRpc,
+  TransactionBuilder,
+  Networks,
+  BASE_FEE,
+  scValToNative,
+} from "@stellar/stellar-sdk";
+
+type StellarNetwork = "mainnet" | "testnet" | "futurenet";
+
+const NETWORK_PASSPHRASES: Record<StellarNetwork, string> = {
+  mainnet: Networks.PUBLIC,
+  testnet: Networks.TESTNET,
+  futurenet: Networks.FUTURENET,
+};
+
+const RPC_URLS: Record<StellarNetwork, string> = {
+  mainnet: "https://soroban-rpc.mainnet.stellar.gateway.fm",
+  testnet: "https://soroban-testnet.stellar.org",
+  futurenet: "https://rpc-futurenet.stellar.org",
+};
+
+const DEFAULT_DECIMALS = 7;
 
 /**
  * Hook to access governance configuration including token decimals.
- * 
- * In a full implementation, this would integrate with the GovernorClient
- * from the SDK to fetch decimals from the contract. For now, it provides
- * a default of 7 (Stellar native asset standard).
+ *
+ * Queries the token-votes contract's `token()` entrypoint for the underlying
+ * asset, then that token's `decimals()`, using the same raw-simulate pattern
+ * already used by `governors/page.tsx` for `token()`/`name()`. Falls back to
+ * the Stellar-native default of 7 if the query fails (e.g. missing env vars
+ * or an RPC error), so callers always get a usable divisor.
  */
 export function useGovernorConfig() {
-  const [decimals, setDecimals] = useState<number>(7);
-  const [divisor, setDivisor] = useState<number>(10_000_000);
+  const [decimals, setDecimals] = useState<number>(DEFAULT_DECIMALS);
+  const [divisor, setDivisor] = useState<number>(10 ** DEFAULT_DECIMALS);
 
   useEffect(() => {
-    // TODO: Fetch decimals from GovernorClient when SDK integration is complete
-    // For now, use hardcoded default
-    const fetchedDecimals = 7;
-    setDecimals(fetchedDecimals);
-    setDivisor(Math.pow(10, fetchedDecimals));
+    let cancelled = false;
+
+    async function fetchDecimals() {
+      try {
+        const votesAddress = process.env.NEXT_PUBLIC_VOTES_ADDRESS;
+        const network = (process.env.NEXT_PUBLIC_NETWORK ||
+          "testnet") as StellarNetwork;
+        const rpcUrl = process.env.NEXT_PUBLIC_RPC_URL;
+        if (!votesAddress) return;
+
+        const server = new SorobanRpc.Server(rpcUrl ?? RPC_URLS[network], {
+          allowHttp: false,
+        });
+        const networkPassphrase = NETWORK_PASSPHRASES[network];
+
+        const votesContract = new Contract(votesAddress);
+        const tokenResult = await server.simulateTransaction(
+          new TransactionBuilder(await server.getAccount(votesAddress), {
+            fee: BASE_FEE,
+            networkPassphrase,
+          })
+            .addOperation(votesContract.call("token"))
+            .setTimeout(30)
+            .build(),
+        );
+        if (SorobanRpc.Api.isSimulationError(tokenResult)) return;
+        const tokenAddress = scValToNative(
+          (tokenResult as SorobanRpc.Api.SimulateTransactionSuccessResponse).result
+            ?.retval,
+        ) as string;
+        if (!tokenAddress) return;
+
+        const tokenContract = new Contract(tokenAddress);
+        const decimalsResult = await server.simulateTransaction(
+          new TransactionBuilder(await server.getAccount(tokenAddress), {
+            fee: BASE_FEE,
+            networkPassphrase,
+          })
+            .addOperation(tokenContract.call("decimals"))
+            .setTimeout(30)
+            .build(),
+        );
+        if (SorobanRpc.Api.isSimulationError(decimalsResult)) return;
+        const fetchedDecimals = Number(
+          scValToNative(
+            (decimalsResult as SorobanRpc.Api.SimulateTransactionSuccessResponse)
+              .result?.retval,
+          ),
+        );
+        if (cancelled || !Number.isFinite(fetchedDecimals)) return;
+
+        setDecimals(fetchedDecimals);
+        setDivisor(Math.pow(10, fetchedDecimals));
+      } catch {
+        // Keep the Stellar-native default (7) if the query fails.
+      }
+    }
+
+    void fetchDecimals();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   return { decimals, divisor };

--- a/app/src/lib/wallet-context.tsx
+++ b/app/src/lib/wallet-context.tsx
@@ -69,6 +69,8 @@ function truncateAddress(addr: string): string {
   return `${addr.slice(0, 4)}...${addr.slice(-4)}`;
 }
 
+const LS_WALLET_ID = "nebgov_wallet_id";
+
 // Provider
 
 export function WalletProvider({ children }: { children: React.ReactNode }) {
@@ -79,14 +81,49 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
   const [isConnecting, setIsConnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const applyConnectedWallet = useCallback(async (rawAddress: string) => {
+    setAddress(truncateAddress(rawAddress));
+    setPublicKey(rawAddress);
+    if (typeof window !== "undefined" && "Notification" in window) {
+      void Notification.requestPermission();
+    }
+
+    try {
+      const login = await backendFetch<{ token: string }>("/auth/login", {
+        method: "POST",
+        body: JSON.stringify({ wallet_address: rawAddress }),
+      });
+      setAuthToken(login.token);
+      await syncNotificationsFromBackend();
+    } catch {
+      // Backend is optional; localStorage notifications still work.
+    }
+  }, []);
+
   // Initialise the kit once — only on the client
   useEffect(() => {
-    kitRef.current = new StellarWalletsKit({
+    const kit = new StellarWalletsKit({
       network: WalletNetwork.TESTNET,
       selectedWalletId: FREIGHTER_ID,
       modules: [new FreighterModule(), new xBullModule(), new AlbedoModule()],
     });
-  }, []);
+    kitRef.current = kit;
+
+    // Restore a previously connected wallet session (e.g. after a page
+    // reload) instead of leaving the user disconnected until they click
+    // "connect wallet" again.
+    const lastWalletId =
+      typeof window !== "undefined" ? localStorage.getItem(LS_WALLET_ID) : null;
+    if (lastWalletId) {
+      kit.setWallet(lastWalletId);
+      kit
+        .getAddress({ skipRequestAccess: true })
+        .then(({ address: rawAddress }) => applyConnectedWallet(rawAddress))
+        .catch(() => {
+          localStorage.removeItem(LS_WALLET_ID);
+        });
+    }
+  }, [applyConnectedWallet]);
 
   const connect = useCallback(async (): Promise<string | null> => {
     // E2E test mock — skip the Freighter modal and inject directly
@@ -116,22 +153,10 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
             kit.setWallet(option.id);
             const { address: rawAddress } = await kit.getAddress();
             connectedPublicKey = rawAddress;
-            setAddress(truncateAddress(rawAddress));
-            setPublicKey(rawAddress);
-            if (typeof window !== "undefined" && "Notification" in window) {
-              void Notification.requestPermission();
+            if (typeof window !== "undefined") {
+              localStorage.setItem(LS_WALLET_ID, option.id);
             }
-
-            try {
-              const login = await backendFetch<{ token: string }>("/auth/login", {
-                method: "POST",
-                body: JSON.stringify({ wallet_address: rawAddress }),
-              });
-              setAuthToken(login.token);
-              await syncNotificationsFromBackend();
-            } catch {
-              // Backend is optional; localStorage notifications still work.
-            }
+            await applyConnectedWallet(rawAddress);
           } catch (err) {
             const msg =
               err instanceof Error ? err.message : "Failed to get address";
@@ -149,7 +174,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     }
 
     return connectedPublicKey;
-  }, []);
+  }, [applyConnectedWallet]);
 
   const disconnect = useCallback(async () => {
     const kit = kitRef.current;
@@ -164,6 +189,9 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     setPublicKey(null);
     setError(null);
     setAuthToken(null);
+    if (typeof window !== "undefined") {
+      localStorage.removeItem(LS_WALLET_ID);
+    }
   }, []);
 
   const signTransaction = useCallback(

--- a/sdk/src/votes.ts
+++ b/sdk/src/votes.ts
@@ -128,6 +128,46 @@ export class VotesClient {
   }
 
   /**
+   * Wallet-signing variant of {@link undelegate}: takes the signer's public
+   * key plus a callback that signs an unsigned XDR envelope (e.g. a
+   * wallet-kit `signTransaction`) instead of a raw {@link Keypair}. Mirrors
+   * `submitWithSign` in `coSponsorship.ts`.
+   *
+   * @returns The Stellar transaction hash, suitable for linking to a block explorer.
+   */
+  async undelegateWithSign(
+    signerPublicKey: string,
+    signUnsignedXdr: (xdr: string) => Promise<string>,
+  ): Promise<string> {
+    return this.retry(async () => {
+      const account = await this.server.getAccount(signerPublicKey);
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(
+          this.contract.call(
+            "undelegate",
+            nativeToScVal(signerPublicKey, { type: "address" }),
+          ),
+        )
+        .setTimeout(30)
+        .build();
+
+      const prepared = await this.server.prepareTransaction(tx);
+      const signedXdr = await signUnsignedXdr(prepared.toXDR());
+      const signed = TransactionBuilder.fromXDR(signedXdr, this.networkPassphrase);
+
+      const result = await this.server.sendTransaction(signed);
+      if (result.status === "ERROR") {
+        throw parseVotesError(result);
+      }
+      return result.hash;
+    }, (e) => this.isRetryableSubmissionError(e));
+  }
+
+  /**
    * Delegate voting power to another address (or self-delegate to activate votes).
    *
    * @returns The Stellar transaction hash, suitable for linking to a block explorer.
@@ -153,6 +193,48 @@ export class VotesClient {
       const prepared = await this.server.prepareTransaction(tx);
       prepared.sign(signer);
       const result = await this.server.sendTransaction(prepared);
+      if (result.status === "ERROR") {
+        throw parseVotesError(result);
+      }
+      return result.hash;
+    }, (e) => this.isRetryableSubmissionError(e));
+  }
+
+  /**
+   * Wallet-signing variant of {@link delegate}: takes the signer's public
+   * key plus a callback that signs an unsigned XDR envelope (e.g. a
+   * wallet-kit `signTransaction`) instead of a raw {@link Keypair}. Mirrors
+   * `submitWithSign` in `coSponsorship.ts`.
+   *
+   * @returns The Stellar transaction hash, suitable for linking to a block explorer.
+   */
+  async delegateWithSign(
+    signerPublicKey: string,
+    delegatee: string,
+    signUnsignedXdr: (xdr: string) => Promise<string>,
+  ): Promise<string> {
+    return this.retry(async () => {
+      const account = await this.server.getAccount(signerPublicKey);
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(
+          this.contract.call(
+            "delegate",
+            nativeToScVal(signerPublicKey, { type: "address" }),
+            nativeToScVal(delegatee, { type: "address" }),
+          ),
+        )
+        .setTimeout(30)
+        .build();
+
+      const prepared = await this.server.prepareTransaction(tx);
+      const signedXdr = await signUnsignedXdr(prepared.toXDR());
+      const signed = TransactionBuilder.fromXDR(signedXdr, this.networkPassphrase);
+
+      const result = await this.server.sendTransaction(signed);
       if (result.status === "ERROR") {
         throw parseVotesError(result);
       }


### PR DESCRIPTION
## Summary

- Closes #923 — `DelegateModal` signed delegate/undelegate transactions with a `Keypair` loaded from `NEXT_PUBLIC_DELEGATE_SECRET_KEY` instead of the connected wallet. `NEXT_PUBLIC_*` vars are inlined into the client bundle, so this shipped a private key to every visitor. Added `delegateWithSign`/`undelegateWithSign` to `VotesClient` (mirroring `CoSponsorshipClient.*WithSign`'s prepare → `signUnsignedXdr` → submit pattern) and wired `DelegateModal` to `useWallet().signTransaction`. `getDelegateSigner()` and the `Keypair` import are removed from the component entirely.
- Closes #924 — the delegates page called `window.location.reload()` immediately after `toast.success(...)`, tearing down the DOM (and the 8s toast with its Explorer link) before the user could see or click it.
- Closes #925 — the same `window.location.reload()` reset `WalletProvider`'s in-memory state, silently disconnecting the wallet after every delegate/undelegate/gasless-delegate action, and there was no mount-time session restore at all.
- Closes #937 — `useGovernorConfig` hardcoded 7 decimals (`divisor = 10_000_000`) instead of querying the actual token, so every voting-power number on the Delegates page and governor registry cards would be silently wrong for a non-7-decimal governance token.

## Changes

- `sdk/src/votes.ts`: added `VotesClient.delegateWithSign` / `undelegateWithSign`, wallet-signing variants of the existing `Keypair`-based methods, following the same `submitWithSign` pattern already used by `CoSponsorshipClient`.
- `app/src/components/DelegateModal.tsx`: use `useWallet().signTransaction` via the new SDK methods; removed the hardcoded-secret signer path.
- `app/src/app/delegates/page.tsx`: extracted the inline fetch effect into a reusable `fetchDelegates` callback and pass it as `onDelegated` to both `DelegateModal` and `GaslessDelegateModal`, replacing the two `window.location.reload()` calls with an in-place refetch.
- `app/src/lib/wallet-context.tsx`: `WalletProvider` now persists the selected wallet id (`localStorage`) on connect and attempts a silent mount-time restore (`kit.setWallet` + `kit.getAddress({ skipRequestAccess: true })`), clearing the id on disconnect or if restore fails. Shared the login/notification-sync logic between `connect()` and the restore path via a new `applyConnectedWallet` helper.
- `app/src/hooks/useGovernorConfig.ts`: queries the token-votes contract's `token()` and that token's `decimals()` via a raw simulate call (same pattern already used in `governors/page.tsx` for `token()`/`name()`), falling back to the Stellar-native default of 7 if the query fails.
- `app/src/components/__tests__/DelegateModal.validation.test.tsx`: updated mocks for the new `signTransaction` wallet-context field and `delegateWithSign`/`undelegateWithSign` SDK methods; removed the now-unused `NEXT_PUBLIC_DELEGATE_SECRET_KEY`/`Keypair.fromSecret` mock setup.

## Test plan

- [x] Manual review of all 6 changed files against the issues' suggested fixes and existing codebase patterns (`CoSponsorshipClient.submitWithSign`, `treasury/streams/page.tsx`'s `signTransaction` wiring, `governors/page.tsx`'s raw-simulate `token()`/`name()` calls).
- [x] `DelegateModal` validation test suite updated to match the new wallet-signing call shape (no test previously exercised a real submit path, so behavior coverage is unchanged).
- [ ] Live wallet connect/delegate/undelegate flow against a deployed testnet governor — needs a real wallet extension + funded testnet account, not available in this environment.
- [ ] Non-7-decimal token display — needs a governor deployed against a token with different decimals to verify end-to-end.
