### PR TITLE
fix: modal dialog a11y, reputation leaderboard pagination, effective-threshold history

### DIFF
--- a/app/src/components/CreateStreamModal.tsx
+++ b/app/src/components/CreateStreamModal.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import toast from "react-hot-toast";
 import type { TreasuryClient } from "../lib/treasury-client";
 import { isValidStellarAddress } from "../lib/utils/stellarAddress";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 interface CreateStreamModalProps {
   client: TreasuryClient;
@@ -32,6 +33,7 @@ export function CreateStreamModal({
   const [cooldownLedgers, setCooldownLedgers] = useState("0");
   const [proposalId, setProposalId] = useState("0");
   const [submitting, setSubmitting] = useState(false);
+  const dialogRef = useFocusTrap<HTMLDivElement>(true, onClose);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -70,9 +72,27 @@ export function CreateStreamModal({
   };
 
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+    <div
+      ref={dialogRef}
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="create-stream-modal-title"
+      tabIndex={-1}
+    >
       <div className="bg-white rounded-lg p-6 w-full max-w-md max-h-[90vh] overflow-y-auto">
-        <h2 className="text-lg font-semibold mb-4">Create Budget Stream</h2>
+        <div className="flex items-start justify-between mb-4">
+          <h2 id="create-stream-modal-title" className="text-lg font-semibold">
+            Create Budget Stream
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 p-1 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
         <form onSubmit={handleSubmit} className="space-y-3">
           <div>
             <label className="text-xs text-gray-500">Stream Name (symbol)</label>

--- a/app/src/components/DelegateModal.tsx
+++ b/app/src/components/DelegateModal.tsx
@@ -9,6 +9,7 @@ import { isValidStellarAddress } from "../lib/utils/stellarAddress";
 import toast from "react-hot-toast";
 import { VotesClient, type Network } from "@nebgov/sdk";
 import { useWallet } from "../lib/wallet-context";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 interface Props {
   open: boolean;
@@ -61,6 +62,7 @@ export function DelegateModal({
   const [delegateeError, setDelegateeError] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const { isConnected, publicKey, signTransaction } = useWallet();
+  const dialogRef = useFocusTrap<HTMLDivElement>(open, onClose);
 
   useEffect(() => {
     setDelegatee(prefillAddress ?? "");
@@ -147,11 +149,27 @@ export function DelegateModal({
   }
 
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+    <div
+      ref={dialogRef}
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="delegate-modal-title"
+      tabIndex={-1}
+    >
       <div className="bg-white rounded-2xl p-6 w-full max-w-md shadow-xl">
-        <h2 className="text-lg font-bold text-gray-900 mb-1">
-          Delegate Voting Power
-        </h2>
+        <div className="flex items-start justify-between mb-1">
+          <h2 id="delegate-modal-title" className="text-lg font-bold text-gray-900">
+            Delegate Voting Power
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 p-1 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
         <p className="text-sm text-gray-500 mb-4">
           Delegate to yourself to activate your voting power, or choose another
           address.

--- a/app/src/components/ExtendStreamModal.tsx
+++ b/app/src/components/ExtendStreamModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import toast from "react-hot-toast";
 import type { TreasuryClient, TreasuryBudgetStream } from "../lib/treasury-client";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 interface ExtendStreamModalProps {
   client: TreasuryClient;
@@ -27,6 +28,7 @@ export function ExtendStreamModal({
 }: ExtendStreamModalProps) {
   const [newEndLedger, setNewEndLedger] = useState(String(stream.endLedger + 50000));
   const [error, setError] = useState("");
+  const dialogRef = useFocusTrap<HTMLDivElement>(true, onClose);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -54,9 +56,27 @@ export function ExtendStreamModal({
   };
 
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+    <div
+      ref={dialogRef}
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="extend-stream-modal-title"
+      tabIndex={-1}
+    >
       <div className="bg-white rounded-lg p-6 w-full max-w-md">
-        <h2 className="text-lg font-semibold mb-1">Extend Stream</h2>
+        <div className="flex items-start justify-between mb-1">
+          <h2 id="extend-stream-modal-title" className="text-lg font-semibold">
+            Extend Stream
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 p-1 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
         <p className="text-xs text-gray-500 mb-4">
           {stream.name} — Current End Ledger: {stream.endLedger}
         </p>

--- a/app/src/components/GaslessDelegateModal.tsx
+++ b/app/src/components/GaslessDelegateModal.tsx
@@ -15,6 +15,7 @@ import {
   EXPIRY_PRESET_LABELS,
   type ExpiryPreset,
 } from "../hooks/useGaslessDelegation";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 interface Props {
   open: boolean;
@@ -48,6 +49,7 @@ export function GaslessDelegateModal({
   const [expiryPreset, setExpiryPreset] = useState<ExpiryPreset>("1month");
   const { isConnected, publicKey, connect } = useWallet();
   const { delegateGasless, submitting } = useGaslessDelegation();
+  const dialogRef = useFocusTrap<HTMLDivElement>(open, onClose);
 
   useEffect(() => {
     setDelegatee(prefillAddress ?? "");
@@ -102,11 +104,27 @@ export function GaslessDelegateModal({
   }
 
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+    <div
+      ref={dialogRef}
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="gasless-delegate-modal-title"
+      tabIndex={-1}
+    >
       <div className="bg-white rounded-2xl p-6 w-full max-w-md shadow-xl">
-        <h2 className="text-lg font-bold text-gray-900 mb-1">
-          Delegate for free — we pay the fee
-        </h2>
+        <div className="flex items-start justify-between mb-1">
+          <h2 id="gasless-delegate-modal-title" className="text-lg font-bold text-gray-900">
+            Delegate for free — we pay the fee
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 p-1 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
         <p className="text-sm text-gray-500 mb-4">
           Sign a delegation permit with your wallet. No transaction, no gas —
           our relayer submits it and pays the network fee for you.

--- a/app/src/components/StreamSpendModal.tsx
+++ b/app/src/components/StreamSpendModal.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import toast from "react-hot-toast";
 import type { TreasuryClient, TreasuryBudgetStream } from "../lib/treasury-client";
 import { isValidStellarAddress } from "../lib/utils/stellarAddress";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 interface StreamSpendModalProps {
   client: TreasuryClient;
@@ -27,6 +28,7 @@ export function StreamSpendModal({
   const [amount, setAmount] = useState("");
   const [memo, setMemo] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const dialogRef = useFocusTrap<HTMLDivElement>(true, onClose);
 
   const remaining = stream.totalAllocated - stream.totalSpent;
 
@@ -78,9 +80,27 @@ export function StreamSpendModal({
   };
 
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+    <div
+      ref={dialogRef}
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="stream-spend-modal-title"
+      tabIndex={-1}
+    >
       <div className="bg-white rounded-lg p-6 w-full max-w-md">
-        <h2 className="text-lg font-semibold mb-1">Spend from Stream</h2>
+        <div className="flex items-start justify-between mb-1">
+          <h2 id="stream-spend-modal-title" className="text-lg font-semibold">
+            Spend from Stream
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 p-1 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
         <p className="text-xs text-gray-500 mb-4">
           {stream.name} — Remaining: {remaining.toString()} / Max: {stream.maxSingleSpend.toString()}
         </p>

--- a/app/src/components/TopUpStreamModal.tsx
+++ b/app/src/components/TopUpStreamModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import toast from "react-hot-toast";
 import type { TreasuryClient, TreasuryBudgetStream } from "../lib/treasury-client";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 interface TopUpStreamModalProps {
   client: TreasuryClient;
@@ -27,6 +28,7 @@ export function TopUpStreamModal({
 }: TopUpStreamModalProps) {
   const [amount, setAmount] = useState("");
   const [error, setError] = useState("");
+  const dialogRef = useFocusTrap<HTMLDivElement>(true, onClose);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -56,9 +58,27 @@ export function TopUpStreamModal({
   };
 
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+    <div
+      ref={dialogRef}
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="topup-stream-modal-title"
+      tabIndex={-1}
+    >
       <div className="bg-white rounded-lg p-6 w-full max-w-md">
-        <h2 className="text-lg font-semibold mb-1">Top Up Stream</h2>
+        <div className="flex items-start justify-between mb-1">
+          <h2 id="topup-stream-modal-title" className="text-lg font-semibold">
+            Top Up Stream
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 p-1 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
         <p className="text-xs text-gray-500 mb-4">{stream.name} — Additional Allocation</p>
         <form onSubmit={handleSubmit} className="space-y-3">
           <div>

--- a/app/src/hooks/useFocusTrap.ts
+++ b/app/src/hooks/useFocusTrap.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Traps Tab focus within a dialog while it's open, closes it on Escape, and
+ * restores focus to whatever was focused before the dialog opened once it closes.
+ */
+export function useFocusTrap<T extends HTMLElement>(isOpen: boolean, onClose: () => void) {
+  const containerRef = useRef<T | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const container = containerRef.current;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    const focusable = container?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    (focusable?.[0] ?? container)?.focus();
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab" || !container) return;
+
+      const focusableEls = Array.from(
+        container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((el) => el.offsetParent !== null);
+      if (focusableEls.length === 0) return;
+
+      const first = focusableEls[0];
+      const last = focusableEls[focusableEls.length - 1];
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      previouslyFocused?.focus();
+    };
+  }, [isOpen, onClose]);
+
+  return containerRef;
+}

--- a/packages/indexer/migrations/009_add_effective_threshold_history.sql
+++ b/packages/indexer/migrations/009_add_effective_threshold_history.sql
@@ -1,0 +1,17 @@
+-- Up Migration
+
+CREATE TABLE IF NOT EXISTS effective_threshold_history (
+    id SERIAL PRIMARY KEY,
+    proposer_address VARCHAR(56) NOT NULL,
+    ledger INTEGER NOT NULL,
+    old_threshold NUMERIC NOT NULL,
+    new_threshold NUMERIC NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_effective_threshold_history_proposer
+    ON effective_threshold_history(proposer_address, ledger DESC);
+
+-- Down Migration
+
+DROP TABLE IF EXISTS effective_threshold_history;

--- a/packages/indexer/src/__tests__/api.test.ts
+++ b/packages/indexer/src/__tests__/api.test.ts
@@ -449,6 +449,74 @@ describe("GET /proposals with cursor pagination", () => {
       expect(response.body).toEqual({ error: "Internal server error" });
     });
   });
+
+  describe("GET /reputation/:address/threshold-history (issue #919)", () => {
+    it("should paginate results and report hasMore", async () => {
+      const mockRows = [
+        { ledger: 205, old_threshold: "1000", new_threshold: "1200", created_at: "2026-01-01T00:00:00Z" },
+      ];
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: mockRows });
+
+      const response = await request(app).get("/reputation/GADDR/threshold-history?limit=1&offset=0");
+
+      expect(response.status).toBe(200);
+      expect(response.body.history).toEqual(mockRows);
+      expect(response.body.pagination).toEqual({ limit: 1, offset: 0, hasMore: true });
+    });
+
+    it("should not report hasMore when fewer rows than the limit are returned", async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+
+      const response = await request(app).get("/reputation/GADDR/threshold-history?limit=50&offset=0");
+
+      expect(response.status).toBe(200);
+      expect(response.body.pagination).toEqual({ limit: 50, offset: 0, hasMore: false });
+    });
+
+    it("should return 500 on database error", async () => {
+      (mockPool.query as jest.Mock).mockRejectedValueOnce(new Error("Database error"));
+
+      const response = await request(app).get("/reputation/GADDR/threshold-history");
+
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({ error: "Internal server error" });
+    });
+  });
+
+  describe("GET /reputation/leaderboard (offset, issue #920)", () => {
+    it("should pass limit and offset to the query and rank relative to offset", async () => {
+      const mockRows = [
+        { proposer_address: "GADDR201", reputation_score: 42, last_updated_ledger: 100 },
+      ];
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: mockRows });
+
+      const response = await request(app).get("/reputation/leaderboard?limit=1&offset=200");
+
+      expect(response.status).toBe(200);
+      expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining("OFFSET $2"), [1, 200]);
+      expect(response.body.leaderboard).toEqual([
+        { rank: 201, address: "GADDR201", reputation_score: 42, last_updated_ledger: 100 },
+      ]);
+    });
+
+    it("should default offset to 0 when not provided", async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+
+      const response = await request(app).get("/reputation/leaderboard");
+
+      expect(response.status).toBe(200);
+      expect(mockPool.query).toHaveBeenCalledWith(expect.any(String), [50, 0]);
+    });
+
+    it("should return 500 on database error", async () => {
+      (mockPool.query as jest.Mock).mockRejectedValueOnce(new Error("Database error"));
+
+      const response = await request(app).get("/reputation/leaderboard");
+
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({ error: "Internal server error" });
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/indexer/src/__tests__/governor-events.int.test.ts
+++ b/packages/indexer/src/__tests__/governor-events.int.test.ts
@@ -50,6 +50,11 @@ describe("governor event indexing (integration)", () => {
     } catch {
       // Table may not exist if migration hasn't run
     }
+    try {
+      await pool.query("DELETE FROM effective_threshold_history");
+    } catch {
+      // Table may not exist if migration hasn't run
+    }
   });
 
   afterAll(async () => {
@@ -307,11 +312,7 @@ describe("governor event indexing (integration)", () => {
       ledger: 204,
       type: "ReputationUpdated",
       topicArgs: [proposer],
-      value: {
-        old_score: 100n,
-        new_score: 150n,
-        reason: "active_proposal_passed",
-      },
+      value: [proposer, 100, 150, "active_proposal_passed"],
     });
 
     const server = new FakeServer([reputationUpdated]) as unknown as SorobanRpc.Server;
@@ -324,12 +325,39 @@ describe("governor event indexing (integration)", () => {
     expect(latest).toBe(204);
 
     const rows = await pool.query(
-      "SELECT proposer, old_score, new_score, reason FROM proposer_reputation WHERE ledger = 204",
+      "SELECT proposer_address, reputation_score, last_updated_ledger FROM proposer_reputation WHERE proposer_address = $1",
+      [proposer],
     );
     expect(rows.rows.length).toBe(1);
-    expect(rows.rows[0].proposer).toBe(proposer);
-    expect(rows.rows[0].old_score).toBe(100);
-    expect(rows.rows[0].new_score).toBe(150);
-    expect(rows.rows[0].reason).toBe("active_proposal_passed");
+    expect(rows.rows[0].reputation_score).toBe(150);
+    expect(rows.rows[0].last_updated_ledger).toBe(204);
+  });
+
+  it("indexes EffectiveThresholdChanged event into effective_threshold_history (issue #919)", async () => {
+    const proposer = "GPROPOSER222222222222222222222222222222222";
+    const thresholdChanged = makeEvent({
+      contractId: GOVERNOR,
+      ledger: 205,
+      type: "EffectiveThresholdChanged",
+      topicArgs: [proposer],
+      value: [proposer, 1000n, 1200n],
+    });
+
+    const server = new FakeServer([thresholdChanged]) as unknown as SorobanRpc.Server;
+    const latest = await processEvents(
+      server,
+      { rpcUrl: "http://fake", governorAddress: GOVERNOR, pollIntervalMs: 1 },
+      1,
+    );
+
+    expect(latest).toBe(205);
+
+    const rows = await pool.query(
+      "SELECT proposer_address, ledger, old_threshold, new_threshold FROM effective_threshold_history WHERE ledger = 205",
+    );
+    expect(rows.rows.length).toBe(1);
+    expect(rows.rows[0].proposer_address).toBe(proposer);
+    expect(Number(rows.rows[0].old_threshold)).toBe(1000);
+    expect(Number(rows.rows[0].new_threshold)).toBe(1200);
   });
 });

--- a/packages/indexer/src/api.ts
+++ b/packages/indexer/src/api.ts
@@ -1123,24 +1123,52 @@ export function createApp(server: SorobanRpc.Server): express.Application {
     },
   );
 
-  // GET /reputation/leaderboard?limit=50
+  // GET /reputation/:address/threshold-history?offset=0&limit=50
+  app.get(
+    "/reputation/:address/threshold-history",
+    strictLimiter,
+    async (req: Request, res: Response): Promise<void> => {
+      const { address } = req.params;
+      const offset = Math.max(Number(req.query.offset ?? 0), 0);
+      const limit = Math.min(Math.max(Number(req.query.limit ?? 50), 1), 200);
+      try {
+        const result = await pool.query(
+          `SELECT ledger, old_threshold, new_threshold, created_at
+           FROM effective_threshold_history
+           WHERE proposer_address = $1
+           ORDER BY ledger DESC
+           OFFSET $2 LIMIT $3`,
+          [address, offset, limit],
+        );
+        res.json({
+          history: result.rows,
+          pagination: { limit, offset, hasMore: result.rows.length === limit },
+        });
+      } catch {
+        res.status(500).json({ error: "Internal server error" });
+      }
+    },
+  );
+
+  // GET /reputation/leaderboard?limit=50&offset=0
   app.get(
     "/reputation/leaderboard",
     async (req: Request, res: Response): Promise<void> => {
       const limit = Math.min(Math.max(Number(req.query.limit ?? 50), 1), 200);
-      const key = `reputation:leaderboard:${limit}`;
+      const offset = Math.max(Number(req.query.offset ?? 0), 0);
+      const key = `reputation:leaderboard:${limit}:${offset}`;
       try {
         const data = await cached(key, TTL.reputation, async () => {
           const result = await pool.query(
             `SELECT proposer_address, reputation_score, last_updated_ledger
              FROM proposer_reputation
              ORDER BY reputation_score DESC
-             LIMIT $1`,
-            [limit],
+             LIMIT $1 OFFSET $2`,
+            [limit, offset],
           );
           return {
             leaderboard: result.rows.map((r, i) => ({
-              rank: i + 1,
+              rank: offset + i + 1,
               address: r.proposer_address,
               reputation_score: r.reputation_score,
               last_updated_ledger: r.last_updated_ledger,

--- a/packages/indexer/src/events.ts
+++ b/packages/indexer/src/events.ts
@@ -589,6 +589,12 @@ async function handleEffectiveThresholdChanged(
   const data = scValToNative(event.value) as [string, bigint, bigint];
   const [, oldThreshold, newThreshold] = data;
 
+  await pool.query(
+    `INSERT INTO effective_threshold_history (proposer_address, ledger, old_threshold, new_threshold)
+     VALUES ($1, $2, $3, $4)`,
+    [proposer, event.ledger, oldThreshold.toString(), newThreshold.toString()],
+  );
+
   broadcast({
     type: "effective_threshold_changed",
     data: {
@@ -1046,31 +1052,3 @@ async function handleGovernorUpgraded(
   );
 }
 
-async function handleReputationUpdated(
-  event: SorobanRpc.Api.EventResponse,
-  topics: unknown[],
-): Promise<void> {
-  const proposer = topics[1] as string;
-  const data = scValToNative(event.value) as Record<string, unknown>;
-  const oldScore = Number(data.old_score);
-  const newScore = Number(data.new_score);
-  const reason = String(data.reason ?? "");
-
-  await pool.query(
-    `INSERT INTO proposer_reputation (proposer, old_score, new_score, reason, ledger)
-     VALUES ($1, $2, $3, $4, $5)`,
-    [proposer, oldScore, newScore, reason, event.ledger],
-  );
-}
-
-async function handleEffectiveThresholdChanged(
-  event: SorobanRpc.Api.EventResponse,
-  topics: unknown[],
-): Promise<void> {
-  const data = scValToNative(event.value) as Record<string, unknown>;
-  const oldThreshold = BigInt(Number(data.old_threshold ?? 0n));
-  const newThreshold = BigInt(Number(data.new_threshold ?? 0n));
-
-  // Log the threshold change (in a real implementation, this might be stored)
-  console.log(`Threshold changed from ${oldThreshold} to ${newThreshold} at ledger ${event.ledger}`);
-}


### PR DESCRIPTION
Fixes #933
Fixes #920 
Fixes #919

## #933 — Delegation and treasury modals lack dialog semantics
`CoSponsorModal` already implements `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, and a labeled close button. Added a shared `useFocusTrap` hook (`app/src/hooks/useFocusTrap.ts`) providing focus trapping, Escape-to-close, and focus restoration on close, then applied the same accessible pattern to:
- `DelegateModal`
- `GaslessDelegateModal`
- `CreateStreamModal`
- `StreamSpendModal`

While implementing this I found `ExtendStreamModal` and `TopUpStreamModal` (added after this issue was filed) have the exact same gap, so I fixed those too for consistency with the rest of the modal family.

## #920 — GET /reputation/leaderboard missing offset param
Added `offset` query param handling: applied to the `LIMIT ... OFFSET` query, included in the cache key, and used to compute `rank: offset + i + 1` so ranks past 200 are reachable.

## #919 — No schema for effective-threshold history
Added migration `009_add_effective_threshold_history.sql` creating `effective_threshold_history` (proposer_address, ledger, old_threshold, new_threshold, created_at) with an index on `(proposer_address, ledger DESC)`. `handleEffectiveThresholdChanged` now inserts into this table before broadcasting. Added `GET /reputation/:address/threshold-history` with the same offset/limit pagination pattern as `/reputation/:address/history`.

While wiring this up I found `events.ts` had a **second**, unreachable pair of `handleReputationUpdated`/`handleEffectiveThresholdChanged` definitions further down the file (duplicate function names — leftover from an earlier bad merge). The duplicates decoded the on-chain event as a struct/map (`data.old_threshold`, etc.) instead of the tuple shape Soroban's `#[contracttype]` actually emits, and the `handleReputationUpdated` duplicate inserted into `proposer_reputation` using columns that don't exist in that table's migration. Since both handlers share a name with the real, correctly-wired ones earlier in the file, this also meant the file didn't type-check. Removed the broken duplicates and fixed a stale integration test (`governor-events.int.test.ts`) that had been written against that broken decode shape.

## Testing
No Docker/Postgres available in this sandbox, so the new DB-backed tests couldn't be executed locally. Added:
- `packages/indexer/src/__tests__/api.test.ts`: pagination/offset coverage for `/reputation/leaderboard` and the new `/reputation/:address/threshold-history` endpoint (pure unit tests, DB mocked — these do run without a real DB).
- `packages/indexer/src/__tests__/governor-events.int.test.ts`: fixed the stale `ReputationUpdated` case and added an `EffectiveThresholdChanged` case (both are `DATABASE_URL`-gated integration tests, skipped in this sandbox).

Manually reviewed the modal diffs for correctness (focus trap targets the outer dialog container consistently with `CoSponsorModal`'s existing structure; Escape closes via the same `onClose` prop each modal already had).