### PR TITLE
fix(timelock): persist batch dependency graphs

### DIFF
--- a/contracts/timelock/src/lib.rs
+++ b/contracts/timelock/src/lib.rs
@@ -526,6 +526,8 @@ impl TimelockContract {
             .persistent()
             .set(&DataKey::BatchOperation(batch_op_id.clone()), &batch);
 
+        Self::persist_batch_dependency_graph(env.clone(), &batch_op_id, &batch.predecessor);
+
         // Extend TTL to cover the full operation lifecycle (delay + execution window)
         // plus a safety buffer. Stellar mainnet closes ledgers roughly every 5 seconds.
         let seconds_until_expiry = delay + execution_window;
@@ -890,6 +892,25 @@ impl TimelockContract {
         emit_operation_scheduled(&env, &op_id, &target, &fn_name, ready_at, expires_at);
 
         op_id
+    }
+
+    fn persist_batch_dependency_graph(env: Env, batch_op_id: &Bytes, predecessor: &Bytes) {
+        let mut nodes = Vec::new(&env);
+        nodes.push_back(batch_op_id.clone());
+
+        let mut edges = Vec::new(&env);
+        if !predecessor.is_empty() {
+            nodes.push_back(predecessor.clone());
+            edges.push_back(DependencyEdge {
+                from: predecessor.clone(),
+                to: batch_op_id.clone(),
+            });
+        }
+
+        let graph = DependencyGraph { nodes, edges };
+        env.storage()
+            .persistent()
+            .set(&DataKey::BatchDependencyGraph(batch_op_id.clone()), &graph);
     }
 
     fn validate_predecessor(env: &Env, predecessor: &Bytes) {

--- a/contracts/timelock/src/test_dag.rs
+++ b/contracts/timelock/src/test_dag.rs
@@ -746,19 +746,45 @@ fn test_get_batch_dependency_graph_populated() {
     let governor = Address::generate(&env);
     client.initialize(&admin, &governor, &0, &1_209_600);
 
-    let op_a = Bytes::from_slice(&env, b"op_a");
-    let op_b = Bytes::from_slice(&env, b"op_b");
+    let target = env.register(MockTarget, ());
 
-    // A depends on B
-    let mut a_preds = Vec::new(&env);
-    a_preds.push_back(op_b.clone());
-    set_predecessors(&env, &contract_id, &op_a, &a_preds);
+    let pred_op_id = client.schedule(
+        &governor,
+        &target,
+        &Bytes::new(&env),
+        &Symbol::new(&env, "exec"),
+        &0,
+        &Bytes::new(&env),
+        &Bytes::from_slice(&env, b"pred_salt"),
+    );
 
-    // Verify the DAG is retrievable (currently returns None since
-    // batch dependency graphs are only persisted on schedule_batch).
-    let batch_op_id = Bytes::from_slice(&env, b"nonexistent_batch");
+    let mut targets = Vec::new(&env);
+    targets.push_back(target.clone());
+
+    let mut datas = Vec::new(&env);
+    datas.push_back(Bytes::new(&env));
+
+    let mut fn_names = Vec::new(&env);
+    fn_names.push_back(Symbol::new(&env, "exec"));
+
+    let batch_op_id = client.schedule_batch(
+        &governor,
+        &targets,
+        &datas,
+        &fn_names,
+        &0,
+        &pred_op_id,
+        &Bytes::from_slice(&env, b"batch_salt"),
+    );
+
     let graph = client.get_batch_dependency_graph(&batch_op_id);
-    assert!(graph.is_none(), "non-existent batch should return None");
+    assert!(graph.is_some(), "scheduled batch should persist a dependency graph");
+
+    let graph = graph.unwrap();
+    assert_eq!(graph.nodes.len(), 2);
+    assert_eq!(graph.edges.len(), 1);
+    assert_eq!(graph.edges.get(0).unwrap().from, pred_op_id);
+    assert_eq!(graph.edges.get(0).unwrap().to, batch_op_id);
 }
 
 #[test]


### PR DESCRIPTION
# fix(timelock): persist batch dependency graphs

## Summary

This PR fixes the timelock bug where batch dependency graphs were never persisted, causing `get_batch_dependency_graph` to always return `None` for scheduled batches.

## What changed

- Persist a dependency graph whenever a batch is scheduled.
- Record the batch node and its predecessor edge so the graph is retrievable later.
- Added regression coverage to ensure scheduled batches expose a populated dependency graph.

## Why

`BatchDependencyGraph(Bytes)` was defined and queried, but never populated. As a result, the contract helper always returned `None`, and the SDK path for `getBatchDependencyGraph` could not resolve a graph.

## Verification

- Ran:
  `cargo test -p sorogov-timelock test_get_batch_dependency_graph_populated -- --nocapture`

Closes: #836
