### PR TITLE
fix(token-votes): resolve delegation registry bugs (#806 #807 #808 #809)

### DIFF
--- a/contracts/token-votes/src/delegation_registry.rs
+++ b/contracts/token-votes/src/delegation_registry.rs
@@ -7,7 +7,7 @@
 //! (already representable via the existing `Delegate` mapping) can be
 //! resolved, audited, and bounded.
 
-use crate::{DataKey, TokenVotesContract};
+use crate::{DataKey, TokenVotesContract, TokenVotesError};
 use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
 
 /// Safety bound on delegation-chain traversal. Real chains are already
@@ -76,7 +76,7 @@ fn resolve_chain(env: &Env, start: Address) -> Vec<Address> {
     let mut hops = 0u32;
     loop {
         if hops >= MAX_CHAIN_WALK {
-            break;
+            env.panic_with_error(TokenVotesError::ChainDepthExceeded);
         }
         let next: Option<Address> = env
             .storage()
@@ -203,13 +203,6 @@ pub(crate) fn register_delegation(
 
     let full_chain = resolve_chain(env, delegator.clone());
     let depth = full_chain.len() - 1;
-    env.storage()
-        .persistent()
-        .set(&DataKey::DelegationChain(delegator.clone()), &full_chain);
-    env.storage()
-        .persistent()
-        .set(&DataKey::ChainDepth(delegator.clone()), &depth);
-
 
     emit_delegation_registered(env, delegator, delegatee, power, depth);
 }
@@ -224,15 +217,16 @@ pub(crate) fn revoke_registry_entry(
     current_ledger: u32,
 ) {
     let record_key = DataKey::DelegationRecord(delegator.clone(), old_delegatee.clone());
-    if let Some(mut entry) = env
+    let Some(mut entry) = env
         .storage()
         .persistent()
         .get::<_, DelegationEntry>(&record_key)
-    {
-        entry.active = false;
-        entry.revoked_at_ledger = Some(current_ledger);
-        env.storage().persistent().set(&record_key, &entry);
-    }
+    else {
+        return;
+    };
+    entry.active = false;
+    entry.revoked_at_ledger = Some(current_ledger);
+    env.storage().persistent().set(&record_key, &entry);
 
     let history_key = DataKey::DelegationHistory(delegator.clone());
     if let Some(mut history) = env
@@ -414,6 +408,7 @@ pub(crate) fn get_received_delegations(
 
 pub(crate) fn set_delegation_depth_limit(env: &Env, new_limit: u32) {
     assert!(new_limit >= 1, "depth limit must be at least 1");
+    assert!(new_limit <= MAX_CHAIN_WALK, "depth limit must not exceed MAX_CHAIN_WALK");
     let old_limit = get_depth_limit(env);
     env.storage()
         .instance()

--- a/contracts/token-votes/src/error.rs
+++ b/contracts/token-votes/src/error.rs
@@ -23,4 +23,5 @@ pub enum TokenVotesError {
     RelayerNotWhitelisted = 14,
     InvalidChainId = 15,
     InvalidContractId = 16,
+    ChainDepthExceeded = 17,
 }

--- a/contracts/token-votes/src/lib.rs
+++ b/contracts/token-votes/src/lib.rs
@@ -308,6 +308,9 @@ impl TokenVotesContract {
             .get(&DataKey::Delegate(delegator.clone()));
 
         if let Some(old_delegatee) = previous_delegate {
+            if old_delegatee == delegator {
+                return;
+            }
             let record: DelegatorRecord = env
                 .storage()
                 .persistent()


### PR DESCRIPTION
Fixes #806, #807, #808, #809

## Summary
Resolves four delegation-registry bugs in `contracts/token-votes`:

- **#806** — `revoke_delegation()` now early-returns (no-op) when the caller is self-delegated, mirroring the existing guard in `undelegate()` and preventing accidental destruction of voting power.
- **#807** — Removes the dead writes to `DataKey::DelegationChain` and `DataKey::ChainDepth` in `register_delegation()`. These keys were written on every delegation but never read; the public getters already resolve the chain live via `resolve_chain()`.
- **#808** — Caps `set_delegation_depth_limit()` at `MAX_CHAIN_WALK` (64) so admins cannot raise the limit past the traversal guard. Also changes `resolve_chain()` to panic with a typed `ChainDepthExceeded` error instead of silently truncating when the cap is hit, making invariant violations loud.
- **#809** — `revoke_registry_entry()` now returns immediately when no `DelegationRecord` exists for the pair, preventing orphan `DelegationRevoked` events for legacy delegations that pre-date the registry.

## Test plan
No new tests added. Existing token-votes tests cover the affected paths; the changes are minimal and preserve existing behavior for registered delegations.