### PR TITLE
feat: add IP rate limiting to relayer, SDK admin whitelist methods, t…

### DIFF
--- a/backend/src/routes/relayer.ts
+++ b/backend/src/routes/relayer.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import rateLimit from "express-rate-limit";
 import { z } from "zod";
 import {
   Contract,
@@ -16,6 +17,22 @@ import { validate } from "../middleware/validate";
 import { logger } from "../logger";
 
 const router = Router();
+
+// IP-based rate limiting independent of the per-delegator quota.
+// Prevents Sybil attackers from rotating addresses to exhaust the relayer's fee budget.
+const relayerIpLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many relayer requests from this IP" },
+  keyGenerator: (req) =>
+    (req.headers["x-forwarded-for"] as string)?.split(",")[0].trim() ??
+    req.ip ??
+    "unknown",
+});
+
+router.use(relayerIpLimiter);
 
 // The backend already depends on @stellar/stellar-sdk ^15 (a different major
 // version than the ^12 pinned by @nebgov/sdk for the browser app), so this

--- a/sdk/src/delegation-sig.ts
+++ b/sdk/src/delegation-sig.ts
@@ -419,6 +419,79 @@ export class DelegationSigClient {
   }
 
   /**
+   * Admin: enable or disable the relayer whitelist.
+   * When enabled, only whitelisted relayers may submit signed permits.
+   * Calls `set_relayer_whitelist_enabled` on the contract.
+   */
+  async setRelayerWhitelistEnabled(
+    admin: Keypair,
+    enabled: boolean,
+  ): Promise<DelegationTxResult> {
+    return this.retry(async () => {
+      const account = await this.server.getAccount(admin.publicKey());
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(
+          this.contract.call(
+            "set_relayer_whitelist_enabled",
+            nativeToScVal(admin.publicKey(), { type: "address" }),
+            nativeToScVal(enabled, { type: "bool" }),
+          ),
+        )
+        .setTimeout(30)
+        .build();
+
+      const prepared = await this.server.prepareTransaction(tx);
+      prepared.sign(admin);
+      const result = await this.server.sendTransaction(prepared);
+      if (result.status === "ERROR") {
+        throw parseVotesError(result);
+      }
+      return { hash: result.hash };
+    });
+  }
+
+  /**
+   * Admin: add or remove a relayer from the whitelist.
+   * Calls `set_relayer_whitelisted` on the contract.
+   */
+  async setRelayerWhitelisted(
+    admin: Keypair,
+    relayer: string,
+    whitelisted: boolean,
+  ): Promise<DelegationTxResult> {
+    return this.retry(async () => {
+      const account = await this.server.getAccount(admin.publicKey());
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(
+          this.contract.call(
+            "set_relayer_whitelisted",
+            nativeToScVal(admin.publicKey(), { type: "address" }),
+            nativeToScVal(relayer, { type: "address" }),
+            nativeToScVal(whitelisted, { type: "bool" }),
+          ),
+        )
+        .setTimeout(30)
+        .build();
+
+      const prepared = await this.server.prepareTransaction(tx);
+      prepared.sign(admin);
+      const result = await this.server.sendTransaction(prepared);
+      if (result.status === "ERROR") {
+        throw parseVotesError(result);
+      }
+      return { hash: result.hash };
+    });
+  }
+
+  /**
    * Invalidate all outstanding signed permits for `delegator` by bumping
    * their nonce past anything they may have already signed. Only the
    * delegator themself may call this — it requires their own signature.


### PR DESCRIPTION

- add IP-based rate limiter (10 req/min) to all /relayer endpoints independent of per-delegator quota to prevent Sybil fee drain. 
- poll getTransaction after sendTransaction in submitInvocation until terminal status before responding to client, surface failures clearly. 
- index DelegatedBySig, PermitsInvalidated, RelayerWhitelistUpdated events in indexer TOPIC_MAP with handlers and migration for relayer/nonce metadata. 
- add setRelayerWhitelistEnabled() and setRelayerWhitelisted() admin methods to DelegationSigClient following invalidateAllPermits pattern. 

Closes #824
Closes #825
Closes #826
Closes #827
