### PR TITLE
fix(sdk): DelegationSigClient reads throw instead of masking RPC failures

### DIFF
--- a/sdk/src/__tests__/delegation-sig.test.ts
+++ b/sdk/src/__tests__/delegation-sig.test.ts
@@ -1,0 +1,96 @@
+// Define mocks with 'mock' prefix and use 'var' for hoisting support
+var mockScValToNative = jest.fn();
+var mockNativeToScVal = jest.fn();
+var mockSimulate = jest.fn();
+var mockGetAccount = jest.fn();
+var mockIsSimulationError = jest.fn();
+var mockGetLatestLedger = jest.fn();
+
+import { DelegationSigClient } from "../delegation-sig";
+import { VotesError, VotesErrorCode } from "../errors";
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const actual = jest.requireActual("@stellar/stellar-sdk");
+  return {
+    ...actual,
+    scValToNative: mockScValToNative,
+    nativeToScVal: mockNativeToScVal,
+    SorobanRpc: {
+      ...actual.SorobanRpc,
+      Server: jest.fn().mockImplementation(() => ({
+        simulateTransaction: mockSimulate,
+        getAccount: mockGetAccount,
+        getLatestLedger: mockGetLatestLedger,
+      })),
+      Api: {
+        isSimulationError: mockIsSimulationError,
+      },
+    },
+    Contract: jest.fn().mockImplementation((addr) => ({
+      call: jest.fn().mockReturnValue({}),
+      address: () => addr,
+      contractId: () => addr,
+    })),
+    TransactionBuilder: jest.fn().mockImplementation(() => ({
+      addOperation: jest.fn().mockReturnThis(),
+      setTimeout: jest.fn().mockReturnThis(),
+      build: jest.fn().mockReturnValue({}),
+    })),
+  };
+});
+
+import { xdr, Account } from "@stellar/stellar-sdk";
+
+describe("DelegationSigClient", () => {
+  let client: DelegationSigClient;
+  const validGAddr = "GBFUUXATVOGXGD4KS3I423QFZSPE4ZFOQ3TCJVWFUYSIPULXIRVRE2DT";
+  const validCAddr = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAccount.mockResolvedValue(new Account(validGAddr, "1"));
+    mockNativeToScVal.mockReturnValue({} as xdr.ScVal);
+
+    client = new DelegationSigClient({
+      votesAddress: validCAddr,
+      network: "testnet",
+      maxAttempts: 1,
+    });
+  });
+
+  describe("getNonce()", () => {
+    it("returns the decoded nonce on a successful simulation", async () => {
+      mockIsSimulationError.mockReturnValue(false);
+      mockSimulate.mockResolvedValue({ result: { retval: {} as xdr.ScVal } });
+      mockScValToNative.mockReturnValue(5);
+
+      await expect(client.getNonce(validGAddr)).resolves.toBe(5n);
+    });
+
+    it("returns 0n when simulation succeeds with no retval", async () => {
+      mockIsSimulationError.mockReturnValue(false);
+      mockSimulate.mockResolvedValue({ result: undefined });
+
+      await expect(client.getNonce(validGAddr)).resolves.toBe(0n);
+    });
+
+    it("throws a VotesError instead of returning a fallback when simulation fails", async () => {
+      mockIsSimulationError.mockReturnValue(true);
+      mockSimulate.mockResolvedValue({ error: "HostError: Value(HostError(...))" });
+
+      await expect(client.getNonce(validGAddr)).rejects.toMatchObject({
+        constructor: VotesError,
+        code: VotesErrorCode.SimulationFailed,
+      });
+    });
+  });
+
+  describe("isRelayerAllowed()", () => {
+    it("throws instead of defaulting to true when simulation fails", async () => {
+      mockIsSimulationError.mockReturnValue(true);
+      mockSimulate.mockResolvedValue({ error: "RPC unavailable" });
+
+      await expect(client.isRelayerAllowed(validGAddr)).rejects.toThrow(VotesError);
+    });
+  });
+});

--- a/sdk/src/delegation-sig.ts
+++ b/sdk/src/delegation-sig.ts
@@ -150,6 +150,14 @@ export class DelegationSigClient {
     );
   }
 
+  /**
+   * `fallback` is only used when simulation *succeeds* but returns no
+   * retval — a genuinely empty result. A failed simulation (RPC/contract
+   * error) throws instead of returning `fallback`, so transient RPC
+   * failures can't masquerade as legitimate default values (e.g. `getNonce`
+   * returning `0n` on a network hiccup, indistinguishable from an unused
+   * nonce — see issue #828).
+   */
   private async simulateRead<T>(
     fnName: string,
     args: xdr.ScVal[],
@@ -167,7 +175,13 @@ export class DelegationSigClient {
           .build(),
       );
 
-      if (SorobanRpc.Api.isSimulationError(result)) return fallback;
+      if (SorobanRpc.Api.isSimulationError(result)) {
+        throw new VotesError(
+          VotesErrorCode.SimulationFailed,
+          `Simulation of "${fnName}" failed: ${result.error}`,
+          result,
+        );
+      }
       const raw = (result as SorobanRpc.Api.SimulateTransactionSuccessResponse)
         .result?.retval;
       return raw ? decode(raw) : fallback;


### PR DESCRIPTION
## Problem

`DelegationSigClient.simulateRead()` in `sdk/src/delegation-sig.ts` collapsed every `SorobanRpc.Api.isSimulationError(result)` case into the caller's `fallback` value. That made a transient RPC/simulation failure indistinguishable from a legitimate default:

- `getNonce` → `0n` (looks like "unused nonce")
- `isNonceUsed` → `false`
- `isRelayerAllowed` → `true`
- `getDelegationPermitExpiry` → `null`

A caller hitting a network hiccup during `getNonce` would sign a permit with a stale/wrong nonce and later get a cryptic on-chain `NonceAlreadyUsed` error, obscuring the real (RPC) root cause.

## Fix

`simulateRead()` now only returns `fallback` when the simulation *succeeds* but returns no retval (a genuinely empty result). When `isSimulationError(result)` is true, it throws `VotesError(VotesErrorCode.SimulationFailed, ...)` instead — the same pattern already used by `VotesClient.getVotesSettings()` in `sdk/src/votes.ts` for the identical distinction.

This affects `getNonce`, `isNonceUsed`, `getDomainSeparator`, `computePermitHash`, `isRelayerAllowed`, and `getDelegationPermitExpiry`, all of which are built on `simulateRead`.

## Testing

Added `sdk/src/__tests__/delegation-sig.test.ts` covering:
- successful simulation with a decoded value
- successful simulation with no retval (still falls back)
- failed simulation (now throws `VotesError` instead of silently returning the fallback)

Ran the full SDK suite (`pnpm --filter @nebgov/sdk test`): 288/288 executable tests pass, including the 4 new ones. Note: 5 unrelated suites fail to compile due to a pre-existing type error in `sdk/src/timelock.ts` (`FailedOperation.data` missing in `mapFailedOp`) that already exists on `main` and is untouched by this PR.

Closes #828