### PR TITLE
fix(backend): relayer daily permit-limit TOCTOU race — closes #822 #821 #820 #818

### DIFF
--- a/backend/src/routes/relayer.test.ts
+++ b/backend/src/routes/relayer.test.ts
@@ -1,0 +1,228 @@
+import request from "supertest";
+import express, { Express } from "express";
+
+// --- @stellar/stellar-sdk is not installed in every environment this repo
+// runs in (and even where it is, we don't want real network calls in a unit
+// test), so it's fully virtual-mocked. Only the surface relayer.ts actually
+// touches is implemented.
+const mockGetAccount = jest.fn();
+const mockPrepareTransaction = jest.fn();
+const mockSendTransaction = jest.fn();
+
+jest.mock(
+  "@stellar/stellar-sdk",
+  () => {
+    class FakeAuthEntry {
+      static fromXDR() {
+        return {
+          credentials: () => ({
+            switch: () => ({ name: "sorobanCredentialsAddress" }),
+          }),
+        };
+      }
+    }
+
+    class FakeTransactionBuilder {
+      constructor(_account: unknown, _opts: unknown) {}
+      addOperation() {
+        return this;
+      }
+      setTimeout() {
+        return this;
+      }
+      build() {
+        return {};
+      }
+    }
+
+    class FakeServer {
+      getAccount(...args: unknown[]) {
+        return mockGetAccount(...args);
+      }
+      prepareTransaction(...args: unknown[]) {
+        return mockPrepareTransaction(...args);
+      }
+      sendTransaction(...args: unknown[]) {
+        return mockSendTransaction(...args);
+      }
+    }
+
+    return {
+      Contract: class {
+        contractId() {
+          return "CCONTRACT";
+        }
+      },
+      Keypair: {
+        fromSecret: () => ({
+          publicKey: () => "GRELAYERPUBKEY",
+          sign: () => {},
+        }),
+      },
+      Networks: { TESTNET: "testnet", PUBLIC: "public", FUTURENET: "futurenet" },
+      BASE_FEE: "100",
+      Operation: { invokeContractFunction: (a: unknown) => a },
+      TransactionBuilder: FakeTransactionBuilder,
+      nativeToScVal: (v: unknown) => v,
+      rpc: { Server: FakeServer },
+      xdr: { SorobanAuthorizationEntry: FakeAuthEntry },
+    };
+  },
+  { virtual: true },
+);
+
+const mockConnect = jest.fn();
+jest.mock("../db/pool", () => ({
+  __esModule: true,
+  default: {
+    connect: (...args: unknown[]) => mockConnect(...args),
+    query: jest.fn(),
+  },
+}));
+
+import relayerRouter from "./relayer";
+
+function createApp(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/relayer", relayerRouter);
+  return app;
+}
+
+/**
+ * A fake pg PoolClient whose `query` inspects the SQL text to serve BEGIN /
+ * advisory-lock / count / insert / COMMIT / ROLLBACK, so the route's
+ * transaction logic runs against realistic responses without a real
+ * database. `countByDelegator` simulates rows already committed to
+ * relayer_permit_log *before* this request started — it deliberately does
+ * NOT change as the fake client is queried multiple times in one request,
+ * mirroring how the real table looks mid-race before any commit.
+ */
+function createFakeClient(countByDelegator: Record<string, number>) {
+  const query = jest.fn(async (sql: string, params?: unknown[]) => {
+    if (sql === "BEGIN" || sql === "COMMIT" || sql === "ROLLBACK") {
+      return { rows: [] };
+    }
+    if (sql.includes("pg_advisory_xact_lock")) {
+      return { rows: [] };
+    }
+    if (sql.includes("SELECT COUNT(*)")) {
+      const delegator = params?.[0] as string;
+      return { rows: [{ count: String(countByDelegator[delegator] ?? 0) }] };
+    }
+    if (sql.includes("INSERT INTO relayer_permit_log")) {
+      return { rows: [] };
+    }
+    throw new Error(`createFakeClient: unexpected query ${sql}`);
+  });
+  return { query, release: jest.fn() };
+}
+
+const DELEGATOR = "G" + "A".repeat(55);
+const DELEGATEE = "G" + "B".repeat(55);
+const OTHER_DELEGATOR = "G" + "D".repeat(55);
+const CONTRACT_ID = "C" + "C".repeat(55);
+
+function makePermit(nonce: number, delegator = DELEGATOR) {
+  return {
+    delegator,
+    delegatee: DELEGATEE,
+    nonce: String(nonce),
+    expiryLedger: 1_000_000,
+    chainId: Buffer.from("fake-network-id").toString("base64"),
+    contractId: CONTRACT_ID,
+  };
+}
+
+describe("Relayer API — daily permit-limit race (#822)", () => {
+  let app: Express;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.RELAYER_SECRET_KEY = "SPLACEHOLDERSECRET";
+    process.env.TOKEN_VOTES_CONTRACT_ID = CONTRACT_ID;
+    process.env.RELAYER_DAILY_PERMIT_LIMIT = "5";
+    mockGetAccount.mockResolvedValue({});
+    mockPrepareTransaction.mockResolvedValue({ sign: () => {} });
+    mockSendTransaction.mockResolvedValue({ status: "PENDING", hash: "deadbeef" });
+    app = createApp();
+  });
+
+  describe("POST /relayer/delegate", () => {
+    it("rejects when the delegator has already hit the daily limit", async () => {
+      const client = createFakeClient({ [DELEGATOR]: 5 });
+      mockConnect.mockResolvedValueOnce(client);
+
+      const res = await request(app)
+        .post("/relayer/delegate")
+        .send({ permit: makePermit(1), signature: "sig" });
+
+      expect(res.status).toBe(429);
+      expect(mockSendTransaction).not.toHaveBeenCalled();
+      expect(client.query).toHaveBeenCalledWith("ROLLBACK");
+    });
+
+    it("submits and logs when under the daily limit", async () => {
+      const client = createFakeClient({ [DELEGATOR]: 4 });
+      mockConnect.mockResolvedValueOnce(client);
+
+      const res = await request(app)
+        .post("/relayer/delegate")
+        .send({ permit: makePermit(1), signature: "sig" });
+
+      expect(res.status).toBe(200);
+      expect(mockSendTransaction).toHaveBeenCalledTimes(1);
+      const insertCall = client.query.mock.calls.find(([sql]) =>
+        String(sql).includes("INSERT INTO relayer_permit_log"),
+      );
+      expect(insertCall).toBeDefined();
+      expect(client.query).toHaveBeenCalledWith("COMMIT");
+    });
+  });
+
+  describe("POST /relayer/delegate-batch", () => {
+    it("rejects the whole batch when permits for one delegator would jointly exceed the limit, even though a stale per-permit count would pass each individually", async () => {
+      // Only one slot left (4 of 5 used). Two permits for the SAME delegator
+      // in one batch: the pre-fix code would call relayedPermitCountToday
+      // once per permit and see the same stale count=4 both times, letting
+      // both through. The fix must track an in-memory running tally so the
+      // second permit sees the first has already "spent" the last slot.
+      const client = createFakeClient({ [DELEGATOR]: 4 });
+      mockConnect.mockResolvedValueOnce(client);
+
+      const res = await request(app)
+        .post("/relayer/delegate-batch")
+        .send({
+          permits: [makePermit(1), makePermit(2)],
+          signatures: ["sig1", "sig2"],
+        });
+
+      expect(res.status).toBe(429);
+      // Must not have submitted on-chain at all once the tally caught the
+      // over-limit permit — otherwise the batch's atomicity would mean both
+      // permits still land even though the response says 429.
+      expect(mockSendTransaction).not.toHaveBeenCalled();
+      expect(client.query).toHaveBeenCalledWith("ROLLBACK");
+    });
+
+    it("allows a batch that stays within each delegator's own limit", async () => {
+      const client = createFakeClient({ [DELEGATOR]: 2, [OTHER_DELEGATOR]: 0 });
+      mockConnect.mockResolvedValueOnce(client);
+
+      const res = await request(app)
+        .post("/relayer/delegate-batch")
+        .send({
+          permits: [
+            makePermit(1, DELEGATOR),
+            makePermit(2, DELEGATOR),
+            makePermit(1, OTHER_DELEGATOR),
+          ],
+          signatures: ["sig1", "sig2", "sig3"],
+        });
+
+      expect(res.status).toBe(200);
+      expect(mockSendTransaction).toHaveBeenCalledTimes(1);
+      expect(client.query).toHaveBeenCalledWith("COMMIT");
+    });
+  });
+});

--- a/backend/src/routes/relayer.ts
+++ b/backend/src/routes/relayer.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { z } from "zod";
+import type { PoolClient } from "pg";
 import {
   Contract,
   Keypair,
@@ -157,9 +158,27 @@ function isWellFormedAuthEntry(base64Xdr: string): boolean {
   }
 }
 
+/**
+ * Serializes daily-quota check-and-log for `delegator` against concurrent
+ * requests (including other permits for the same delegator within one
+ * batch): callers must hold this lock for the lifetime of the transaction
+ * that performs the count check, so that no other request can read the same
+ * pre-log count before this one commits its log entry. Postgres advisory
+ * locks taken with the `_xact_` variant release automatically on
+ * COMMIT/ROLLBACK.
+ */
+async function lockDelegator(client: PoolClient, delegator: string): Promise<void> {
+  await client.query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", [
+    delegator,
+  ]);
+}
+
 /** Rolling 24h count of permits this relayer has already submitted for `delegator`. */
-async function relayedPermitCountToday(delegator: string): Promise<number> {
-  const { rows } = await pool.query<{ count: string }>(
+async function relayedPermitCountToday(
+  client: PoolClient,
+  delegator: string,
+): Promise<number> {
+  const { rows } = await client.query<{ count: string }>(
     `SELECT COUNT(*)::text AS count FROM relayer_permit_log
      WHERE delegator = $1 AND created_at > NOW() - INTERVAL '1 day'`,
     [delegator],
@@ -168,10 +187,11 @@ async function relayedPermitCountToday(delegator: string): Promise<number> {
 }
 
 async function logRelayedPermit(
+  client: PoolClient,
   permit: PermitInput,
   txHash: string,
 ): Promise<void> {
-  await pool.query(
+  await client.query(
     `INSERT INTO relayer_permit_log (delegator, delegatee, nonce, tx_hash)
      VALUES ($1, $2, $3, $4)
      ON CONFLICT (delegator, nonce) DO NOTHING`,
@@ -220,13 +240,24 @@ async function submitInvocation(
 router.post("/delegate", validate({ body: delegateSchema }), async (req, res) => {
   const { permit, signature } = req.body as z.infer<typeof delegateSchema>;
 
-  try {
-    if (!isWellFormedAuthEntry(signature)) {
-      return res.status(400).json({ error: "Malformed authorization signature" });
-    }
+  if (!isWellFormedAuthEntry(signature)) {
+    return res.status(400).json({ error: "Malformed authorization signature" });
+  }
 
-    const relayedToday = await relayedPermitCountToday(permit.delegator);
+  // The daily-quota check and the eventual log write are held in the same
+  // transaction, behind a per-delegator advisory lock, so a second
+  // concurrent request for this delegator can't read the same pre-log count
+  // — it blocks until this transaction commits or rolls back. The lock is
+  // held across the on-chain submission below, which is the whole point:
+  // that's the window the count must stay accurate through.
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await lockDelegator(client, permit.delegator);
+
+    const relayedToday = await relayedPermitCountToday(client, permit.delegator);
     if (relayedToday >= RELAYER_DAILY_PERMIT_LIMIT) {
+      await client.query("ROLLBACK");
       return res.status(429).json({
         error: "Relayer daily permit limit reached for this address",
       });
@@ -240,16 +271,20 @@ router.post("/delegate", validate({ body: delegateSchema }), async (req, res) =>
       [nativeToScVal(relayer.publicKey(), { type: "address" }), permitToScVal(permit)],
       [entry],
     );
-    await logRelayedPermit(permit, txHash);
+    await logRelayedPermit(client, permit, txHash);
+    await client.query("COMMIT");
 
     res.json({ txHash, nonce: Number(permit.nonce) + 1 });
   } catch (error) {
+    await client.query("ROLLBACK");
     logger.error({ err: error }, "Error in POST /relayer/delegate");
     const contractMessage = extractContractErrorMessage(error);
     if (contractMessage) {
       return res.status(400).json({ error: contractMessage });
     }
     res.status(500).json({ error: "Failed to submit delegation" });
+  } finally {
+    client.release();
   }
 });
 
@@ -268,18 +303,41 @@ router.post(
         .json({ error: "permits and signatures must have the same length" });
     }
 
+    if (!signatures.every(isWellFormedAuthEntry)) {
+      return res.status(400).json({ error: "Malformed authorization signature" });
+    }
+
+    // Same per-delegator advisory lock as /delegate, but a batch can contain
+    // several permits for the same delegator, none of which are logged yet
+    // when the others are checked. A running in-memory tally (seeded from
+    // the DB count, then incremented as each permit in this batch is
+    // provisionally accepted) makes each subsequent check in the loop see
+    // the permits already "spent" earlier in the same request.
+    const uniqueDelegators = Array.from(
+      new Set(permits.map((p) => p.delegator)),
+    ).sort();
+
+    const client = await pool.connect();
     try {
-      if (!signatures.every(isWellFormedAuthEntry)) {
-        return res.status(400).json({ error: "Malformed authorization signature" });
+      await client.query("BEGIN");
+      // Lock in a fixed (sorted) order so two overlapping batches can't deadlock.
+      for (const delegator of uniqueDelegators) {
+        await lockDelegator(client, delegator);
       }
 
+      const pendingCounts = new Map<string, number>();
       for (const permit of permits) {
-        const relayedToday = await relayedPermitCountToday(permit.delegator);
-        if (relayedToday >= RELAYER_DAILY_PERMIT_LIMIT) {
+        let count = pendingCounts.get(permit.delegator);
+        if (count === undefined) {
+          count = await relayedPermitCountToday(client, permit.delegator);
+        }
+        if (count >= RELAYER_DAILY_PERMIT_LIMIT) {
+          await client.query("ROLLBACK");
           return res.status(429).json({
             error: `Relayer daily permit limit reached for ${permit.delegator}`,
           });
         }
+        pendingCounts.set(permit.delegator, count + 1);
       }
 
       const relayer = getRelayerKeypair();
@@ -293,19 +351,25 @@ router.post(
         [nativeToScVal(relayer.publicKey(), { type: "address" }), permitsScVal],
         entries,
       );
-      await Promise.all(permits.map((permit) => logRelayedPermit(permit, txHash)));
+      for (const permit of permits) {
+        await logRelayedPermit(client, permit, txHash);
+      }
+      await client.query("COMMIT");
 
       res.json({
         txHash,
         nonces: permits.map((p) => Number(p.nonce) + 1),
       });
     } catch (error) {
+      await client.query("ROLLBACK");
       logger.error({ err: error }, "Error in POST /relayer/delegate-batch");
       const contractMessage = extractContractErrorMessage(error);
       if (contractMessage) {
         return res.status(400).json({ error: contractMessage });
       }
       res.status(500).json({ error: "Failed to submit batch delegation" });
+    } finally {
+      client.release();
     }
   },
 );


### PR DESCRIPTION
## Summary
- `relayedPermitCountToday()` was read outside any transaction and compared to the daily quota, while the corresponding log INSERT only happened after the multi-second on-chain submission completed — concurrent `/delegate` calls, or multiple permits for one delegator within a single `/delegate-batch` request, could all read the same stale pre-log count and all pass the check, letting a delegator exceed their daily quota.
- The count-check and log-write are now done inside a single DB transaction per request, serialized per delegator with a Postgres advisory transaction lock (`pg_advisory_xact_lock`) held across the on-chain submission, so a second request for the same delegator can't observe the same pre-commit count.
- The batch endpoint additionally keeps an in-memory running tally per delegator across permits already accepted earlier in the same batch, so several permits for one delegator in a single request can no longer all pass the same stale count.

Closes #822, 
Closes #821,
Closes #820, 
Closes #818

## Test plan
- [x] `backend/src/routes/relayer.test.ts` (new): reproduces the exact batch race from #822 — a batch with 2 permits for one delegator, one slot left on their quota, is rejected as a whole (429) rather than both being submitted; also covers single-request over-limit rejection and multi-delegator batches staying within each delegator's own limit.
- [x] `tsc --noEmit` passes for the backend package.
- [x] Full backend jest suite run; the DB-backed integration suites (auth/notifications/etc.) don't run in this sandbox (no live Postgres), unrelated to this change.