### PR TITLE
fix(sdk): add missing TimelockErrorCode entries for DAG error codes 1…

### DIFF
--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -142,6 +142,12 @@ export enum TimelockErrorCode {
   PredecessorNotDone = 1,
   PredecessorNotFound = 2,
   OperationExpired = 3,
+  DependencyCycleDetected = 10,
+  PredecessorNotComplete = 11,
+  BatchInRecoveryMode = 12,
+  BatchRecoveryExpired = 13,
+  OperationAlreadyInBatch = 14,
+  InvalidPredecessorList = 15,
 
   // SDK-level codes
   SimulationFailed = 100,
@@ -157,6 +163,18 @@ const TIMELOCK_MESSAGES: Record<TimelockErrorCode, string> = {
     "Cannot schedule: the specified predecessor operation does not exist",
   [TimelockErrorCode.OperationExpired]:
     "Operation has expired and can no longer be executed",
+  [TimelockErrorCode.DependencyCycleDetected]:
+    "The dependency graph contains a cycle and cannot be scheduled",
+  [TimelockErrorCode.PredecessorNotComplete]:
+    "A predecessor operation in the batch has not completed yet",
+  [TimelockErrorCode.BatchInRecoveryMode]:
+    "Batch is in recovery mode and cannot accept this operation",
+  [TimelockErrorCode.BatchRecoveryExpired]:
+    "Batch recovery deadline has expired",
+  [TimelockErrorCode.OperationAlreadyInBatch]:
+    "Operation is already part of a batch",
+  [TimelockErrorCode.InvalidPredecessorList]:
+    "Invalid predecessor list provided",
   [TimelockErrorCode.SimulationFailed]: "Simulation failed",
   [TimelockErrorCode.TransactionFailed]: "Transaction failed",
   [TimelockErrorCode.TransactionTimeout]: "Transaction timed out",


### PR DESCRIPTION
…0-15

contracts/timelock/src/lib.rs defines six DAG-specific error codes (DependencyCycleDetected, PredecessorNotComplete, BatchInRecoveryMode, BatchRecoveryExpired, OperationAlreadyInBatch, InvalidPredecessorList) that TimelockErrorCode never mirrored. scheduleWithDeps, executeBatchPartial, retryFailedOperation, and skipFailedOperation reverting with any of these fell back to a generic "Timelock contract error #N" with no enum member to branch on.

Closes #908