### PR TITLE
feat(frontend): add invalidate pending gasless permits action

### DIFF
--- a/app/src/components/GaslessDelegateModal.tsx
+++ b/app/src/components/GaslessDelegateModal.tsx
@@ -48,7 +48,7 @@ export function GaslessDelegateModal({
   const [delegateeError, setDelegateeError] = useState("");
   const [expiryPreset, setExpiryPreset] = useState<ExpiryPreset>("1month");
   const { isConnected, publicKey, connect } = useWallet();
-  const { delegateGasless, submitting } = useGaslessDelegation();
+  const { delegateGasless, invalidateAllPermits, submitting } = useGaslessDelegation();
   const dialogRef = useFocusTrap<HTMLDivElement>(open, onClose);
 
   useEffect(() => {
@@ -100,6 +100,35 @@ export function GaslessDelegateModal({
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       toast.error(`Gasless delegation failed: ${msg}`);
+    }
+  }
+
+  async function handleInvalidatePermits() {
+    try {
+      if (!isConnected || !publicKey) {
+        toast.error("Connect your wallet first.");
+        return;
+      }
+
+      const result = await invalidateAllPermits();
+      toast.success(
+        <div>
+          Pending gasless permits were invalidated.{" "}
+          <a
+            href={explorerTxUrl(result.txHash)}
+            target="_blank"
+            rel="noreferrer"
+            className="underline"
+          >
+            View on Explorer →
+          </a>
+        </div>,
+        { duration: 8000 },
+      );
+      onClose();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      toast.error(`Permit invalidation failed: ${msg}`);
     }
   }
 
@@ -213,6 +242,15 @@ export function GaslessDelegateModal({
               {submitting ? "Signing…" : "Delegate for free"}
             </button>
           </div>
+
+          <button
+            type="button"
+            onClick={() => void handleInvalidatePermits()}
+            disabled={submitting || !isConnected || !publicKey}
+            className="w-full rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm font-medium text-amber-800 hover:bg-amber-100 disabled:opacity-50"
+          >
+            {submitting ? "Submitting…" : "Invalidate pending gasless permits"}
+          </button>
         </form>
       </div>
     </div>

--- a/app/src/components/__tests__/GaslessDelegateModal.validation.test.tsx
+++ b/app/src/components/__tests__/GaslessDelegateModal.validation.test.tsx
@@ -8,8 +8,10 @@ import { GaslessDelegateModal } from "../GaslessDelegateModal";
 
 const VALID_ADDRESS = "GDOOXICJPSOZDQRCEHZPR6MAX5PUZXVWGJ3QPVEU4DADIZQ4YBQOJNIB";
 const VALID_ADDRESS_2 = "GD6HLZWRE5FHK3SDLZB3FH56R3H3ECAAYCPWWU7O7EK4FCNT2Z7S6D5I";
+const mockDelegateGasless = jest.fn();
+const mockInvalidateAllPermits = jest.fn();
 
-jest.mock("../lib/wallet-context", () => ({
+jest.mock("../../lib/wallet-context", () => ({
   useWallet: () => ({
     isConnected: true,
     publicKey: VALID_ADDRESS_2,
@@ -22,9 +24,10 @@ jest.mock("react-hot-toast", () => ({
   default: { success: jest.fn(), error: jest.fn() },
 }));
 
-jest.mock("../hooks/useGaslessDelegation", () => ({
+jest.mock("../../hooks/useGaslessDelegation", () => ({
   useGaslessDelegation: () => ({
-    delegateGasless: jest.fn().mockResolvedValue({ txHash: "txhash789" }),
+    delegateGasless: mockDelegateGasless.mockResolvedValue({ txHash: "txhash789" }),
+    invalidateAllPermits: mockInvalidateAllPermits.mockResolvedValue({ txHash: "txhash123" }),
     submitting: false,
   }),
   EXPIRY_PRESET_LABELS: {
@@ -44,6 +47,10 @@ const defaultProps = {
 describe("GaslessDelegateModal — Stellar address validation", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockDelegateGasless.mockReset();
+    mockInvalidateAllPermits.mockReset();
+    mockDelegateGasless.mockResolvedValue({ txHash: "txhash789" });
+    mockInvalidateAllPermits.mockResolvedValue({ txHash: "txhash123" });
   });
 
   describe("rendering", () => {
@@ -233,6 +240,14 @@ describe("GaslessDelegateModal — Stellar address validation", () => {
       render(<GaslessDelegateModal {...defaultProps} onClose={onClose} />);
       await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
       expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("permit invalidation", () => {
+    it("invokes the invalidation action when the user requests it", async () => {
+      render(<GaslessDelegateModal {...defaultProps} />);
+      await userEvent.click(screen.getByRole("button", { name: /invalidate pending gasless permits/i }));
+      expect(mockInvalidateAllPermits).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/app/src/hooks/useGaslessDelegation.ts
+++ b/app/src/hooks/useGaslessDelegation.ts
@@ -31,7 +31,7 @@ export const EXPIRY_PRESET_LABELS: Record<ExpiryPreset, string> = {
 
 export interface GaslessDelegationResult {
   txHash: string;
-  nonce: number;
+  nonce?: number;
 }
 
 function getDelegationSigClientFromEnv(): DelegationSigClient {
@@ -56,7 +56,7 @@ function getDelegationSigClientFromEnv(): DelegationSigClient {
  * transaction itself, it only signs an authorization off-chain.
  */
 export function useGaslessDelegation() {
-  const { isConnected, publicKey, signAuthEntry } = useWallet();
+  const { isConnected, publicKey, signTransaction } = useWallet();
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -120,5 +120,26 @@ export function useGaslessDelegation() {
     [isConnected, publicKey, signAuthEntry],
   );
 
-  return { delegateGasless, submitting, error };
+  const invalidateAllPermits = useCallback(async (): Promise<GaslessDelegationResult> => {
+    if (!isConnected || !publicKey) {
+      throw new Error("Connect your wallet first.");
+    }
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      const client = getDelegationSigClientFromEnv();
+      const tx = await client.invalidateAllPermitsWithSign(publicKey, signTransaction);
+
+      return { txHash: tx.hash };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+      throw err;
+    } finally {
+      setSubmitting(false);
+    }
+  }, [isConnected, publicKey, signTransaction]);
+
+  return { delegateGasless, invalidateAllPermits, submitting, error };
 }

--- a/sdk/src/delegation-sig.ts
+++ b/sdk/src/delegation-sig.ts
@@ -449,4 +449,37 @@ export class DelegationSigClient {
       return { hash: result.hash };
     });
   }
+
+  /** Wallet-signing variant of {@link invalidateAllPermits}. */
+  async invalidateAllPermitsWithSign(
+    signerPublicKey: string,
+    signUnsignedXdr: (xdr: string) => Promise<string>,
+  ): Promise<DelegationTxResult> {
+    return this.retry(async () => {
+      const account = await this.server.getAccount(signerPublicKey);
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(
+          this.contract.call(
+            "invalidate_all_permits",
+            nativeToScVal(signerPublicKey, { type: "address" }),
+          ),
+        )
+        .setTimeout(30)
+        .build();
+
+      const prepared = await this.server.prepareTransaction(tx);
+      const signedXdr = await signUnsignedXdr(prepared.toXDR());
+      const signed = TransactionBuilder.fromXDR(signedXdr, this.networkPassphrase);
+
+      const result = await this.server.sendTransaction(signed);
+      if (result.status === "ERROR") {
+        throw parseVotesError(result);
+      }
+      return { hash: result.hash };
+    });
+  }
 }


### PR DESCRIPTION
# feat(frontend): add invalidate pending gasless permits action

## Summary
This change exposes a new “Invalidate pending gasless permits” action in the gasless delegation UI so users can revoke outstanding signed permits that may no longer be safe to use.

## What changed
- Added an action in the gasless delegation modal to invalidate pending permits.
- Wired the action to a real wallet-signed transaction flow for the contract’s invalidate_all_permits entrypoint.
- Added frontend regression coverage for the new action.

## Why
This provides a security-relevant safety valve for the gasless delegation flow, allowing a delegator to invalidate outstanding permits if they were signed incorrectly or if a relayer/UI compromise is suspected.

## Testing
- Verified with:
  - `pnpm --filter nebgov-app test -- --runTestsByPath src/components/__tests__/GaslessDelegateModal.validation.test.tsx --runInBand`
  
Closes: #830 