### PR TITLE
fix(timelock): enable partial batch recovery

### DIFF
--- a/contracts/timelock/src/lib.rs
+++ b/contracts/timelock/src/lib.rs
@@ -288,8 +288,8 @@ impl TimelockContract {
     }
 
     /// Execute a batch with partial completion tolerance (queues for recovery on any failure).
-    /// Note: Individual operation failures will cause the entire transaction to revert.
-    /// This function sets up recovery state that can be used to retry operations after investigation.
+    /// Each sub-operation is attempted independently. If one fails, it is recorded in recovery state
+    /// and the batch continues to the next operation.
     pub fn execute_batch_partial(env: Env, caller: Address, batch_op_id: Bytes) -> PartialBatchExecutionState {
         caller.require_auth();
         Self::require_governor(&env, &caller);
@@ -308,11 +308,9 @@ impl TimelockContract {
         }
 
         let mut completed_ops: Vec<Bytes> = Vec::new(&env);
-        // No failures accumulate here: any sub-call panic reverts the whole tx.
-        // The empty vec documents the shape of the state that gets persisted.
-        let failed_ops: Vec<FailedOperation> = Vec::new(&env);
+        let mut failed_ops: Vec<FailedOperation> = Vec::new(&env);
+        let mut recovery_mode = false;
 
-        // Execute all operations in order. If any fails, transaction reverts (standard Soroban behavior).
         for i in 0..batch.targets.len() {
             let op_id = Self::hash_op_in_batch(
                 &env,
@@ -327,16 +325,33 @@ impl TimelockContract {
             let data = batch.datas.get(i).unwrap();
             let args = Self::decode_invocation_args(&env, &data);
 
-            // Execute the contract invocation (will panic/revert if it fails)
-            let _: Val = env.invoke_contract(&target, &fn_name, args);
-            completed_ops.push_back(op_id.clone());
-            emit_partial_op_succeeded(
-                &env,
-                &batch_op_id,
-                &op_id,
-                completed_ops.len(),
-                batch.targets.len(),
-            );
+            let invocation_result = env.try_invoke_contract::<(), soroban_sdk::Error>(&target, &fn_name, args);
+            match invocation_result {
+                Ok(Ok(_)) => {
+                    completed_ops.push_back(op_id.clone());
+                    emit_partial_op_succeeded(
+                        &env,
+                        &batch_op_id,
+                        &op_id,
+                        completed_ops.len(),
+                        batch.targets.len(),
+                    );
+                }
+                Ok(Err(_)) | Err(_) => {
+                    let failed_op = FailedOperation {
+                        op_id: op_id.clone(),
+                        target: target.clone(),
+                        fn_name: fn_name.clone(),
+                        data: data.clone(),
+                        failure_reason: symbol_short!("failed"),
+                        failed_at_ledger: env.ledger().sequence(),
+                        retry_count: 0,
+                    };
+                    failed_ops.push_back(failed_op);
+                    recovery_mode = true;
+                    emit_partial_op_failed(&env, &batch_op_id, &op_id);
+                }
+            }
         }
 
         let recovery_deadline = env.ledger().sequence() + 100_000;
@@ -346,12 +361,16 @@ impl TimelockContract {
             completed_ops: completed_ops.clone(),
             failed_ops: failed_ops.clone(),
             pending_ops: Vec::new(&env),
-            recovery_mode: false,
+            recovery_mode,
             recovery_deadline,
         };
 
         let state_key = DataKey::PartialBatchState(batch_op_id.clone());
         env.storage().persistent().set(&state_key, &state);
+
+        if recovery_mode {
+            emit_batch_recovery_entered(&env, &batch_op_id, recovery_deadline);
+        }
 
         emit_partial_batch_started(&env, &batch_op_id, batch.targets.len());
 

--- a/contracts/timelock/src/test_dag.rs
+++ b/contracts/timelock/src/test_dag.rs
@@ -24,6 +24,10 @@ impl MockTarget {
             .unwrap_or(false)
     }
 
+    pub fn fail(_env: Env) {
+        panic!("forced failure")
+    }
+
     pub fn store_i128(env: Env, value: i128) {
         env.storage()
             .persistent()
@@ -367,7 +371,7 @@ fn test_partial_batch_enters_recovery_on_first_failure() {
     datas.push_back(Bytes::new(&env));
 
     let mut fn_names = Vec::new(&env);
-    fn_names.push_back(Symbol::new(&env, "exec"));
+    fn_names.push_back(Symbol::new(&env, "fail"));
 
     let batch_op_id = client.schedule_batch(
         &governor,
@@ -381,11 +385,12 @@ fn test_partial_batch_enters_recovery_on_first_failure() {
 
     env.ledger().with_mut(|l| l.timestamp = 1);
 
-    // Execute batch partially
     let state = client.execute_batch_partial(&governor, &batch_op_id);
 
-    // Verify state structure
     assert_eq!(state.batch_op_id, batch_op_id);
+    assert!(state.recovery_mode, "a failed sub-operation should enable recovery mode");
+    assert_eq!(state.failed_ops.len(), 1, "the failed sub-operation should be recorded");
+    assert!(state.completed_ops.is_empty(), "no successful sub-operations should be recorded when the batch fails");
 }
 
 #[test]


### PR DESCRIPTION
# fix(timelock): enable partial batch recovery

## Summary
This PR fixes the timelock partial-batch recovery flow so failed sub-operations are no longer lost. Previously, `execute_batch_partial` used a non-guarded invocation path that aborted the transaction on the first failure, which meant recovery state was never populated and the retry/skip paths were effectively unreachable.

## What changed
- Switched each sub-operation in `execute_batch_partial` to use `env.try_invoke_contract(...)`.
- Captured failed sub-operations and recorded them in `failed_ops`.
- Enabled `recovery_mode` when any sub-operation fails.
- Emitted the recovery-related events for failed operations and batch recovery entry.
- Added a regression test covering the failure path so recovery state is exercised.

## Why
The previous implementation always failed fast, so `retry_failed_operation` and `skip_failed_operation` could not meaningfully operate in production. This change makes partial batch execution behave as intended by preserving failed operations for later recovery handling.

## Verification
- Ran:
  `cargo test -p sorogov-timelock test_partial_batch_enters_recovery_on_first_failure -- --nocapture`

Result:
- 1 test passed
- 0 failed

Closes: #837 