### PR TITLE
feat(frontend): preflight gasless delegation validation

### DIFF
--- a/app/src/components/GaslessDelegateModal.tsx
+++ b/app/src/components/GaslessDelegateModal.tsx
@@ -46,9 +46,10 @@ export function GaslessDelegateModal({
 }: Props) {
   const [delegatee, setDelegatee] = useState(prefillAddress || "");
   const [delegateeError, setDelegateeError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
   const [expiryPreset, setExpiryPreset] = useState<ExpiryPreset>("1month");
   const { isConnected, publicKey, connect } = useWallet();
-  const { delegateGasless, submitting } = useGaslessDelegation();
+  const { delegateGasless, preflightDelegatee } = useGaslessDelegation();
   const dialogRef = useFocusTrap<HTMLDivElement>(open, onClose);
 
   useEffect(() => {
@@ -74,9 +75,24 @@ export function GaslessDelegateModal({
     e.preventDefault();
     if (!validateDelegatee(delegatee)) return;
 
+    setSubmitting(true);
     try {
       if (!isConnected || !publicKey) {
         toast.error("Connect your wallet first.");
+        return;
+      }
+
+      let preflight;
+      try {
+        preflight = await preflightDelegatee(delegatee);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setDelegateeError(msg);
+        return;
+      }
+
+      if (!preflight.ok) {
+        setDelegateeError(preflight.error ?? "Unable to validate this delegation.");
         return;
       }
 
@@ -100,6 +116,8 @@ export function GaslessDelegateModal({
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       toast.error(`Gasless delegation failed: ${msg}`);
+    } finally {
+      setSubmitting(false);
     }
   }
 

--- a/app/src/components/__tests__/GaslessDelegateModal.validation.test.tsx
+++ b/app/src/components/__tests__/GaslessDelegateModal.validation.test.tsx
@@ -8,8 +8,10 @@ import { GaslessDelegateModal } from "../GaslessDelegateModal";
 
 const VALID_ADDRESS = "GDOOXICJPSOZDQRCEHZPR6MAX5PUZXVWGJ3QPVEU4DADIZQ4YBQOJNIB";
 const VALID_ADDRESS_2 = "GD6HLZWRE5FHK3SDLZB3FH56R3H3ECAAYCPWWU7O7EK4FCNT2Z7S6D5I";
+const mockDelegateGasless = jest.fn();
+const mockPreflightDelegatee = jest.fn();
 
-jest.mock("../lib/wallet-context", () => ({
+jest.mock("../../lib/wallet-context", () => ({
   useWallet: () => ({
     isConnected: true,
     publicKey: VALID_ADDRESS_2,
@@ -22,9 +24,10 @@ jest.mock("react-hot-toast", () => ({
   default: { success: jest.fn(), error: jest.fn() },
 }));
 
-jest.mock("../hooks/useGaslessDelegation", () => ({
+jest.mock("../../hooks/useGaslessDelegation", () => ({
   useGaslessDelegation: () => ({
-    delegateGasless: jest.fn().mockResolvedValue({ txHash: "txhash789" }),
+    delegateGasless: mockDelegateGasless.mockResolvedValue({ txHash: "txhash789" }),
+    preflightDelegatee: mockPreflightDelegatee.mockResolvedValue(undefined),
     submitting: false,
   }),
   EXPIRY_PRESET_LABELS: {
@@ -44,6 +47,10 @@ const defaultProps = {
 describe("GaslessDelegateModal — Stellar address validation", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockDelegateGasless.mockReset();
+    mockPreflightDelegatee.mockReset();
+    mockDelegateGasless.mockResolvedValue({ txHash: "txhash789" });
+    mockPreflightDelegatee.mockResolvedValue(undefined);
   });
 
   describe("rendering", () => {
@@ -200,6 +207,20 @@ describe("GaslessDelegateModal — Stellar address validation", () => {
       await userEvent.type(input, VALID_ADDRESS);
       const btn = screen.getByRole("button", { name: /delegate for free/i });
       expect(btn).not.toBeDisabled();
+    });
+
+    it("shows an inline error and skips the wallet-sign flow when preflight validation fails", async () => {
+      mockPreflightDelegatee.mockRejectedValueOnce(new Error("This delegation would create a cycle."));
+      render(<GaslessDelegateModal {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Stellar address (G...)");
+      await userEvent.type(input, VALID_ADDRESS);
+      const form = input.closest("form")!;
+      fireEvent.submit(form);
+
+      await waitFor(() => {
+        expect(screen.getByText("This delegation would create a cycle.")).toBeInTheDocument();
+      });
+      expect(mockDelegateGasless).not.toHaveBeenCalled();
     });
   });
 

--- a/app/src/hooks/useGaslessDelegation.ts
+++ b/app/src/hooks/useGaslessDelegation.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useState } from "react";
 import { DelegationSigClient, type Network } from "@nebgov/sdk";
+import { isValidStellarAddress } from "../lib/utils/stellarAddress";
 import { useWallet } from "../lib/wallet-context";
 import { backendFetch } from "../lib/backend";
 
@@ -34,6 +35,11 @@ export interface GaslessDelegationResult {
   nonce: number;
 }
 
+export interface GaslessPreflightResult {
+  ok: boolean;
+  error?: string;
+}
+
 function getDelegationSigClientFromEnv(): DelegationSigClient {
   const votesAddress = process.env.NEXT_PUBLIC_VOTES_ADDRESS;
   const network = (process.env.NEXT_PUBLIC_NETWORK || "testnet") as Network;
@@ -59,6 +65,48 @@ export function useGaslessDelegation() {
   const { isConnected, publicKey, signAuthEntry } = useWallet();
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const preflightDelegatee = useCallback(
+    async (delegatee: string): Promise<GaslessPreflightResult> => {
+      if (!delegatee.trim()) {
+        return { ok: false, error: "Address is required." };
+      }
+
+      if (!isValidStellarAddress(delegatee)) {
+        return { ok: false, error: "Invalid Stellar address." };
+      }
+
+      if (!isConnected || !publicKey) {
+        return { ok: false, error: "Connect your wallet first." };
+      }
+
+      try {
+        const client = getDelegationSigClientFromEnv();
+        const [wouldCreateCycle, depthLimit, currentDepth] = await Promise.all([
+          client.wouldCreateCycle(publicKey, delegatee.trim()),
+          client.getDelegationDepthLimit(),
+          client.getChainDepth(publicKey),
+        ]);
+
+        if (wouldCreateCycle) {
+          return { ok: false, error: "This delegation would create a cycle." };
+        }
+
+        if (currentDepth + 1 > depthLimit) {
+          return {
+            ok: false,
+            error: `This delegation would exceed the maximum delegation depth of ${depthLimit}.`,
+          };
+        }
+
+        return { ok: true };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { ok: false, error: message };
+      }
+    },
+    [isConnected, publicKey],
+  );
 
   const delegateGasless = useCallback(
     async (
@@ -120,5 +168,5 @@ export function useGaslessDelegation() {
     [isConnected, publicKey, signAuthEntry],
   );
 
-  return { delegateGasless, submitting, error };
+  return { delegateGasless, preflightDelegatee, submitting, error };
 }


### PR DESCRIPTION
# feat(frontend): preflight gasless delegation validation

## Summary
This change adds pre-flight validation to the gasless delegation modal so users are blocked before a wallet-sign prompt when a delegation would be invalid.

## What changed
- Validates the delegatee address format client-side before starting the gasless flow.
- Checks whether the proposed delegation would create a delegation cycle before requesting a wallet signature.
- Checks the current delegation depth against the protocol depth limit and surfaces a clear inline error when it would be exceeded.
- Added regression coverage for the new pre-flight validation behavior.

## Why
This prevents users from signing a permit and waiting through the relayer round-trip only to discover that the delegation is doomed to fail due to a malformed address or invalid graph shape.

## Testing
- Verified with:
  - `pnpm --filter nebgov-app test -- --runTestsByPath src/components/__tests__/GaslessDelegateModal.validation.test.tsx --runInBand`

Closes: #829 