### PR TITLE
fix(timelock): fold predecessors into op_id hash in schedule_with_deps

### DIFF
--- a/contracts/timelock/src/lib.rs
+++ b/contracts/timelock/src/lib.rs
@@ -202,7 +202,39 @@ impl TimelockContract {
         Bytes::from_array(&env, &hash.to_array())
     }
 
+    /// Compute a deterministic op_id that folds the full predecessors list into
+    /// the hash, preventing collisions with plain `schedule` calls that pass an
+    /// empty predecessor.  Each predecessor's bytes are appended after the
+    /// fn_name so that different predecessor sets always yield different IDs.
+    fn compute_op_id_with_deps(
+        env: &Env,
+        target: &Address,
+        data: &Bytes,
+        fn_name: &Symbol,
+        predecessors: &Vec<Bytes>,
+        salt: &Bytes,
+    ) -> Bytes {
+        let mut combined = Bytes::new(env);
+        combined.append(&target.to_xdr(env));
+        combined.append(data);
+        combined.append(&fn_name.to_xdr(env));
+        for pred in predecessors.iter() {
+            combined.append(&pred);
+        }
+        combined.append(salt);
+        let hash = env.crypto().sha256(&combined);
+        Bytes::from_array(env, &hash.to_array())
+    }
+
     /// Schedule an operation with multiple predecessor dependencies.
+    ///
+    /// The op_id is computed by [`compute_op_id_with_deps`], which folds the
+    /// full predecessors list into the hash.  This guarantees that:
+    /// - `schedule(target, data, fn, delay, Bytes::new(), salt)` and
+    ///   `schedule_with_deps(target, data, fn, delay, preds, salt)` with
+    ///   identical target/data/salt **never** share an op_id.
+    /// - Two `schedule_with_deps` calls with different predecessor sets but
+    ///   identical target/data/salt also **never** share an op_id.
     #[allow(clippy::too_many_arguments)]
     pub fn schedule_with_deps(
         env: Env,
@@ -221,8 +253,57 @@ impl TimelockContract {
             Self::validate_predecessor(&env, &pred);
         }
 
-        let op_id =
-            Self::schedule_operation(env.clone(), target, data, fn_name, delay, Bytes::new(&env), salt);
+        let min_delay = Self::min_delay(env.clone());
+        assert!(delay >= min_delay, "delay too short");
+
+        // Compute op_id that includes the predecessors list so that it is
+        // always distinct from a plain `schedule` call with the same
+        // target/data/salt.
+        let op_id = Self::compute_op_id_with_deps(
+            &env,
+            &target,
+            &data,
+            &fn_name,
+            &predecessors,
+            &salt,
+        );
+
+        // Guard against a second call silently overwriting an existing operation.
+        assert!(
+            !env.storage().persistent().has(&DataKey::Operation(op_id.clone())),
+            "operation already scheduled"
+        );
+
+        let execution_window = Self::execution_window(env.clone());
+        let ready_at = env.ledger().timestamp() + delay;
+        let expires_at = ready_at + execution_window;
+
+        let op = Operation {
+            target: target.clone(),
+            data,
+            fn_name: fn_name.clone(),
+            ready_at,
+            expires_at,
+            executed: false,
+            cancelled: false,
+            predecessor: Bytes::new(&env),
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Operation(op_id.clone()), &op);
+
+        // Extend TTL to cover the full operation lifecycle (delay + execution window)
+        // plus a safety buffer. Stellar mainnet closes ledgers roughly every 5 seconds.
+        let seconds_until_expiry = delay + execution_window;
+        let ttl_ledgers = ((seconds_until_expiry / 5) + 1000) as u32;
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Operation(op_id.clone()), ttl_ledgers, ttl_ledgers);
+
+        env.events()
+            .publish((symbol_short!("schedule"),), op_id.clone());
+        emit_operation_scheduled(&env, &op_id, &target, &fn_name, ready_at, expires_at);
 
         // Persist the predecessor set so all_predecessors_done() and the
         // topological sort can resolve this operation's dependencies later.
@@ -860,6 +941,14 @@ impl TimelockContract {
             data.clone(),
             predecessor.clone(),
             salt,
+        );
+
+        // Guard: reject scheduling when the op_id already exists to prevent
+        // silent overwrites of an existing operation's ready_at/expires_at/
+        // executed state.
+        assert!(
+            !env.storage().persistent().has(&DataKey::Operation(op_id.clone())),
+            "operation already scheduled"
         );
 
         let op = Operation {

--- a/contracts/timelock/src/test.rs
+++ b/contracts/timelock/src/test.rs
@@ -653,7 +653,11 @@ fn test_salt_uniqueness() {
 }
 
 #[test]
-/// Test that same salt produces same ID (idempotent scheduling).
+#[should_panic]
+/// Regression test for the bug #832 guard: scheduling the same operation twice
+/// (identical target/data/salt) must be rejected now that the duplicate-scheduling
+/// guard is in place. Previously this would silently overwrite the first
+/// operation's storage entry (the unsafe behavior the bug described).
 fn test_same_salt_same_id() {
     let env = Env::default();
     env.mock_all_auths();
@@ -670,7 +674,8 @@ fn test_same_salt_same_id() {
     let delay = 1000u64;
     let salt = Bytes::from_slice(&env, b"same_salt");
 
-    let op_id1 = client.schedule(
+    // First call succeeds.
+    client.schedule(
         &governor,
         &target,
         &data,
@@ -679,7 +684,8 @@ fn test_same_salt_same_id() {
         &Bytes::new(&env),
         &salt,
     );
-    let op_id2 = client.schedule(
+    // Second call with identical inputs must panic with "operation already scheduled".
+    client.schedule(
         &governor,
         &target,
         &data,
@@ -688,18 +694,6 @@ fn test_same_salt_same_id() {
         &Bytes::new(&env),
         &salt,
     );
-
-    assert_eq!(op_id1, op_id2);
-
-    // The second schedule should overwrite the first (same storage key)
-    let op: Operation = env.as_contract(&contract_id, || {
-        env.storage()
-            .persistent()
-            .get(&DataKey::Operation(op_id1.clone()))
-            .unwrap()
-    });
-    // Both operations have same ID, so only one record exists
-    assert_eq!(op.data, data);
 }
 
 #[test]
@@ -728,7 +722,10 @@ fn test_predecessor_changes_id() {
 }
 
 #[test]
-/// Test that empty predecessor and empty salt produce consistent ID.
+#[should_panic]
+/// Regression test for the bug #832 guard: scheduling the same operation
+/// twice with empty predecessor and empty salt must be rejected. Previously
+/// the second call silently overwrote the first operation's storage entry.
 fn test_empty_predecessor_and_salt() {
     let env = Env::default();
     env.mock_all_auths();
@@ -744,7 +741,8 @@ fn test_empty_predecessor_and_salt() {
     let fn_name = Symbol::new(&env, "exec");
     let delay = 1000u64;
 
-    let op_id1 = client.schedule(
+    // First call succeeds.
+    client.schedule(
         &governor,
         &target,
         &data,
@@ -753,7 +751,8 @@ fn test_empty_predecessor_and_salt() {
         &Bytes::new(&env),
         &Bytes::new(&env),
     );
-    let op_id2 = client.schedule(
+    // Second call with identical inputs must panic with "operation already scheduled".
+    client.schedule(
         &governor,
         &target,
         &data,
@@ -762,8 +761,6 @@ fn test_empty_predecessor_and_salt() {
         &Bytes::new(&env),
         &Bytes::new(&env),
     );
-
-    assert_eq!(op_id1, op_id2);
 }
 
 #[test]
@@ -1093,6 +1090,154 @@ fn test_initialize_guard_prevents_reinitialization() {
 
     client.initialize(&admin, &governor, &100, &1000);
 
+
     // Second initialize attempt should panic
     client.initialize(&attacker, &attacker, &0, &u64::MAX);
+}
+
+#[test]
+/// Regression test for #832: schedule() and schedule_with_deps() with the
+/// same target/data/salt MUST produce different op_ids.
+/// Before the fix, both called compute_op_id with an empty predecessor bytes,
+/// causing hash collisions and silent storage overwrites.
+fn test_schedule_and_schedule_with_deps_do_not_collide() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TimelockContract, ());
+    let client = TimelockContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let governor = Address::generate(&env);
+    client.initialize(&admin, &governor, &0, &1_209_600);
+
+    let target = Address::generate(&env);
+    let data = Bytes::new(&env);
+    let fn_name = Symbol::new(&env, "exec");
+    let salt = Bytes::from_slice(&env, b"same_salt");
+
+    // Schedule a predecessor so schedule_with_deps can reference it.
+    let pred_op_id = client.schedule(
+        &governor,
+        &target,
+        &data,
+        &fn_name,
+        &0,
+        &Bytes::new(&env),
+        &Bytes::from_slice(&env, b"pred_salt"),
+    );
+
+    // Plain schedule call with the same target/data/salt.
+    let op_id_plain = client.schedule(
+        &governor,
+        &target,
+        &data,
+        &fn_name,
+        &0,
+        &Bytes::new(&env),
+        &salt,
+    );
+
+    // schedule_with_deps with the same target/data/salt but a non-empty
+    // predecessors list must produce a DIFFERENT op_id.
+    let mut predecessors = Vec::new(&env);
+    predecessors.push_back(pred_op_id.clone());
+
+    let op_id_with_deps = client.schedule_with_deps(
+        &governor,
+        &target,
+        &data,
+        &fn_name,
+        &0,
+        &predecessors,
+        &salt,
+    );
+
+    assert_ne!(
+        op_id_plain, op_id_with_deps,
+        "schedule() and schedule_with_deps() with the same target/data/salt \
+         must NOT produce the same op_id (fix for bug #832)"
+    );
+
+    // Both operations should independently exist in storage.
+    assert!(
+        client.get_operation(&op_id_plain).is_some(),
+        "plain schedule op should be stored"
+    );
+    assert!(
+        client.get_operation(&op_id_with_deps).is_some(),
+        "schedule_with_deps op should be stored"
+    );
+}
+
+#[test]
+/// Regression test for #832 (part 2): two schedule_with_deps calls with
+/// different predecessor sets but the same target/data/salt must produce
+/// different op_ids.
+fn test_schedule_with_deps_different_predecessors_do_not_collide() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TimelockContract, ());
+    let client = TimelockContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let governor = Address::generate(&env);
+    client.initialize(&admin, &governor, &0, &1_209_600);
+
+    let target = Address::generate(&env);
+    let data = Bytes::new(&env);
+    let fn_name = Symbol::new(&env, "exec");
+    let salt = Bytes::from_slice(&env, b"shared_salt");
+
+    // Create two distinct predecessor operations.
+    let pred_a = client.schedule(
+        &governor,
+        &target,
+        &data,
+        &fn_name,
+        &0,
+        &Bytes::new(&env),
+        &Bytes::from_slice(&env, b"salt_a"),
+    );
+    let pred_b = client.schedule(
+        &governor,
+        &target,
+        &data,
+        &fn_name,
+        &0,
+        &Bytes::new(&env),
+        &Bytes::from_slice(&env, b"salt_b"),
+    );
+
+    // First call: depends only on pred_a.
+    let mut preds_a = Vec::new(&env);
+    preds_a.push_back(pred_a.clone());
+    let op_id_a = client.schedule_with_deps(
+        &governor,
+        &target,
+        &data,
+        &fn_name,
+        &0,
+        &preds_a,
+        &salt,
+    );
+
+    // Second call: depends only on pred_b — same target/data/salt, different predecessors.
+    let mut preds_b = Vec::new(&env);
+    preds_b.push_back(pred_b.clone());
+    let op_id_b = client.schedule_with_deps(
+        &governor,
+        &target,
+        &data,
+        &fn_name,
+        &0,
+        &preds_b,
+        &salt,
+    );
+
+    assert_ne!(
+        op_id_a, op_id_b,
+        "schedule_with_deps with different predecessor sets must produce \
+         different op_ids even when target/data/salt are identical (fix for bug #832)"
+    );
+
+    assert!(client.get_operation(&op_id_a).is_some());
+    assert!(client.get_operation(&op_id_b).is_some());
 }


### PR DESCRIPTION
Closes #832

compute_op_id_with_deps is introduced as a private helper that builds the op_id hash from target + data + fn_name + each predecessor's bytes
+ salt.  schedule_with_deps now uses this helper instead of calling schedule_operation with an empty Bytes predecessor, which was the root cause of the collision.

Consequences of the old bug that are now prevented:
- schedule(target, data, fn, delay, empty, salt) and schedule_with_deps(target, data, fn, delay, preds, salt) with the same target/data/salt no longer produce the same op_id.
- Two schedule_with_deps calls with different predecessor sets but identical target/data/salt no longer collide.

A duplicate-scheduling guard (assert on storage existence) is also added to both schedule_operation and schedule_with_deps so that any future collision — regardless of cause — results in a clear panic instead of a silent overwrite of ready_at/expires_at/executed state.

Tests:
- test_schedule_and_schedule_with_deps_do_not_collide: asserts that schedule() and schedule_with_deps() with the same target/data/salt produce different op_ids (primary regression test for #832).
- test_schedule_with_deps_different_predecessors_do_not_collide: asserts that two schedule_with_deps calls with different predecessor sets but same target/data/salt produce different op_ids.
- test_same_salt_same_id and test_empty_predecessor_and_salt are updated to #[should_panic] because the duplicate-scheduling guard now correctly rejects the previously-allowed silent overwrite behavior.