### PR TITLE
fix(co-sponsorship): resolve finalize_draft error mapping and stale draft power/indexer state

### DIFF
--- a/contracts/co-sponsorship/src/tests.rs
+++ b/contracts/co-sponsorship/src/tests.rs
@@ -525,15 +525,10 @@ fn test_initialize_rejects_reinitialization() {
     client.initialize(&admin, &gov_id, &votes_id, &7_200u32, &20u32);
 }
 
-/// Regression test for #866: a successful `finalize_draft` rechecks each
+/// Regression test for #866/#850: a successful `finalize_draft` rechecks each
 /// co-sponsor's *current* voting power (not their power at pledge time)
-/// and updates `draft.total_power` to the rechecked sum.
-///
-/// However, `draft.co_sponsor_power[i]` and `get_co_sponsor_power()` are
-/// **not** updated to reflect the live recheck — they still return the
-/// stale pledge-time values.  This test documents that inconsistency so
-/// it has a guardrail against accidental regressions and a clear assertion
-/// of today's behaviour.
+/// and updates both `draft.total_power` and the per-sponsor breakdown to the
+/// rechecked values.
 #[test]
 fn test_finalize_draft_success_with_changed_sponsor_power() {
     let (env, client, votes, _admin) = setup(1_000);
@@ -565,18 +560,15 @@ fn test_finalize_draft_success_with_changed_sponsor_power() {
     assert_eq!(finalized.total_power, 1_300,
         "total_power must be rechecked against live voting power");
 
-    // Per-sponsor entries are NOT updated to match the recheck —
-    // they still hold the stale pledge-time values.
-    // This assertion documents today's behaviour; the underlying
-    // inconsistency is tracked in issue #866.
-    assert_eq!(finalized.co_sponsor_power.get(0).unwrap(), 600,
-        "co_sponsor_power[0] is currently stale (pledge-time value)");
+    // Per-sponsor entries must also be rechecked to match the live values.
+    assert_eq!(finalized.co_sponsor_power.get(0).unwrap(), 800,
+        "co_sponsor_power[0] should reflect the sponsor's latest live power");
     assert_eq!(finalized.co_sponsor_power.get(1).unwrap(), 500,
-        "co_sponsor_power[1] is currently stale (pledge-time value)");
+        "co_sponsor_power[1] should remain unchanged when its power is unchanged");
 
     // Same for the per-sponsor storage key.
-    assert_eq!(client.get_co_sponsor_power(&draft_id, &sponsor_a), 600,
-        "get_co_sponsor_power returns stale pledge-time power");
+    assert_eq!(client.get_co_sponsor_power(&draft_id, &sponsor_a), 800,
+        "get_co_sponsor_power should return the latest live power");
     assert_eq!(client.get_co_sponsor_power(&draft_id, &sponsor_b), 500,
-        "get_co_sponsor_power returns stale pledge-time power");
+        "get_co_sponsor_power should return the latest live power");
 }

--- a/sdk/src/__tests__/errors.test.ts
+++ b/sdk/src/__tests__/errors.test.ts
@@ -1,7 +1,10 @@
 import {
+  CoSponsorshipError,
+  CoSponsorshipErrorCode,
   extractContractErrorCode,
   GovernorError,
   GovernorErrorCode,
+  parseCoSponsorshipError,
   parseGovernorError,
   parseTimelockError,
   parseTreasuryError,
@@ -84,6 +87,21 @@ describe("GovernorError", () => {
     const err = new GovernorError(code as GovernorErrorCode, `message-${code}`);
     expect(err.code).toBe(code);
     expect(err.message).toBe(`message-${code}`);
+  });
+});
+
+describe("parseCoSponsorshipError", () => {
+  it("maps finalize_draft governor failures to a generic nested-governor message", () => {
+    const err = parseCoSponsorshipError(
+      { error: "Error(Contract, #6)" },
+      undefined,
+      "finalize_draft",
+    );
+
+    expect(err).toBeInstanceOf(CoSponsorshipError);
+    expect(err.code).toBe(CoSponsorshipErrorCode.TransactionFailed);
+    expect(err.message).toContain("Governor rejected the underlying proposal");
+    expect(err.message).toContain("rate-limited");
   });
 });
 


### PR DESCRIPTION
## Summary
This PR fixes a set of co-sponsorship issues around finalize_draft and draft lifecycle state.

## What changed
Disambiguates error handling for finalize_draft failures that originate from nested governor calls, so SDK error mapping no longer mislabels governor-specific reverts as unrelated co-sponsorship errors.
Refreshes the per-sponsor co-sponsorship power snapshot during finalize_draft so the stored breakdown matches the recomputed live total power.
Ensures expired draft expiry signaling is no longer dependent on simulated getter-only reads, so expiry handling can be observed through actual state-changing flows.
Includes the recomputed total power in the DraftFinalized event and persists it in the indexer so finalized drafts expose the correct power value.
## Why
These fixes prevent misleading SDK errors, keep draft power data consistent across UI/API/indexer surfaces, and ensure expiry/finalization events are emitted reliably in production.
## Fixes 
closes #850 
closes #851 
closes #852 
closes #853 

