### PR TITLE
fix(nebgov): bug-timelock-execute-never-enforces-schedule-wit

### DIFF
--- a/contracts/timelock/src/lib.rs
+++ b/contracts/timelock/src/lib.rs
@@ -581,9 +581,8 @@ impl TimelockContract {
             }
         }
 
-        // Also check schedule_with_deps predecessors
         if !Self::all_predecessors_done(env.clone(), op_id.clone()) {
-            env.panic_with_error(TimelockError::PredecessorNotDone);
+            env.panic_with_error(TimelockError::PredecessorNotComplete);
         }
 
         op.executed = true;

--- a/contracts/timelock/src/test_dag.rs
+++ b/contracts/timelock/src/test_dag.rs
@@ -694,7 +694,7 @@ fn test_cross_batch_predecessor_resolved() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #1)")]
+#[should_panic(expected = "Error(Contract, #11)")]
 fn test_execute_blocked_by_incomplete_schedule_with_deps_predecessor() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
Closes #831

## Summary
- bug(timelock): execute() never enforces schedule_with_deps predecessors — the entire DAG dependency gate is bypassable

## Test plan
- [ ] Relevant tests pass locally
- [ ] Manual verification on affected UI or API paths