### PR TITLE
feat(governance-tuning): add analytics-driven adaptive parameter recommender

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build SDK
+        run: pnpm --filter @nebgov/sdk run build
+
       - name: Run backend database migrations
         run: pnpm --filter nebgov-backend run migrate
 

--- a/app/src/app/governance-tuning/page.tsx
+++ b/app/src/app/governance-tuning/page.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useGovernanceTuning } from "../../hooks/useGovernanceTuning";
+import { TuningRecommendationCard } from "../../components/TuningRecommendationCard";
+
+function ParticipationTrendChart({ snapshotVotesCast }: { snapshotVotesCast: string[] }) {
+  if (!snapshotVotesCast || snapshotVotesCast.length < 2) {
+    return (
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        Not enough snapshot history yet to plot a trend.
+      </p>
+    );
+  }
+
+  const values = snapshotVotesCast.map((v) => Number(BigInt(v)));
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const width = 320;
+  const height = 80;
+  const points = values
+    .map((v, i) => {
+      const x = (i / (values.length - 1)) * width;
+      const y = height - ((v - min) / range) * height;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className="w-full h-20"
+      role="img"
+      aria-label="Trailing participation trend (cumulative votes cast per snapshot)"
+    >
+      <polyline
+        points={points}
+        fill="none"
+        className="stroke-indigo-500 dark:stroke-indigo-400"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export default function GovernanceTuningPage() {
+  const { latest, history, loading, error } = useGovernanceTuning();
+
+  const snapshotVotesCast = (latest?.rationale.inputs.snapshotVotesCast as string[] | undefined) ?? [];
+
+  return (
+    <div className="max-w-5xl mx-auto p-6 space-y-6">
+      <div>
+        <h1 className="text-3xl font-semibold text-gray-900 dark:text-white">Governance tuning</h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Analytics-driven recommendations for quorum and proposal threshold, computed periodically
+          from the indexer&apos;s governance analytics. Recommendations are never applied
+          automatically by default — review one and submit it as an ordinary proposal.
+        </p>
+      </div>
+
+      {error && (
+        <p className="rounded-xl border border-rose-200 bg-rose-50 dark:border-rose-900 dark:bg-rose-900/20 p-4 text-sm text-rose-700 dark:text-rose-300">
+          {error}
+        </p>
+      )}
+
+      {loading ? (
+        <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-6 text-sm text-gray-500 dark:text-gray-400">
+          Loading recommendations...
+        </div>
+      ) : !latest ? (
+        <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-6 text-sm text-gray-500 dark:text-gray-400">
+          No recommendation has been computed yet.
+        </div>
+      ) : (
+        <>
+          <TuningRecommendationCard recommendation={latest} />
+
+          <section className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-5">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3">
+              Participation trend
+            </h2>
+            <ParticipationTrendChart snapshotVotesCast={snapshotVotesCast} />
+          </section>
+        </>
+      )}
+
+      <section className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-5">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3">
+          Recommendation history
+        </h2>
+        {history.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">No history yet.</p>
+        ) : (
+          <ul className="space-y-2">
+            {history.map((rec) => (
+              <li
+                key={rec.id}
+                className="rounded-lg border border-gray-100 dark:border-gray-800 p-3 text-sm flex flex-wrap items-center justify-between gap-2"
+              >
+                <span className="text-gray-500 dark:text-gray-400">
+                  {new Date(rec.computedAt).toLocaleString()}
+                </span>
+                <span className="font-mono text-xs tabular-nums text-gray-700 dark:text-gray-300">
+                  quorum {rec.currentQuorumNumerator} → {rec.recommendedQuorumNumerator}, threshold{" "}
+                  {rec.currentProposalThreshold.toString()} → {rec.recommendedProposalThreshold.toString()}
+                </span>
+                {rec.autoProposed && (
+                  <span className="px-2 py-0.5 rounded-full bg-indigo-50 dark:bg-indigo-900/20 text-indigo-700 dark:text-indigo-300 text-xs font-semibold">
+                    auto-proposed
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/src/components/GaslessDelegateModal.tsx
+++ b/app/src/components/GaslessDelegateModal.tsx
@@ -49,7 +49,7 @@ export function GaslessDelegateModal({
   const [submitting, setSubmitting] = useState(false);
   const [expiryPreset, setExpiryPreset] = useState<ExpiryPreset>("1month");
   const { isConnected, publicKey, connect } = useWallet();
-  const { delegateGasless, preflightDelegatee } = useGaslessDelegation();
+  const { delegateGasless, preflightDelegatee, invalidateAllPermits } = useGaslessDelegation();
   const dialogRef = useFocusTrap<HTMLDivElement>(open, onClose);
 
   useEffect(() => {

--- a/app/src/components/NavBar.tsx
+++ b/app/src/components/NavBar.tsx
@@ -19,6 +19,7 @@ import {
   Moon,
   Bell,
   Settings,
+  SlidersHorizontal,
 } from "lucide-react";
 import { useTheme } from "../hooks/useTheme";
 import { useTranslations } from "next-intl";
@@ -43,6 +44,7 @@ const NAV_LINKS = [
   { name: "Delegates", href: "/delegates", icon: Users },
   { name: "Analytics", href: "/analytics", icon: BarChart3 },
   { name: "Treasury", href: "/treasury", icon: Wallet2 },
+  { name: "Governance Tuning", href: "/governance-tuning", icon: SlidersHorizontal },
   { name: "Settings", href: "/settings", icon: Settings },
 ];
 

--- a/app/src/components/TuningRecommendationCard.tsx
+++ b/app/src/components/TuningRecommendationCard.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { GovernorClient, type TuningRecommendation } from "@nebgov/sdk";
+import { xdr } from "@stellar/stellar-sdk";
+import { readGovernorConfig } from "../lib/nebgov-env";
+import { useWallet } from "../lib/wallet-context";
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function DirectionBadge({ direction }: { direction: "up" | "down" | "unchanged" }) {
+  const styles =
+    direction === "up"
+      ? "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-300"
+      : direction === "down"
+      ? "bg-rose-50 text-rose-700 dark:bg-rose-900/20 dark:text-rose-300"
+      : "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400";
+  const label = direction === "up" ? "↑ Up" : direction === "down" ? "↓ Down" : "No change";
+  return <span className={`px-2 py-0.5 rounded-full text-xs font-semibold ${styles}`}>{label}</span>;
+}
+
+export function TuningRecommendationCard({
+  recommendation,
+}: {
+  recommendation: TuningRecommendation;
+}) {
+  const router = useRouter();
+  const { isConnected, publicKey } = useWallet();
+  const config = useMemo(() => readGovernorConfig(), []);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const quorumChanged =
+    recommendation.recommendedQuorumNumerator !== recommendation.currentQuorumNumerator;
+  const thresholdChanged =
+    recommendation.recommendedProposalThreshold !== recommendation.currentProposalThreshold;
+  const hasChange = quorumChanged || thresholdChanged;
+
+  async function handlePropose() {
+    if (!config) return;
+    try {
+      setSubmitting(true);
+      setError(null);
+      const governor = new GovernorClient(config);
+      const source = publicKey ?? config.governorAddress;
+      const currentSettings = await governor.getSettings(source);
+      const nextSettings = {
+        ...currentSettings,
+        quorumNumerator: recommendation.recommendedQuorumNumerator,
+        proposalThreshold: recommendation.recommendedProposalThreshold,
+      };
+      const { target, fnName, calldata } = governor.buildUpdateConfigProposal(nextSettings);
+      const encodedArg = xdr.ScVal.fromXDR(Buffer.from(calldata));
+      const simulation = await governor.simulateTargetInvocation(source, target, fnName, [encodedArg]);
+      if (!simulation.ok) {
+        throw new Error(simulation.error ?? "Simulation failed");
+      }
+
+      const q = new URLSearchParams({
+        step: "2",
+        target,
+        fnName,
+        calldataHex: toHex(calldata),
+        from: "governance-tuning",
+      });
+      router.push(`/propose?${q.toString()}`);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Could not build update_config proposal");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-5 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+          Latest recommendation
+        </h3>
+        <span className="text-xs text-gray-400 dark:text-gray-500">
+          {new Date(recommendation.computedAt).toLocaleString()}
+        </span>
+      </div>
+
+      {error && (
+        <p className="rounded-lg border border-rose-200 bg-rose-50 dark:border-rose-900 dark:bg-rose-900/20 p-3 text-sm text-rose-700 dark:text-rose-300">
+          {error}
+        </p>
+      )}
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="rounded-lg border border-gray-100 dark:border-gray-800 p-3">
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-200">quorum_numerator</span>
+            <DirectionBadge direction={recommendation.rationale.quorumNumerator.direction} />
+          </div>
+          <p className="font-mono text-sm tabular-nums text-gray-900 dark:text-gray-100">
+            {recommendation.currentQuorumNumerator} {"->"} {recommendation.recommendedQuorumNumerator}
+          </p>
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            {recommendation.rationale.quorumNumerator.reason}
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-gray-100 dark:border-gray-800 p-3">
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-200">proposal_threshold</span>
+            <DirectionBadge direction={recommendation.rationale.proposalThreshold.direction} />
+          </div>
+          <p className="font-mono text-sm tabular-nums text-gray-900 dark:text-gray-100">
+            {recommendation.currentProposalThreshold.toString()} {"->"}{" "}
+            {recommendation.recommendedProposalThreshold.toString()}
+          </p>
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            {recommendation.rationale.proposalThreshold.reason}
+          </p>
+        </div>
+      </div>
+
+      <p className="text-xs text-gray-400 dark:text-gray-500">
+        voting_period: {recommendation.rationale.votingPeriod.reason}
+      </p>
+
+      {recommendation.autoProposed ? (
+        <p className="text-sm text-indigo-600 dark:text-indigo-300">
+          Already submitted on-chain{recommendation.proposalId !== null ? ` as proposal #${recommendation.proposalId}` : ""}.
+        </p>
+      ) : (
+        <button
+          type="button"
+          onClick={handlePropose}
+          disabled={!isConnected || !config || submitting || !hasChange}
+          className="w-full rounded-lg bg-indigo-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {submitting
+            ? "Verifying calldata..."
+            : !hasChange
+            ? "No parameter change to propose"
+            : "Propose This Change"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/__tests__/GaslessDelegateModal.validation.test.tsx
+++ b/app/src/components/__tests__/GaslessDelegateModal.validation.test.tsx
@@ -10,6 +10,7 @@ const VALID_ADDRESS = "GDOOXICJPSOZDQRCEHZPR6MAX5PUZXVWGJ3QPVEU4DADIZQ4YBQOJNIB"
 const VALID_ADDRESS_2 = "GD6HLZWRE5FHK3SDLZB3FH56R3H3ECAAYCPWWU7O7EK4FCNT2Z7S6D5I";
 const mockDelegateGasless = jest.fn();
 const mockPreflightDelegatee = jest.fn();
+const mockInvalidateAllPermits = jest.fn();
 
 jest.mock("../../lib/wallet-context", () => ({
   useWallet: () => ({
@@ -28,6 +29,7 @@ jest.mock("../../hooks/useGaslessDelegation", () => ({
   useGaslessDelegation: () => ({
     delegateGasless: mockDelegateGasless.mockResolvedValue({ txHash: "txhash789" }),
     preflightDelegatee: mockPreflightDelegatee.mockResolvedValue(undefined),
+    invalidateAllPermits: mockInvalidateAllPermits.mockResolvedValue({ txHash: "invalidate-txhash" }),
     submitting: false,
   }),
   EXPIRY_PRESET_LABELS: {
@@ -49,8 +51,10 @@ describe("GaslessDelegateModal — Stellar address validation", () => {
     jest.clearAllMocks();
     mockDelegateGasless.mockReset();
     mockPreflightDelegatee.mockReset();
+    mockInvalidateAllPermits.mockReset();
     mockDelegateGasless.mockResolvedValue({ txHash: "txhash789" });
     mockPreflightDelegatee.mockResolvedValue(undefined);
+    mockInvalidateAllPermits.mockResolvedValue({ txHash: "invalidate-txhash" });
   });
 
   describe("rendering", () => {

--- a/app/src/hooks/useGaslessDelegation.ts
+++ b/app/src/hooks/useGaslessDelegation.ts
@@ -1,10 +1,11 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import { DelegationSigClient, type Network } from "@nebgov/sdk";
+import { DelegationSigClient, VotesClient, type Network } from "@nebgov/sdk";
 import { isValidStellarAddress } from "../lib/utils/stellarAddress";
 import { useWallet } from "../lib/wallet-context";
 import { backendFetch } from "../lib/backend";
+import { readGovernorConfig } from "../lib/nebgov-env";
 
 /**
  * Approximate ledger close time used to convert a human-friendly expiry
@@ -56,13 +57,23 @@ function getDelegationSigClientFromEnv(): DelegationSigClient {
   });
 }
 
+function getVotesClientFromEnv(): VotesClient {
+  const config = readGovernorConfig();
+  if (!config) {
+    throw new Error(
+      "Missing NEXT_PUBLIC_GOVERNOR_ADDRESS/NEXT_PUBLIC_TIMELOCK_ADDRESS/NEXT_PUBLIC_VOTES_ADDRESS in .env.local",
+    );
+  }
+  return new VotesClient(config);
+}
+
 /**
  * Sign a delegation permit with the connected wallet and submit it through
  * the backend relayer — the connected wallet never pays a fee or submits a
  * transaction itself, it only signs an authorization off-chain.
  */
 export function useGaslessDelegation() {
-  const { isConnected, publicKey, signTransaction } = useWallet();
+  const { isConnected, publicKey, signAuthEntry, signTransaction } = useWallet();
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -81,11 +92,15 @@ export function useGaslessDelegation() {
       }
 
       try {
-        const client = getDelegationSigClientFromEnv();
+        // Cycle/depth-limit checks are read directly off the token-votes
+        // contract's delegation registry — that's VotesClient, not
+        // DelegationSigClient (which only handles the signed-permit
+        // relayer flow used by delegateGasless below).
+        const votes = getVotesClientFromEnv();
         const [wouldCreateCycle, depthLimit, currentDepth] = await Promise.all([
-          client.wouldCreateCycle(publicKey, delegatee.trim()),
-          client.getDelegationDepthLimit(),
-          client.getChainDepth(publicKey),
+          votes.wouldCreateCycle(publicKey, delegatee.trim()),
+          votes.getDelegationDepthLimit(),
+          votes.getChainDepth(publicKey),
         ]);
 
         if (wouldCreateCycle) {
@@ -168,5 +183,25 @@ export function useGaslessDelegation() {
     [isConnected, publicKey, signAuthEntry],
   );
 
-  return { delegateGasless, preflightDelegatee, submitting, error };
+  const invalidateAllPermits = useCallback(async (): Promise<GaslessDelegationResult> => {
+    if (!isConnected || !publicKey) {
+      throw new Error("Connect your wallet first.");
+    }
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      const client = getDelegationSigClientFromEnv();
+      const { hash } = await client.invalidateAllPermitsWithSign(publicKey, signTransaction);
+      return { txHash: hash };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+      throw err;
+    } finally {
+      setSubmitting(false);
+    }
+  }, [isConnected, publicKey, signTransaction]);
+
+  return { delegateGasless, preflightDelegatee, invalidateAllPermits, submitting, error };
 }

--- a/app/src/hooks/useGovernanceTuning.ts
+++ b/app/src/hooks/useGovernanceTuning.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { GovernanceTuningClient, type Network, type TuningRecommendation } from "@nebgov/sdk";
+import { backendBaseUrl } from "../lib/backend";
+
+interface UseGovernanceTuningResult {
+  latest: TuningRecommendation | null;
+  history: TuningRecommendation[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+/**
+ * Governance tuning recommender (issue #998): backend-sourced, not indexer
+ * or on-chain — see `GovernanceTuningClient`'s doc comment for why this
+ * hook's data source differs from every other governance hook in this app.
+ */
+export function useGovernanceTuning(): UseGovernanceTuningResult {
+  const [latest, setLatest] = useState<TuningRecommendation | null>(null);
+  const [history, setHistory] = useState<TuningRecommendation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshToken, setRefreshToken] = useState(0);
+
+  const refresh = useCallback(() => setRefreshToken((t) => t + 1), []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const governorAddress = process.env.NEXT_PUBLIC_GOVERNOR_ADDRESS;
+        const timelockAddress = process.env.NEXT_PUBLIC_TIMELOCK_ADDRESS;
+        const votesAddress = process.env.NEXT_PUBLIC_VOTES_ADDRESS;
+        const network = (process.env.NEXT_PUBLIC_NETWORK || "testnet") as Network;
+
+        if (!governorAddress || !timelockAddress || !votesAddress) {
+          throw new Error("Missing required environment variables for GovernanceTuningClient");
+        }
+
+        const client = new GovernanceTuningClient({
+          governorAddress,
+          timelockAddress,
+          votesAddress,
+          network,
+          backendUrl: backendBaseUrl(),
+        });
+
+        const [latestRec, historyRecs] = await Promise.all([
+          client.getLatestRecommendation(),
+          client.getRecommendationHistory(20),
+        ]);
+
+        if (cancelled) return;
+        setLatest(latestRec);
+        setHistory(historyRecs);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load governance tuning data");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshToken]);
+
+  return { latest, history, loading, error, refresh };
+}

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -37,3 +37,13 @@ EMAIL_PROVIDER_API_KEY=
 EMAIL_FROM_ADDRESS=notifications@nebgov.dev
 # Telegram channel deliveries fail (and retry) until set.
 TELEGRAM_BOT_TOKEN=
+
+# Governance tuning recommender (issue #998)
+# Base URL of the indexer's REST API — the analyzer reads /analytics/* and
+# /config-history from here, never a fresh on-chain read.
+INDEXER_URL=http://localhost:3002
+# Only needed if governance_tuning_config.auto_propose is turned on via
+# PUT /governance-tuning/config (default: off, recommendations are recorded
+# for a human to review). Reuses the same funded account as the gasless
+# delegation relayer above.
+TIMELOCK_CONTRACT_ID=C...

--- a/backend/migrations/009_add_governance_tuning.sql
+++ b/backend/migrations/009_add_governance_tuning.sql
@@ -1,0 +1,43 @@
+-- Up Migration
+
+-- Governance tuning recommender (issue #998): persists each computed
+-- recommendation for audit history, and a singleton config row so the
+-- analyzer's bands/caps/interval/auto-propose toggle are adjustable at
+-- runtime via PUT /governance-tuning/config instead of requiring a restart.
+
+CREATE TABLE IF NOT EXISTS governance_tuning_recommendations (
+    id SERIAL PRIMARY KEY,
+    computed_at TIMESTAMPTZ DEFAULT NOW(),
+    current_quorum_numerator INTEGER NOT NULL,
+    recommended_quorum_numerator INTEGER NOT NULL,
+    current_proposal_threshold NUMERIC(38,0) NOT NULL,
+    recommended_proposal_threshold NUMERIC(38,0) NOT NULL,
+    rationale JSONB NOT NULL,
+    auto_proposed BOOLEAN NOT NULL DEFAULT FALSE,
+    proposal_id BIGINT
+);
+
+CREATE INDEX IF NOT EXISTS idx_governance_tuning_recommendations_computed_at
+    ON governance_tuning_recommendations(computed_at DESC);
+
+CREATE TABLE IF NOT EXISTS governance_tuning_config (
+    id INTEGER PRIMARY KEY DEFAULT 1,
+    min_quorum_numerator INTEGER NOT NULL DEFAULT 100,
+    max_quorum_numerator INTEGER NOT NULL DEFAULT 5000,
+    max_quorum_delta_bps INTEGER NOT NULL DEFAULT 200,
+    min_proposal_threshold NUMERIC(38,0) NOT NULL DEFAULT 0,
+    max_proposal_threshold NUMERIC(38,0),
+    max_threshold_delta_bps INTEGER NOT NULL DEFAULT 1000,
+    trailing_window INTEGER NOT NULL DEFAULT 10,
+    interval_ms INTEGER NOT NULL DEFAULT 3600000,
+    auto_propose BOOLEAN NOT NULL DEFAULT FALSE,
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    CONSTRAINT governance_tuning_config_singleton CHECK (id = 1)
+);
+
+INSERT INTO governance_tuning_config (id) VALUES (1) ON CONFLICT (id) DO NOTHING;
+
+-- Down Migration
+
+DROP TABLE IF EXISTS governance_tuning_config;
+DROP TABLE IF EXISTS governance_tuning_recommendations;

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^8.5.0",
+    "@nebgov/sdk": "workspace:*",
     "@stellar/stellar-sdk": "^15.0.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",

--- a/backend/src/__tests__/governance-tuning-analyzer.test.ts
+++ b/backend/src/__tests__/governance-tuning-analyzer.test.ts
@@ -1,0 +1,152 @@
+import { computeRecommendation, type AnalyzerInputs } from "../governance-tuning/analyzer";
+import type { GovernanceTuningConfig } from "../governance-tuning/config-store";
+
+function makeConfig(overrides: Partial<GovernanceTuningConfig> = {}): GovernanceTuningConfig {
+  return {
+    minQuorumNumerator: 100,
+    maxQuorumNumerator: 5_000,
+    maxQuorumDeltaBps: 200,
+    minProposalThreshold: 0n,
+    maxProposalThreshold: null,
+    maxThresholdDeltaBps: 1_000,
+    trailingWindow: 10,
+    intervalMs: 3_600_000,
+    autoPropose: false,
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeInputs(overrides: Partial<AnalyzerInputs> = {}): AnalyzerInputs {
+  return {
+    currentQuorumNumerator: 1_000,
+    currentProposalThreshold: 1_000_000n,
+    quorumHitCount: 0n,
+    quorumMissCount: 0n,
+    snapshotVotesCast: [],
+    ...overrides,
+  };
+}
+
+describe("computeRecommendation — quorum_numerator", () => {
+  it("leaves quorum unchanged with fewer than 3 snapshots (no baseline to compare against)", () => {
+    const result = computeRecommendation(
+      makeInputs({ snapshotVotesCast: [100n, 200n] }),
+      makeConfig(),
+    );
+    expect(result.recommendedQuorumNumerator).toBe(1_000);
+    expect(result.rationale.quorumNumerator.direction).toBe("unchanged");
+  });
+
+  it("nudges quorum up when trailing participation is rising well past the no-op band", () => {
+    // baseline deltas: [10, 10] avg 10; recent deltas: [10, 100] avg 55 -> +450%
+    const result = computeRecommendation(
+      makeInputs({ snapshotVotesCast: [0n, 10n, 20n, 30n, 130n] }),
+      makeConfig(),
+    );
+    expect(result.rationale.quorumNumerator.direction).toBe("up");
+    expect(result.recommendedQuorumNumerator).toBeGreaterThan(1_000);
+  });
+
+  it("nudges quorum down when trailing participation is falling well past the no-op band", () => {
+    const result = computeRecommendation(
+      makeInputs({ snapshotVotesCast: [0n, 100n, 200n, 210n, 215n] }),
+      makeConfig(),
+    );
+    expect(result.rationale.quorumNumerator.direction).toBe("down");
+    expect(result.recommendedQuorumNumerator).toBeLessThan(1_000);
+  });
+
+  it("stays unchanged when trailing participation is within the no-op band", () => {
+    const result = computeRecommendation(
+      makeInputs({ snapshotVotesCast: [0n, 100n, 200n, 300n, 402n] }),
+      makeConfig(),
+    );
+    expect(result.rationale.quorumNumerator.direction).toBe("unchanged");
+    expect(result.recommendedQuorumNumerator).toBe(1_000);
+  });
+
+  it("never recommends a step larger than max_quorum_delta_bps in one cycle", () => {
+    const result = computeRecommendation(
+      makeInputs({ snapshotVotesCast: [0n, 1n, 1n, 100_000n] }),
+      makeConfig({ maxQuorumDeltaBps: 50 }),
+    );
+    expect(
+      Math.abs(result.recommendedQuorumNumerator - 1_000),
+    ).toBeLessThanOrEqual(50);
+  });
+
+  it("clamps the recommendation to [min_quorum_numerator, max_quorum_numerator]", () => {
+    const result = computeRecommendation(
+      makeInputs({ currentQuorumNumerator: 4_950, snapshotVotesCast: [0n, 10n, 20n, 30n, 200n] }),
+      makeConfig({ maxQuorumNumerator: 5_000, maxQuorumDeltaBps: 500 }),
+    );
+    expect(result.recommendedQuorumNumerator).toBeLessThanOrEqual(5_000);
+  });
+});
+
+describe("computeRecommendation — proposal_threshold", () => {
+  it("stays unchanged when quorum_hit_count and quorum_miss_count are both zero (documented indexer gap)", () => {
+    const result = computeRecommendation(
+      makeInputs({ quorumHitCount: 0n, quorumMissCount: 0n }),
+      makeConfig(),
+    );
+    expect(result.rationale.proposalThreshold.direction).toBe("unchanged");
+    expect(result.rationale.proposalThreshold.reason).toMatch(/insufficient data/i);
+    expect(result.recommendedProposalThreshold).toBe(1_000_000n);
+  });
+
+  it("nudges threshold down when the trailing quorum-hit rate is high (quorum isn't the bottleneck)", () => {
+    const result = computeRecommendation(
+      makeInputs({ quorumHitCount: 95n, quorumMissCount: 5n }),
+      makeConfig(),
+    );
+    expect(result.rationale.proposalThreshold.direction).toBe("down");
+    expect(result.recommendedProposalThreshold).toBeLessThan(1_000_000n);
+  });
+
+  it("nudges threshold up when the trailing quorum-hit rate is low (spam/noise reduction)", () => {
+    const result = computeRecommendation(
+      makeInputs({ quorumHitCount: 5n, quorumMissCount: 95n }),
+      makeConfig(),
+    );
+    expect(result.rationale.proposalThreshold.direction).toBe("up");
+    expect(result.recommendedProposalThreshold).toBeGreaterThan(1_000_000n);
+  });
+
+  it("stays unchanged when the trailing hit rate is within the healthy band", () => {
+    const result = computeRecommendation(
+      makeInputs({ quorumHitCount: 55n, quorumMissCount: 45n }),
+      makeConfig(),
+    );
+    expect(result.rationale.proposalThreshold.direction).toBe("unchanged");
+    expect(result.recommendedProposalThreshold).toBe(1_000_000n);
+  });
+
+  it("never moves the threshold by more than max_threshold_delta_bps in one cycle", () => {
+    const result = computeRecommendation(
+      makeInputs({ currentProposalThreshold: 1_000_000n, quorumHitCount: 100n, quorumMissCount: 0n }),
+      makeConfig({ maxThresholdDeltaBps: 100 }),
+    );
+    const delta = result.recommendedProposalThreshold - 1_000_000n;
+    expect(delta < 0n ? -delta : delta).toBeLessThanOrEqual(10_000n); // 100 bps of 1_000_000
+  });
+
+  it("clamps the recommendation to min_proposal_threshold", () => {
+    const result = computeRecommendation(
+      makeInputs({ currentProposalThreshold: 100n, quorumHitCount: 100n, quorumMissCount: 0n }),
+      makeConfig({ minProposalThreshold: 90n, maxThresholdDeltaBps: 10_000 }),
+    );
+    expect(result.recommendedProposalThreshold).toBeGreaterThanOrEqual(90n);
+  });
+});
+
+describe("computeRecommendation — voting_period", () => {
+  it("is always left untouched (out of scope for participation-based auto-tuning)", () => {
+    const result = computeRecommendation(
+      makeInputs({ snapshotVotesCast: [0n, 10n, 20n, 30n, 130n], quorumHitCount: 95n, quorumMissCount: 5n }),
+      makeConfig(),
+    );
+    expect(result.rationale.votingPeriod.direction).toBe("unchanged");
+  });
+});

--- a/backend/src/__tests__/governance-tuning-routes.test.ts
+++ b/backend/src/__tests__/governance-tuning-routes.test.ts
@@ -70,6 +70,48 @@ describe("Governance Tuning Endpoints", () => {
       expect(response.body.auto_propose).toBe(true);
       expect(response.body.max_quorum_numerator).toBe(before.body.max_quorum_numerator);
     });
+
+    it("rejects a patch that sets min_quorum_numerator above max_quorum_numerator", async () => {
+      const response = await request(app)
+        .put("/governance-tuning/config")
+        .set("X-ADMIN-SECRET", process.env.ADMIN_SECRET!)
+        .send({ min_quorum_numerator: 9000, max_quorum_numerator: 100 })
+        .expect(400);
+
+      expect(response.body.error).toMatch(/min_quorum_numerator/);
+    });
+
+    it("rejects a one-sided patch that violates the other side's existing value", async () => {
+      // Default config has min_quorum_numerator=100 — lowering max below that
+      // must be rejected even though the patch never touches the min field.
+      const response = await request(app)
+        .put("/governance-tuning/config")
+        .set("X-ADMIN-SECRET", process.env.ADMIN_SECRET!)
+        .send({ max_quorum_numerator: 50 })
+        .expect(400);
+
+      expect(response.body.error).toMatch(/min_quorum_numerator/);
+    });
+
+    it("rejects a patch that sets min_proposal_threshold above max_proposal_threshold", async () => {
+      const response = await request(app)
+        .put("/governance-tuning/config")
+        .set("X-ADMIN-SECRET", process.env.ADMIN_SECRET!)
+        .send({ min_proposal_threshold: "1000", max_proposal_threshold: "500" })
+        .expect(400);
+
+      expect(response.body.error).toMatch(/min_proposal_threshold/);
+    });
+
+    it("allows min_proposal_threshold above a null (unbounded) max_proposal_threshold", async () => {
+      const response = await request(app)
+        .put("/governance-tuning/config")
+        .set("X-ADMIN-SECRET", process.env.ADMIN_SECRET!)
+        .send({ min_proposal_threshold: "1000000000" })
+        .expect(200);
+
+      expect(response.body.min_proposal_threshold).toBe("1000000000");
+    });
   });
 
   describe("GET /governance-tuning/recommendations", () => {

--- a/backend/src/__tests__/governance-tuning-routes.test.ts
+++ b/backend/src/__tests__/governance-tuning-routes.test.ts
@@ -1,0 +1,129 @@
+process.env.ADMIN_SECRET = process.env.ADMIN_SECRET ?? "test-admin-secret";
+
+import request from "supertest";
+import app from "../index";
+import pool from "../db/pool";
+
+describe("Governance Tuning Endpoints", () => {
+  let insertedIds: number[] = [];
+
+  afterAll(async () => {
+    if (insertedIds.length > 0) {
+      await pool.query(
+        "DELETE FROM governance_tuning_recommendations WHERE id = ANY($1)",
+        [insertedIds],
+      );
+    }
+    // Restore the config row to its migration-seeded defaults so this test
+    // file doesn't leak state into other test files sharing the same DB.
+    await pool.query(
+      `UPDATE governance_tuning_config SET
+         min_quorum_numerator = 100, max_quorum_numerator = 5000,
+         max_quorum_delta_bps = 200, min_proposal_threshold = 0,
+         max_proposal_threshold = NULL, max_threshold_delta_bps = 1000,
+         trailing_window = 10, interval_ms = 3600000, auto_propose = FALSE
+       WHERE id = 1`,
+    );
+  });
+
+  describe("GET /governance-tuning/config", () => {
+    it("returns the singleton config row seeded by migration 009", async () => {
+      const response = await request(app).get("/governance-tuning/config").expect(200);
+
+      expect(response.body).toHaveProperty("min_quorum_numerator");
+      expect(response.body).toHaveProperty("max_quorum_numerator");
+      expect(response.body).toHaveProperty("auto_propose", false);
+      expect(typeof response.body.min_proposal_threshold).toBe("string");
+    });
+  });
+
+  describe("PUT /governance-tuning/config", () => {
+    it("rejects requests without an admin secret", async () => {
+      const response = await request(app)
+        .put("/governance-tuning/config")
+        .send({ max_quorum_delta_bps: 300 })
+        .expect(403);
+
+      expect(response.body).toHaveProperty("error");
+    });
+
+    it("rejects an empty patch body", async () => {
+      const response = await request(app)
+        .put("/governance-tuning/config")
+        .set("X-ADMIN-SECRET", process.env.ADMIN_SECRET!)
+        .send({})
+        .expect(400);
+
+      expect(response.body).toHaveProperty("errors");
+    });
+
+    it("updates only the fields provided, leaving the rest unchanged", async () => {
+      const before = await request(app).get("/governance-tuning/config").expect(200);
+
+      const response = await request(app)
+        .put("/governance-tuning/config")
+        .set("X-ADMIN-SECRET", process.env.ADMIN_SECRET!)
+        .send({ max_quorum_delta_bps: 321, auto_propose: true })
+        .expect(200);
+
+      expect(response.body.max_quorum_delta_bps).toBe(321);
+      expect(response.body.auto_propose).toBe(true);
+      expect(response.body.max_quorum_numerator).toBe(before.body.max_quorum_numerator);
+    });
+  });
+
+  describe("GET /governance-tuning/recommendations", () => {
+    beforeAll(async () => {
+      for (let i = 0; i < 3; i++) {
+        const result = await pool.query(
+          `INSERT INTO governance_tuning_recommendations
+             (current_quorum_numerator, recommended_quorum_numerator,
+              current_proposal_threshold, recommended_proposal_threshold, rationale)
+           VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+          [1000, 1000 + i, "1000000", "1000000", JSON.stringify({ note: `test-${i}` })],
+        );
+        insertedIds.push(result.rows[0].id);
+      }
+    });
+
+    it("returns paginated recommendations, newest first", async () => {
+      const response = await request(app)
+        .get("/governance-tuning/recommendations?limit=2&offset=0")
+        .expect(200);
+
+      expect(response.body).toHaveProperty("data");
+      expect(response.body).toHaveProperty("pagination");
+      expect(response.body.data.length).toBe(2);
+      expect(response.body.pagination.hasMore).toBe(true);
+      expect(response.body.data[0].id).toBeGreaterThan(response.body.data[1].id);
+    });
+
+    it("clamps limit to the documented max", async () => {
+      const response = await request(app)
+        .get("/governance-tuning/recommendations?limit=500")
+        .expect(400);
+
+      expect(response.body).toHaveProperty("errors");
+    });
+
+    it("serializes bigint fields as strings", async () => {
+      const response = await request(app)
+        .get("/governance-tuning/recommendations?limit=1")
+        .expect(200);
+
+      expect(typeof response.body.data[0].current_proposal_threshold).toBe("string");
+      expect(typeof response.body.data[0].recommended_proposal_threshold).toBe("string");
+    });
+  });
+
+  describe("GET /governance-tuning/recommendations/latest", () => {
+    it("returns the most recently computed recommendation", async () => {
+      const response = await request(app)
+        .get("/governance-tuning/recommendations/latest")
+        .expect(200);
+
+      expect(response.body).not.toBeNull();
+      expect(response.body.id).toBe(insertedIds[insertedIds.length - 1]);
+    });
+  });
+});

--- a/backend/src/governance-tuning/analyzer.ts
+++ b/backend/src/governance-tuning/analyzer.ts
@@ -1,0 +1,278 @@
+import { logger } from "../logger";
+import type { GovernanceTuningConfig } from "./config-store";
+import type { TuningRecommendationRationale } from "./recommendation-store";
+
+const INDEXER_URL = process.env.INDEXER_URL ?? "http://localhost:3002";
+
+interface AllTimeStatsResponse {
+  total_proposals: string;
+  total_votes_cast: string;
+  unique_voters: number;
+  quorum_hit_count: string;
+  quorum_miss_count: string;
+  pass_rate_bps: number;
+}
+
+interface SnapshotRow {
+  ledger: number;
+  total_votes_cast: string;
+  created_at: string;
+}
+
+interface SnapshotsResponse {
+  data: SnapshotRow[];
+}
+
+interface ConfigHistoryRow {
+  ledger: number;
+  new_settings: { quorum_numerator: number; proposal_threshold: string | number };
+}
+
+interface ConfigHistoryResponse {
+  data: ConfigHistoryRow[];
+}
+
+async function fetchJson<T>(path: string): Promise<T> {
+  const resp = await fetch(`${INDEXER_URL}${path}`);
+  if (!resp.ok) {
+    throw new Error(`Indexer request to ${path} failed: ${resp.status}`);
+  }
+  return (await resp.json()) as T;
+}
+
+/** Everything the pure `computeRecommendation` formula needs, gathered from the indexer's existing analytics endpoints. */
+export interface AnalyzerInputs {
+  currentQuorumNumerator: number;
+  currentProposalThreshold: bigint;
+  quorumHitCount: bigint;
+  quorumMissCount: bigint;
+  /** `total_votes_cast` at each trailing snapshot, oldest first. */
+  snapshotVotesCast: bigint[];
+}
+
+/**
+ * Fetches everything `computeRecommendation` needs from the indexer's
+ * already-existing `/analytics/*` and `/config-history` endpoints — no new
+ * on-chain reads, per the issue's scope constraint.
+ *
+ * Current on-chain settings are sourced from `/config-history` (mirrors
+ * `ConfigUpdated` events) rather than a fresh on-chain `get_settings()`
+ * call, so this stays entirely indexer-backed. Returns `null` if the
+ * governor has never had `update_config` called — the indexer has no way
+ * to know the genesis settings in that case (same class of scope boundary
+ * documented for `quorum_hit_count`/`quorum_miss_count` below).
+ */
+export async function gatherAnalyzerInputs(
+  trailingWindow: number,
+): Promise<AnalyzerInputs | null> {
+  const [allTimeStats, snapshots, configHistory] = await Promise.all([
+    fetchJson<AllTimeStatsResponse>("/analytics/all-time-stats"),
+    fetchJson<SnapshotsResponse>(`/analytics/snapshots?limit=${trailingWindow * 2}`),
+    fetchJson<ConfigHistoryResponse>("/config-history?limit=1"),
+  ]);
+
+  const latestConfig = configHistory.data[0];
+  if (!latestConfig) {
+    logger.warn(
+      "governance-tuning: no config_updates rows yet — indexer doesn't know the governor's current settings, skipping cycle",
+    );
+    return null;
+  }
+
+  return {
+    currentQuorumNumerator: Number(latestConfig.new_settings.quorum_numerator),
+    currentProposalThreshold: BigInt(latestConfig.new_settings.proposal_threshold),
+    quorumHitCount: BigInt(allTimeStats.quorum_hit_count),
+    quorumMissCount: BigInt(allTimeStats.quorum_miss_count),
+    // `/analytics/snapshots` is ordered ledger DESC; reverse to oldest-first for delta math.
+    snapshotVotesCast: snapshots.data
+      .slice()
+      .reverse()
+      .map((s) => BigInt(s.total_votes_cast)),
+  };
+}
+
+export interface RecommendationResult {
+  recommendedQuorumNumerator: number;
+  recommendedProposalThreshold: bigint;
+  rationale: TuningRecommendationRationale;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function clampBigint(value: bigint, min: bigint, max: bigint | null): bigint {
+  if (value < min) return min;
+  if (max !== null && value > max) return max;
+  return value;
+}
+
+const TREND_EPSILON = 0.05; // 5% relative change before nudging quorum at all
+
+function recommendQuorumNumerator(
+  inputs: AnalyzerInputs,
+  config: GovernanceTuningConfig,
+): { value: number; rationale: TuningRecommendationRationale["quorumNumerator"] } {
+  const deltas: number[] = [];
+  for (let i = 1; i < inputs.snapshotVotesCast.length; i++) {
+    // Converted to Number for trend math (relative change, not a settlement
+    // amount) — same tradeoff the indexer's own bpsOf() participation helper
+    // makes (packages/indexer/src/api.ts).
+    deltas.push(Number(inputs.snapshotVotesCast[i] - inputs.snapshotVotesCast[i - 1]));
+  }
+
+  if (deltas.length < 2) {
+    return {
+      value: inputs.currentQuorumNumerator,
+      rationale: { direction: "unchanged", reason: "insufficient snapshot history for a trend comparison (need at least 3 snapshots)" },
+    };
+  }
+
+  const recentCount = Math.ceil(deltas.length / 2);
+  const recent = deltas.slice(deltas.length - recentCount);
+  const baseline = deltas.slice(0, deltas.length - recentCount);
+  const avg = (xs: number[]) => xs.reduce((a, b) => a + b, 0) / xs.length;
+  const recentAvg = avg(recent);
+  const baselineAvg = avg(baseline);
+
+  let relativeChange: number;
+  if (baselineAvg === 0) {
+    relativeChange = recentAvg > 0 ? 1 : 0;
+  } else {
+    relativeChange = (recentAvg - baselineAvg) / baselineAvg;
+  }
+
+  if (Math.abs(relativeChange) < TREND_EPSILON) {
+    return {
+      value: inputs.currentQuorumNumerator,
+      rationale: {
+        direction: "unchanged",
+        reason: `trailing participation trend (${(relativeChange * 100).toFixed(1)}%) is within the ${TREND_EPSILON * 100}% no-op band`,
+      },
+    };
+  }
+
+  const direction = relativeChange > 0 ? "up" : "down";
+  const deltaBps = Math.min(Math.round(Math.abs(relativeChange) * 10_000), config.maxQuorumDeltaBps);
+  const unclamped = inputs.currentQuorumNumerator + (direction === "up" ? deltaBps : -deltaBps);
+  const value = clamp(unclamped, config.minQuorumNumerator, config.maxQuorumNumerator);
+
+  return {
+    value,
+    rationale: {
+      direction,
+      reason: `trailing participation is ${direction === "up" ? "up" : "down"} ${(Math.abs(relativeChange) * 100).toFixed(1)}% vs. the prior baseline window, nudging quorum ${direction} by ${Math.abs(value - inputs.currentQuorumNumerator)} bps (capped at ${config.maxQuorumDeltaBps} bps/cycle)`,
+    },
+  };
+}
+
+// Below this trailing quorum-hit rate, threshold nudges up (spam/noise reduction).
+const LOW_HIT_RATE_BPS = 3_000;
+// Above this trailing quorum-hit rate, threshold nudges down (participation isn't the bottleneck).
+const HIGH_HIT_RATE_BPS = 8_000;
+
+function recommendProposalThreshold(
+  inputs: AnalyzerInputs,
+  config: GovernanceTuningConfig,
+): { value: bigint; rationale: TuningRecommendationRationale["proposalThreshold"] } {
+  const totalSamples = inputs.quorumHitCount + inputs.quorumMissCount;
+
+  // `/analytics/all-time-stats` documents quorum_hit_count/quorum_miss_count
+  // as always "0" today — the indexer doesn't track eligible supply at each
+  // proposal's start ledger yet (see the comment above that endpoint in
+  // packages/indexer/src/api.ts). Rather than fabricate a hit rate, this
+  // dimension is a documented no-op until that data exists — the formula
+  // below is otherwise ready to use it the moment it's populated.
+  if (totalSamples === 0n) {
+    return {
+      value: inputs.currentProposalThreshold,
+      rationale: {
+        direction: "unchanged",
+        reason: "insufficient data: indexer's quorum_hit_count/quorum_miss_count are not yet populated (documented scope boundary on /analytics/all-time-stats)",
+      },
+    };
+  }
+
+  const hitRateBps = Number((inputs.quorumHitCount * 10_000n) / totalSamples);
+
+  let direction: "up" | "down" | "unchanged" = "unchanged";
+  let deltaBps = 0;
+  if (hitRateBps >= HIGH_HIT_RATE_BPS) {
+    direction = "down";
+    deltaBps = Math.min(
+      config.maxThresholdDeltaBps,
+      Math.round(((hitRateBps - HIGH_HIT_RATE_BPS) * config.maxThresholdDeltaBps) / (10_000 - HIGH_HIT_RATE_BPS)),
+    );
+  } else if (hitRateBps <= LOW_HIT_RATE_BPS) {
+    direction = "up";
+    deltaBps = Math.min(
+      config.maxThresholdDeltaBps,
+      Math.round(((LOW_HIT_RATE_BPS - hitRateBps) * config.maxThresholdDeltaBps) / LOW_HIT_RATE_BPS),
+    );
+  }
+
+  if (direction === "unchanged" || deltaBps === 0) {
+    return {
+      value: inputs.currentProposalThreshold,
+      rationale: {
+        direction: "unchanged",
+        reason: `trailing quorum-hit rate (${(hitRateBps / 100).toFixed(1)}%) is within the healthy ${LOW_HIT_RATE_BPS / 100}%–${HIGH_HIT_RATE_BPS / 100}% band`,
+      },
+    };
+  }
+
+  const signedDeltaBps = BigInt(direction === "up" ? deltaBps : -deltaBps);
+  const unclamped =
+    inputs.currentProposalThreshold + (inputs.currentProposalThreshold * signedDeltaBps) / 10_000n;
+  const value = clampBigint(unclamped, config.minProposalThreshold, config.maxProposalThreshold);
+
+  return {
+    value,
+    rationale: {
+      direction,
+      reason: `trailing quorum-hit rate is ${(hitRateBps / 100).toFixed(1)}%, nudging proposal_threshold ${direction} by ${deltaBps} bps (capped at ${config.maxThresholdDeltaBps} bps/cycle)`,
+    },
+  };
+}
+
+/**
+ * Pure recommendation formula — no I/O, so this is directly unit-testable
+ * (see backend/src/__tests__/governance-tuning-analyzer.test.ts).
+ *
+ * `voting_period` is intentionally never adjusted: out of scope for
+ * participation-based auto-tuning per the issue (timing changes interact
+ * with active proposals in ways this formula doesn't model). The hook is
+ * exposed via `rationale.votingPeriod` so a future config flag can turn it
+ * on without changing this function's shape.
+ */
+export function computeRecommendation(
+  inputs: AnalyzerInputs,
+  config: GovernanceTuningConfig,
+): RecommendationResult {
+  const quorum = recommendQuorumNumerator(inputs, config);
+  const threshold = recommendProposalThreshold(inputs, config);
+
+  return {
+    recommendedQuorumNumerator: quorum.value,
+    recommendedProposalThreshold: threshold.value,
+    rationale: {
+      quorumNumerator: quorum.rationale,
+      proposalThreshold: threshold.rationale,
+      votingPeriod: {
+        direction: "unchanged",
+        reason: "voting_period auto-tuning is out of scope by default (timing changes interact with active proposals) — hook reserved for a future opt-in config flag",
+      },
+      inputs: {
+        currentQuorumNumerator: inputs.currentQuorumNumerator,
+        currentProposalThreshold: inputs.currentProposalThreshold.toString(),
+        quorumHitCount: inputs.quorumHitCount.toString(),
+        quorumMissCount: inputs.quorumMissCount.toString(),
+        // Oldest-first cumulative total_votes_cast at each trailing
+        // snapshot — the raw series behind the quorum_numerator trend
+        // comparison above, for the frontend's participation trend chart.
+        snapshotVotesCast: inputs.snapshotVotesCast.map((v) => v.toString()),
+      },
+    },
+  };
+}

--- a/backend/src/governance-tuning/auto-propose.ts
+++ b/backend/src/governance-tuning/auto-propose.ts
@@ -1,0 +1,94 @@
+import { Keypair } from "@stellar/stellar-sdk";
+import {
+  GovernorClient,
+  hashDescriptionSync,
+  type GovernorSettings,
+  type Network,
+} from "@nebgov/sdk";
+import { logger } from "../logger";
+import type { AnalyzerInputs, RecommendationResult } from "./analyzer";
+
+/**
+ * Submits a recommendation as a real `update_config` governance proposal.
+ *
+ * Only called when `governance_tuning_config.auto_propose` is enabled and a
+ * `RELAYER_SECRET_KEY` is configured — by default the analyzer only records
+ * recommendations for a human to review (see `GovernanceTuningAnalyzerService`).
+ *
+ * Deliberately uses `@nebgov/sdk`'s `GovernorClient` rather than hand-rolling
+ * the `update_config` calldata encoding a second time — this is the one
+ * place in the backend that takes on the SDK's pinned `@stellar/stellar-sdk`
+ * ^12 alongside the backend's own ^15 (see the version-mismatch note in
+ * `backend/src/routes/relayer.ts`), accepted here since it's opt-in and
+ * off by default, and re-deriving `proposals.ts`'s ScVal map encoding by
+ * hand would be a much larger correctness risk for a rarely-exercised path.
+ *
+ * Returns the new proposal's id, or `null` if auto-propose isn't configured.
+ */
+export async function maybeAutoPropose(
+  inputs: AnalyzerInputs,
+  result: RecommendationResult,
+): Promise<bigint | null> {
+  const secret = process.env.RELAYER_SECRET_KEY;
+  const governorAddress = process.env.GOVERNOR_CONTRACT_ID;
+  const votesAddress = process.env.TOKEN_VOTES_CONTRACT_ID;
+  const timelockAddress = process.env.TIMELOCK_CONTRACT_ID;
+  if (!secret || !governorAddress || !votesAddress || !timelockAddress) {
+    logger.warn(
+      "governance-tuning: auto_propose is enabled but RELAYER_SECRET_KEY/GOVERNOR_CONTRACT_ID/TOKEN_VOTES_CONTRACT_ID/TIMELOCK_CONTRACT_ID aren't all configured — skipping auto-propose",
+    );
+    return null;
+  }
+
+  const network = (process.env.STELLAR_NETWORK ?? "testnet") as Network;
+  const rpcUrl = process.env.STELLAR_RPC_URL ?? "https://soroban-testnet.stellar.org";
+  const indexerUrl = process.env.INDEXER_URL ?? "http://localhost:3002";
+
+  const governor = new GovernorClient({
+    governorAddress,
+    timelockAddress,
+    votesAddress,
+    network,
+    rpcUrl,
+    indexerUrl,
+  });
+
+  const currentSettings = await governor.getSettings(governorAddress);
+  const newSettings: GovernorSettings = {
+    ...currentSettings,
+    quorumNumerator: result.recommendedQuorumNumerator,
+    proposalThreshold: result.recommendedProposalThreshold,
+  };
+
+  const { target, fnName, calldata } = governor.buildUpdateConfigProposal(newSettings);
+
+  const description = [
+    "Governance tuning recommendation (automated)",
+    "",
+    `quorum_numerator: ${inputs.currentQuorumNumerator} -> ${result.recommendedQuorumNumerator}`,
+    `proposal_threshold: ${inputs.currentProposalThreshold} -> ${result.recommendedProposalThreshold}`,
+    "",
+    result.rationale.quorumNumerator.reason,
+    result.rationale.proposalThreshold.reason,
+  ].join("\n");
+  const descriptionHash = hashDescriptionSync(description);
+
+  const signer = Keypair.fromSecret(secret);
+  // `signer` is a `Keypair` from the backend's @stellar/stellar-sdk (^15);
+  // `governor.propose` types its parameter against @nebgov/sdk's pinned ^12
+  // copy. Same class, different package instances — identical at runtime
+  // (publicKey()/sign() haven't changed across these majors), incompatible
+  // only nominally to the type checker, hence the cast.
+  const proposalId = await governor.propose(
+    signer as unknown as Parameters<typeof governor.propose>[0],
+    description,
+    descriptionHash,
+    "",
+    [target],
+    [fnName],
+    [Buffer.from(calldata)],
+  );
+
+  logger.info({ proposalId: proposalId.toString() }, "Governance tuning auto-proposed on-chain");
+  return proposalId;
+}

--- a/backend/src/governance-tuning/auto-propose.ts
+++ b/backend/src/governance-tuning/auto-propose.ts
@@ -1,7 +1,7 @@
 import { Keypair } from "@stellar/stellar-sdk";
 import {
   GovernorClient,
-  hashDescriptionSync,
+  hashDescription,
   ProposalState,
   type GovernorSettings,
   type Network,
@@ -126,7 +126,7 @@ export async function maybeAutoPropose(
     result.rationale.quorumNumerator.reason,
     result.rationale.proposalThreshold.reason,
   ].join("\n");
-  const descriptionHash = hashDescriptionSync(description);
+  const descriptionHash = await hashDescription(description);
 
   const signer = Keypair.fromSecret(secret);
   // `signer` is a `Keypair` from the backend's @stellar/stellar-sdk (^15);

--- a/backend/src/governance-tuning/auto-propose.ts
+++ b/backend/src/governance-tuning/auto-propose.ts
@@ -2,18 +2,87 @@ import { Keypair } from "@stellar/stellar-sdk";
 import {
   GovernorClient,
   hashDescriptionSync,
+  ProposalState,
   type GovernorSettings,
   type Network,
 } from "@nebgov/sdk";
 import { logger } from "../logger";
 import type { AnalyzerInputs, RecommendationResult } from "./analyzer";
+import { getLatestRecommendation } from "./recommendation-store";
+
+// Anything short of these means a prior auto-proposed update_config is still
+// in flight (Pending/Active/Succeeded/Queued) — not yet safe to submit another.
+const TERMINAL_PROPOSAL_STATES: ReadonlySet<ProposalState> = new Set([
+  ProposalState.Executed,
+  ProposalState.Defeated,
+  ProposalState.Cancelled,
+  ProposalState.Expired,
+]);
+
+function buildGovernorClient(): GovernorClient | null {
+  const governorAddress = process.env.GOVERNOR_CONTRACT_ID;
+  const votesAddress = process.env.TOKEN_VOTES_CONTRACT_ID;
+  const timelockAddress = process.env.TIMELOCK_CONTRACT_ID;
+  if (!governorAddress || !votesAddress || !timelockAddress) return null;
+
+  const network = (process.env.STELLAR_NETWORK ?? "testnet") as Network;
+  const rpcUrl = process.env.STELLAR_RPC_URL ?? "https://soroban-testnet.stellar.org";
+  const indexerUrl = process.env.INDEXER_URL ?? "http://localhost:3002";
+
+  return new GovernorClient({
+    governorAddress,
+    timelockAddress,
+    votesAddress,
+    network,
+    rpcUrl,
+    indexerUrl,
+  });
+}
+
+/**
+ * Guards against spamming governance with duplicate proposals.
+ *
+ * The indexer's "current" settings (what `computeRecommendation` diffs
+ * against, via `/config-history`) only change once a proposal actually
+ * executes — real wall-clock time away, through voting delay + voting
+ * period + the timelock. Since `interval_ms` is admin-configurable down to
+ * 60 seconds, without this check the analyzer would resubmit an essentially
+ * identical `update_config` proposal every cycle until the first one clears.
+ *
+ * Returns the still-unresolved proposal id if one is in flight (skip
+ * auto-propose this cycle), or `null` if it's safe to submit.
+ */
+export async function findUnresolvedAutoProposal(): Promise<bigint | null> {
+  const latest = await getLatestRecommendation();
+  if (!latest?.autoProposed || latest.proposalId === null) return null;
+
+  const governor = buildGovernorClient();
+  if (!governor) {
+    // Can't check on-chain state — stay safe and assume it's still pending
+    // rather than risk a duplicate submission.
+    return latest.proposalId;
+  }
+
+  try {
+    const state = await governor.getProposalState(latest.proposalId);
+    return TERMINAL_PROPOSAL_STATES.has(state) ? null : latest.proposalId;
+  } catch (err) {
+    logger.warn(
+      { err, proposalId: latest.proposalId.toString() },
+      "governance-tuning: could not check prior auto-proposal's state — skipping this cycle to be safe",
+    );
+    return latest.proposalId;
+  }
+}
 
 /**
  * Submits a recommendation as a real `update_config` governance proposal.
  *
- * Only called when `governance_tuning_config.auto_propose` is enabled and a
- * `RELAYER_SECRET_KEY` is configured — by default the analyzer only records
- * recommendations for a human to review (see `GovernanceTuningAnalyzerService`).
+ * Only called when `governance_tuning_config.auto_propose` is enabled, a
+ * `RELAYER_SECRET_KEY` is configured, and {@link findUnresolvedAutoProposal}
+ * confirms no prior auto-proposal is still in flight — by default the
+ * analyzer only records recommendations for a human to review (see
+ * `GovernanceTuningAnalyzerService`).
  *
  * Deliberately uses `@nebgov/sdk`'s `GovernorClient` rather than hand-rolling
  * the `update_config` calldata encoding a second time — this is the one
@@ -31,27 +100,13 @@ export async function maybeAutoPropose(
 ): Promise<bigint | null> {
   const secret = process.env.RELAYER_SECRET_KEY;
   const governorAddress = process.env.GOVERNOR_CONTRACT_ID;
-  const votesAddress = process.env.TOKEN_VOTES_CONTRACT_ID;
-  const timelockAddress = process.env.TIMELOCK_CONTRACT_ID;
-  if (!secret || !governorAddress || !votesAddress || !timelockAddress) {
+  const governor = buildGovernorClient();
+  if (!secret || !governorAddress || !governor) {
     logger.warn(
       "governance-tuning: auto_propose is enabled but RELAYER_SECRET_KEY/GOVERNOR_CONTRACT_ID/TOKEN_VOTES_CONTRACT_ID/TIMELOCK_CONTRACT_ID aren't all configured — skipping auto-propose",
     );
     return null;
   }
-
-  const network = (process.env.STELLAR_NETWORK ?? "testnet") as Network;
-  const rpcUrl = process.env.STELLAR_RPC_URL ?? "https://soroban-testnet.stellar.org";
-  const indexerUrl = process.env.INDEXER_URL ?? "http://localhost:3002";
-
-  const governor = new GovernorClient({
-    governorAddress,
-    timelockAddress,
-    votesAddress,
-    network,
-    rpcUrl,
-    indexerUrl,
-  });
 
   const currentSettings = await governor.getSettings(governorAddress);
   const newSettings: GovernorSettings = {

--- a/backend/src/governance-tuning/config-store.ts
+++ b/backend/src/governance-tuning/config-store.ts
@@ -1,0 +1,96 @@
+import pool from "../db/pool";
+
+export interface GovernanceTuningConfig {
+  minQuorumNumerator: number;
+  maxQuorumNumerator: number;
+  maxQuorumDeltaBps: number;
+  minProposalThreshold: bigint;
+  maxProposalThreshold: bigint | null;
+  maxThresholdDeltaBps: number;
+  trailingWindow: number;
+  intervalMs: number;
+  autoPropose: boolean;
+  updatedAt: string;
+}
+
+function rowToConfig(row: Record<string, unknown>): GovernanceTuningConfig {
+  return {
+    minQuorumNumerator: Number(row.min_quorum_numerator),
+    maxQuorumNumerator: Number(row.max_quorum_numerator),
+    maxQuorumDeltaBps: Number(row.max_quorum_delta_bps),
+    minProposalThreshold: BigInt(row.min_proposal_threshold as string),
+    maxProposalThreshold:
+      row.max_proposal_threshold === null ? null : BigInt(row.max_proposal_threshold as string),
+    maxThresholdDeltaBps: Number(row.max_threshold_delta_bps),
+    trailingWindow: Number(row.trailing_window),
+    intervalMs: Number(row.interval_ms),
+    autoPropose: Boolean(row.auto_propose),
+    updatedAt: new Date(row.updated_at as string).toISOString(),
+  };
+}
+
+/** Reads the singleton governance-tuning config row, seeded by migration `009_add_governance_tuning.sql`. */
+export async function getGovernanceTuningConfig(): Promise<GovernanceTuningConfig> {
+  const result = await pool.query(
+    `SELECT * FROM governance_tuning_config WHERE id = 1`,
+  );
+  if (result.rows.length === 0) {
+    throw new Error("governance_tuning_config row is missing — migration 009 did not seed it");
+  }
+  return rowToConfig(result.rows[0]);
+}
+
+export interface GovernanceTuningConfigPatch {
+  minQuorumNumerator?: number;
+  maxQuorumNumerator?: number;
+  maxQuorumDeltaBps?: number;
+  minProposalThreshold?: bigint;
+  maxProposalThreshold?: bigint | null;
+  maxThresholdDeltaBps?: number;
+  trailingWindow?: number;
+  intervalMs?: number;
+  autoPropose?: boolean;
+}
+
+const PATCH_COLUMNS: Record<keyof GovernanceTuningConfigPatch, string> = {
+  minQuorumNumerator: "min_quorum_numerator",
+  maxQuorumNumerator: "max_quorum_numerator",
+  maxQuorumDeltaBps: "max_quorum_delta_bps",
+  minProposalThreshold: "min_proposal_threshold",
+  maxProposalThreshold: "max_proposal_threshold",
+  maxThresholdDeltaBps: "max_threshold_delta_bps",
+  trailingWindow: "trailing_window",
+  intervalMs: "interval_ms",
+  autoPropose: "auto_propose",
+};
+
+/** Admin-only: updates whichever fields are present in `patch`, leaving the rest unchanged. */
+export async function updateGovernanceTuningConfig(
+  patch: GovernanceTuningConfigPatch,
+): Promise<GovernanceTuningConfig> {
+  // Filters out `undefined` explicitly, not just absent keys — callers (e.g.
+  // the PUT /governance-tuning/config route) build this object by naming
+  // every field, so an unset field arrives as `{ key: undefined }` rather
+  // than an absent key, and `Object.keys` would otherwise still report it.
+  const keys = (Object.keys(patch) as (keyof GovernanceTuningConfigPatch)[]).filter(
+    (key) => patch[key] !== undefined,
+  );
+  if (keys.length === 0) {
+    return getGovernanceTuningConfig();
+  }
+
+  const setClauses: string[] = [];
+  const values: unknown[] = [];
+  keys.forEach((key, i) => {
+    const value = patch[key];
+    setClauses.push(`${PATCH_COLUMNS[key]} = $${i + 1}`);
+    values.push(typeof value === "bigint" ? value.toString() : value);
+  });
+  setClauses.push("updated_at = NOW()");
+
+  const result = await pool.query(
+    `UPDATE governance_tuning_config SET ${setClauses.join(", ")} WHERE id = 1 RETURNING *`,
+    values,
+  );
+  return rowToConfig(result.rows[0]);
+}

--- a/backend/src/governance-tuning/config-store.ts
+++ b/backend/src/governance-tuning/config-store.ts
@@ -64,6 +64,9 @@ const PATCH_COLUMNS: Record<keyof GovernanceTuningConfigPatch, string> = {
   autoPropose: "auto_propose",
 };
 
+/** Thrown when a patch would leave the config in an internally inconsistent state (e.g. min > max). */
+export class GovernanceTuningConfigValidationError extends Error {}
+
 /** Admin-only: updates whichever fields are present in `patch`, leaving the rest unchanged. */
 export async function updateGovernanceTuningConfig(
   patch: GovernanceTuningConfigPatch,
@@ -77,6 +80,27 @@ export async function updateGovernanceTuningConfig(
   );
   if (keys.length === 0) {
     return getGovernanceTuningConfig();
+  }
+
+  // Cross-field validation needs the *effective* post-patch values, not just
+  // the fields present in this patch — a PUT that only touches one side of a
+  // min/max pair must still be checked against the other side's current value.
+  const current = await getGovernanceTuningConfig();
+  const effectiveMinQuorum = patch.minQuorumNumerator ?? current.minQuorumNumerator;
+  const effectiveMaxQuorum = patch.maxQuorumNumerator ?? current.maxQuorumNumerator;
+  if (effectiveMinQuorum > effectiveMaxQuorum) {
+    throw new GovernanceTuningConfigValidationError(
+      `min_quorum_numerator (${effectiveMinQuorum}) must be <= max_quorum_numerator (${effectiveMaxQuorum})`,
+    );
+  }
+
+  const effectiveMinThreshold = patch.minProposalThreshold ?? current.minProposalThreshold;
+  const effectiveMaxThreshold =
+    patch.maxProposalThreshold !== undefined ? patch.maxProposalThreshold : current.maxProposalThreshold;
+  if (effectiveMaxThreshold !== null && effectiveMinThreshold > effectiveMaxThreshold) {
+    throw new GovernanceTuningConfigValidationError(
+      `min_proposal_threshold (${effectiveMinThreshold}) must be <= max_proposal_threshold (${effectiveMaxThreshold})`,
+    );
   }
 
   const setClauses: string[] = [];

--- a/backend/src/governance-tuning/recommendation-store.ts
+++ b/backend/src/governance-tuning/recommendation-store.ts
@@ -1,0 +1,99 @@
+import pool from "../db/pool";
+
+export interface TuningRecommendationRationale {
+  /** Human-readable explanation per adjusted field, plus the raw analytics inputs used. */
+  quorumNumerator: {
+    direction: "up" | "down" | "unchanged";
+    reason: string;
+  };
+  proposalThreshold: {
+    direction: "up" | "down" | "unchanged";
+    reason: string;
+  };
+  votingPeriod: {
+    direction: "unchanged";
+    reason: string;
+  };
+  inputs: Record<string, unknown>;
+}
+
+export interface TuningRecommendation {
+  id: number;
+  computedAt: string;
+  currentQuorumNumerator: number;
+  recommendedQuorumNumerator: number;
+  currentProposalThreshold: bigint;
+  recommendedProposalThreshold: bigint;
+  rationale: TuningRecommendationRationale;
+  autoProposed: boolean;
+  proposalId: bigint | null;
+}
+
+function rowToRecommendation(row: Record<string, unknown>): TuningRecommendation {
+  return {
+    id: Number(row.id),
+    computedAt: new Date(row.computed_at as string).toISOString(),
+    currentQuorumNumerator: Number(row.current_quorum_numerator),
+    recommendedQuorumNumerator: Number(row.recommended_quorum_numerator),
+    currentProposalThreshold: BigInt(row.current_proposal_threshold as string),
+    recommendedProposalThreshold: BigInt(row.recommended_proposal_threshold as string),
+    rationale: row.rationale as TuningRecommendationRationale,
+    autoProposed: Boolean(row.auto_proposed),
+    proposalId: row.proposal_id === null ? null : BigInt(row.proposal_id as string),
+  };
+}
+
+export interface NewTuningRecommendation {
+  currentQuorumNumerator: number;
+  recommendedQuorumNumerator: number;
+  currentProposalThreshold: bigint;
+  recommendedProposalThreshold: bigint;
+  rationale: TuningRecommendationRationale;
+  autoProposed: boolean;
+  proposalId: bigint | null;
+}
+
+export async function insertRecommendation(
+  rec: NewTuningRecommendation,
+): Promise<TuningRecommendation> {
+  const result = await pool.query(
+    `INSERT INTO governance_tuning_recommendations
+       (current_quorum_numerator, recommended_quorum_numerator,
+        current_proposal_threshold, recommended_proposal_threshold,
+        rationale, auto_proposed, proposal_id)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     RETURNING *`,
+    [
+      rec.currentQuorumNumerator,
+      rec.recommendedQuorumNumerator,
+      rec.currentProposalThreshold.toString(),
+      rec.recommendedProposalThreshold.toString(),
+      JSON.stringify(rec.rationale),
+      rec.autoProposed,
+      rec.proposalId === null ? null : rec.proposalId.toString(),
+    ],
+  );
+  return rowToRecommendation(result.rows[0]);
+}
+
+export async function getLatestRecommendation(): Promise<TuningRecommendation | null> {
+  const result = await pool.query(
+    `SELECT * FROM governance_tuning_recommendations ORDER BY computed_at DESC, id DESC LIMIT 1`,
+  );
+  return result.rows.length === 0 ? null : rowToRecommendation(result.rows[0]);
+}
+
+export async function listRecommendations(
+  limit: number,
+  offset: number,
+): Promise<{ recommendations: TuningRecommendation[]; hasMore: boolean }> {
+  const result = await pool.query(
+    `SELECT * FROM governance_tuning_recommendations
+     ORDER BY computed_at DESC, id DESC LIMIT $1 OFFSET $2`,
+    [limit, offset],
+  );
+  return {
+    recommendations: result.rows.map(rowToRecommendation),
+    hasMore: result.rows.length === limit,
+  };
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,9 +9,11 @@ import authRouter from "./routes/auth";
 import notificationsRouter from "./routes/notifications";
 import securityRouter from "./routes/security";
 import relayerRouter from "./routes/relayer";
+import governanceTuningRouter from "./routes/governance-tuning";
 import { securityMonitor } from "./services/security-monitor";
 import { notificationProcessor } from "./jobs/notification-processor";
 import { deliveryRetry } from "./jobs/delivery-retry";
+import { governanceTuningAnalyzer } from "./jobs/governance-tuning-analyzer";
 import { runBackendMigrations } from "./db/migrationRunner";
 import pino from "pino";
 import pinoHttp from "pino-http";
@@ -109,6 +111,7 @@ app.use("/notifications", notificationsRouter);
 app.use("/security", securityRouter);
 app.use("/relayer", relayerLimiter);
 app.use("/relayer", relayerRouter);
+app.use("/governance-tuning", governanceTuningRouter);
 
 // Error handling
 app.use(
@@ -136,6 +139,9 @@ async function bootstrap(): Promise<void> {
     // Start the notification engine's background jobs
     notificationProcessor.start();
     deliveryRetry.start();
+
+    // Start the governance tuning recommender (issue #998)
+    governanceTuningAnalyzer.start();
   });
 }
 

--- a/backend/src/jobs/governance-tuning-analyzer.ts
+++ b/backend/src/jobs/governance-tuning-analyzer.ts
@@ -2,7 +2,7 @@ import { logger } from "../logger";
 import { computeRecommendation, gatherAnalyzerInputs } from "../governance-tuning/analyzer";
 import { getGovernanceTuningConfig } from "../governance-tuning/config-store";
 import { insertRecommendation } from "../governance-tuning/recommendation-store";
-import { maybeAutoPropose } from "../governance-tuning/auto-propose";
+import { findUnresolvedAutoProposal, maybeAutoPropose } from "../governance-tuning/auto-propose";
 
 /**
  * Governance tuning recommender (issue #998). Same footing as
@@ -71,11 +71,19 @@ export class GovernanceTuningAnalyzerService {
     let proposalId: bigint | null = null;
     let autoProposed = false;
     if (!unchanged && config.autoPropose) {
-      proposalId = await maybeAutoPropose(inputs, result).catch((err) => {
-        logger.error({ err }, "Governance tuning auto-propose failed");
-        return null;
-      });
-      autoProposed = proposalId !== null;
+      const pendingProposalId = await findUnresolvedAutoProposal();
+      if (pendingProposalId !== null) {
+        logger.info(
+          { pendingProposalId: pendingProposalId.toString() },
+          "Governance tuning: skipping auto-propose — a prior auto-proposed update_config hasn't resolved yet",
+        );
+      } else {
+        proposalId = await maybeAutoPropose(inputs, result).catch((err) => {
+          logger.error({ err }, "Governance tuning auto-propose failed");
+          return null;
+        });
+        autoProposed = proposalId !== null;
+      }
     }
 
     const stored = await insertRecommendation({

--- a/backend/src/jobs/governance-tuning-analyzer.ts
+++ b/backend/src/jobs/governance-tuning-analyzer.ts
@@ -1,0 +1,98 @@
+import { logger } from "../logger";
+import { computeRecommendation, gatherAnalyzerInputs } from "../governance-tuning/analyzer";
+import { getGovernanceTuningConfig } from "../governance-tuning/config-store";
+import { insertRecommendation } from "../governance-tuning/recommendation-store";
+import { maybeAutoPropose } from "../governance-tuning/auto-propose";
+
+/**
+ * Governance tuning recommender (issue #998). Same footing as
+ * `NotificationProcessorService`: a standalone background job started from
+ * `bootstrap()`, not a one-off script.
+ */
+export class GovernanceTuningAnalyzerService {
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+
+  start() {
+    const config = getGovernanceTuningConfig();
+    config
+      .then((c) => {
+        logger.info({ intervalMs: c.intervalMs }, "Starting governance tuning analyzer");
+        this.schedule(c.intervalMs);
+      })
+      .catch((err) => {
+        logger.error({ err }, "Failed to start governance tuning analyzer");
+      });
+    // Kick off an immediate first cycle rather than waiting a full interval.
+    void this.tick();
+  }
+
+  stop() {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private schedule(intervalMs: number) {
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = setTimeout(async () => {
+      await this.tick();
+      // Re-read the config each cycle so an admin's PUT /governance-tuning/config
+      // interval change takes effect on the next tick without a restart.
+      const c = await getGovernanceTuningConfig().catch(() => null);
+      this.schedule(c?.intervalMs ?? intervalMs);
+    }, intervalMs);
+  }
+
+  private async tick(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+    try {
+      await this.runCycle();
+    } catch (err) {
+      logger.error({ err }, "Governance tuning analyzer cycle failed");
+    } finally {
+      this.running = false;
+    }
+  }
+
+  async runCycle(): Promise<void> {
+    const config = await getGovernanceTuningConfig();
+    const inputs = await gatherAnalyzerInputs(config.trailingWindow);
+    if (!inputs) return;
+
+    const result = computeRecommendation(inputs, config);
+
+    const unchanged =
+      result.recommendedQuorumNumerator === inputs.currentQuorumNumerator &&
+      result.recommendedProposalThreshold === inputs.currentProposalThreshold;
+
+    let proposalId: bigint | null = null;
+    let autoProposed = false;
+    if (!unchanged && config.autoPropose) {
+      proposalId = await maybeAutoPropose(inputs, result).catch((err) => {
+        logger.error({ err }, "Governance tuning auto-propose failed");
+        return null;
+      });
+      autoProposed = proposalId !== null;
+    }
+
+    const stored = await insertRecommendation({
+      currentQuorumNumerator: inputs.currentQuorumNumerator,
+      recommendedQuorumNumerator: result.recommendedQuorumNumerator,
+      currentProposalThreshold: inputs.currentProposalThreshold,
+      recommendedProposalThreshold: result.recommendedProposalThreshold,
+      rationale: result.rationale,
+      autoProposed,
+      proposalId,
+    });
+
+    logger.info(
+      { id: stored.id, unchanged, autoProposed },
+      "Governance tuning recommendation computed",
+    );
+  }
+}
+
+export const governanceTuningAnalyzer = new GovernanceTuningAnalyzerService();

--- a/backend/src/routes/governance-tuning.ts
+++ b/backend/src/routes/governance-tuning.ts
@@ -1,0 +1,134 @@
+import { Response, Router } from "express";
+import { z } from "zod";
+import { isAdmin } from "../middleware/admin";
+import { validate } from "../middleware/validate";
+import {
+  getGovernanceTuningConfig,
+  updateGovernanceTuningConfig,
+} from "../governance-tuning/config-store";
+import {
+  getLatestRecommendation,
+  listRecommendations,
+} from "../governance-tuning/recommendation-store";
+
+const router = Router();
+
+function serializeRecommendation(rec: Awaited<ReturnType<typeof getLatestRecommendation>>) {
+  if (!rec) return null;
+  return {
+    id: rec.id,
+    computed_at: rec.computedAt,
+    current_quorum_numerator: rec.currentQuorumNumerator,
+    recommended_quorum_numerator: rec.recommendedQuorumNumerator,
+    current_proposal_threshold: rec.currentProposalThreshold.toString(),
+    recommended_proposal_threshold: rec.recommendedProposalThreshold.toString(),
+    rationale: rec.rationale,
+    auto_proposed: rec.autoProposed,
+    proposal_id: rec.proposalId === null ? null : rec.proposalId.toString(),
+  };
+}
+
+function serializeConfig(config: Awaited<ReturnType<typeof getGovernanceTuningConfig>>) {
+  return {
+    min_quorum_numerator: config.minQuorumNumerator,
+    max_quorum_numerator: config.maxQuorumNumerator,
+    max_quorum_delta_bps: config.maxQuorumDeltaBps,
+    min_proposal_threshold: config.minProposalThreshold.toString(),
+    max_proposal_threshold: config.maxProposalThreshold === null ? null : config.maxProposalThreshold.toString(),
+    max_threshold_delta_bps: config.maxThresholdDeltaBps,
+    trailing_window: config.trailingWindow,
+    interval_ms: config.intervalMs,
+    auto_propose: config.autoPropose,
+    updated_at: config.updatedAt,
+  };
+}
+
+// GET /governance-tuning/recommendations?limit=20&offset=0
+const listQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional().default(20),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+});
+
+router.get(
+  "/recommendations",
+  validate({ query: listQuerySchema }),
+  async (req, res: Response): Promise<void> => {
+    const { limit, offset } = req.query as unknown as z.infer<typeof listQuerySchema>;
+    try {
+      const { recommendations, hasMore } = await listRecommendations(limit, offset);
+      res.json({
+        data: recommendations.map(serializeRecommendation),
+        pagination: { limit, offset, hasMore },
+      });
+    } catch {
+      res.status(500).json({ error: "Internal server error" });
+    }
+  },
+);
+
+// GET /governance-tuning/recommendations/latest
+router.get(
+  "/recommendations/latest",
+  async (_req, res: Response): Promise<void> => {
+    try {
+      const rec = await getLatestRecommendation();
+      res.json(serializeRecommendation(rec));
+    } catch {
+      res.status(500).json({ error: "Internal server error" });
+    }
+  },
+);
+
+// GET /governance-tuning/config
+router.get("/config", async (_req, res: Response): Promise<void> => {
+  try {
+    const config = await getGovernanceTuningConfig();
+    res.json(serializeConfig(config));
+  } catch {
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// PUT /governance-tuning/config — admin-only
+const updateConfigSchema = z
+  .object({
+    min_quorum_numerator: z.number().int().min(0).max(10_000).optional(),
+    max_quorum_numerator: z.number().int().min(0).max(10_000).optional(),
+    max_quorum_delta_bps: z.number().int().min(0).max(10_000).optional(),
+    min_proposal_threshold: z.coerce.bigint().nonnegative().optional(),
+    max_proposal_threshold: z.coerce.bigint().nonnegative().nullable().optional(),
+    max_threshold_delta_bps: z.number().int().min(0).max(10_000).optional(),
+    trailing_window: z.number().int().min(2).max(1000).optional(),
+    interval_ms: z.number().int().min(60_000).optional(),
+    auto_propose: z.boolean().optional(),
+  })
+  .refine((body) => Object.keys(body).length > 0, {
+    message: "at least one field is required",
+  });
+
+router.put(
+  "/config",
+  isAdmin,
+  validate({ body: updateConfigSchema }),
+  async (req, res: Response): Promise<void> => {
+    const body = req.body as z.infer<typeof updateConfigSchema>;
+    try {
+      const config = await updateGovernanceTuningConfig({
+        minQuorumNumerator: body.min_quorum_numerator,
+        maxQuorumNumerator: body.max_quorum_numerator,
+        maxQuorumDeltaBps: body.max_quorum_delta_bps,
+        minProposalThreshold: body.min_proposal_threshold,
+        maxProposalThreshold: body.max_proposal_threshold,
+        maxThresholdDeltaBps: body.max_threshold_delta_bps,
+        trailingWindow: body.trailing_window,
+        intervalMs: body.interval_ms,
+        autoPropose: body.auto_propose,
+      });
+      res.json(serializeConfig(config));
+    } catch {
+      res.status(500).json({ error: "Internal server error" });
+    }
+  },
+);
+
+export default router;

--- a/backend/src/routes/governance-tuning.ts
+++ b/backend/src/routes/governance-tuning.ts
@@ -4,6 +4,7 @@ import { isAdmin } from "../middleware/admin";
 import { validate } from "../middleware/validate";
 import {
   getGovernanceTuningConfig,
+  GovernanceTuningConfigValidationError,
   updateGovernanceTuningConfig,
 } from "../governance-tuning/config-store";
 import {
@@ -125,7 +126,11 @@ router.put(
         autoPropose: body.auto_propose,
       });
       res.json(serializeConfig(config));
-    } catch {
+    } catch (err) {
+      if (err instanceof GovernanceTuningConfigValidationError) {
+        res.status(400).json({ error: err.message });
+        return;
+      }
       res.status(500).json({ error: "Internal server error" });
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       '@asteasolutions/zod-to-openapi':
         specifier: ^8.5.0
         version: 8.5.0(zod@4.3.6)
+      '@nebgov/sdk':
+        specifier: workspace:*
+        version: link:../sdk
       '@stellar/stellar-sdk':
         specifier: ^15.0.1
         version: 15.0.1

--- a/sdk/src/governanceTuning.ts
+++ b/sdk/src/governanceTuning.ts
@@ -1,0 +1,139 @@
+import { GovernorError, GovernorErrorCode } from "./errors";
+import { withRetry, isNetworkError } from "./utils";
+import type {
+  GovernorConfig,
+  TuningConfig,
+  TuningRecommendation,
+  TuningRecommendationPage,
+} from "./types";
+
+function mapRecommendation(raw: any): TuningRecommendation {
+  return {
+    id: Number(raw.id),
+    computedAt: raw.computed_at,
+    currentQuorumNumerator: Number(raw.current_quorum_numerator),
+    recommendedQuorumNumerator: Number(raw.recommended_quorum_numerator),
+    currentProposalThreshold: BigInt(raw.current_proposal_threshold),
+    recommendedProposalThreshold: BigInt(raw.recommended_proposal_threshold),
+    rationale: raw.rationale,
+    autoProposed: Boolean(raw.auto_proposed),
+    proposalId: raw.proposal_id === null || raw.proposal_id === undefined ? null : BigInt(raw.proposal_id),
+  };
+}
+
+function mapConfig(raw: any): TuningConfig {
+  return {
+    minQuorumNumerator: Number(raw.min_quorum_numerator),
+    maxQuorumNumerator: Number(raw.max_quorum_numerator),
+    maxQuorumDeltaBps: Number(raw.max_quorum_delta_bps),
+    minProposalThreshold: BigInt(raw.min_proposal_threshold),
+    maxProposalThreshold: raw.max_proposal_threshold === null ? null : BigInt(raw.max_proposal_threshold),
+    maxThresholdDeltaBps: Number(raw.max_threshold_delta_bps),
+    trailingWindow: Number(raw.trailing_window),
+    intervalMs: Number(raw.interval_ms),
+    autoPropose: Boolean(raw.auto_propose),
+    updatedAt: raw.updated_at,
+  };
+}
+
+/**
+ * Client for the governance tuning recommender (issue #998).
+ *
+ * Unlike every other indexer-backed client in this SDK (e.g.
+ * {@link ReputationClient}'s `getScore`/`getLeaderboard`), this one talks
+ * to the **backend** (`backend/src/routes/governance-tuning.ts`), not the
+ * indexer or Soroban RPC — the recommender's state (recommendations,
+ * tunable config) lives in the backend's Postgres schema, not the
+ * indexer's. Requires `config.backendUrl` to be set.
+ *
+ * @example
+ * const client = new GovernanceTuningClient({ ...config, backendUrl: "https://api.nebgov.dev" });
+ * const latest = await client.getLatestRecommendation();
+ */
+export class GovernanceTuningClient {
+  private readonly config: GovernorConfig;
+
+  constructor(config: GovernorConfig) {
+    this.config = config;
+  }
+
+  private async retry<T>(fn: () => Promise<T>): Promise<T> {
+    return withRetry(fn, {
+      maxAttempts: this.config.maxAttempts,
+      baseDelayMs: this.config.baseDelayMs,
+      retryOn: isNetworkError,
+    });
+  }
+
+  private async backendRequest<T>(path: string, init?: RequestInit): Promise<T> {
+    if (!this.config.backendUrl) {
+      throw new GovernorError(
+        GovernorErrorCode.SimulationFailed,
+        `GovernanceTuningClient requires config.backendUrl to be set`,
+      );
+    }
+    return this.retry(async () => {
+      const resp = await fetch(`${this.config.backendUrl}${path}`, init);
+      if (!resp.ok) {
+        throw new GovernorError(
+          GovernorErrorCode.SimulationFailed,
+          `Backend request failed: ${resp.status}`,
+        );
+      }
+      return resp.json() as Promise<T>;
+    });
+  }
+
+  /**
+   * Fetch the most recently computed recommendation.
+   *
+   * Hits `GET /governance-tuning/recommendations/latest`. Returns `null`
+   * if the analyzer hasn't completed a cycle yet.
+   */
+  async getLatestRecommendation(): Promise<TuningRecommendation | null> {
+    const raw = await this.backendRequest<any>("/governance-tuning/recommendations/latest");
+    return raw === null ? null : mapRecommendation(raw);
+  }
+
+  /**
+   * Fetch past recommendations as a flat array, newest first.
+   *
+   * Hits `GET /governance-tuning/recommendations`. For pagination metadata
+   * (e.g. "load more" UI), use {@link getRecommendationHistoryPage} instead.
+   *
+   * @param limit  - Maximum number of entries to return (default 20, max 100 per the backend)
+   * @param offset - Number of entries to skip for pagination (default 0)
+   */
+  async getRecommendationHistory(limit = 20, offset = 0): Promise<TuningRecommendation[]> {
+    const { recommendations } = await this.getRecommendationHistoryPage(limit, offset);
+    return recommendations;
+  }
+
+  /**
+   * Fetch a single page of recommendations with pagination metadata.
+   *
+   * Hits `GET /governance-tuning/recommendations`.
+   *
+   * @param limit  - Page size (default 20, max 100 per the backend)
+   * @param offset - Page offset (default 0)
+   */
+  async getRecommendationHistoryPage(limit = 20, offset = 0): Promise<TuningRecommendationPage> {
+    const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+    const raw = await this.backendRequest<any>(`/governance-tuning/recommendations?${params}`);
+    return {
+      recommendations: (raw.data as any[]).map(mapRecommendation),
+      pagination: raw.pagination,
+    };
+  }
+
+  /**
+   * Fetch the recommender's current tunable config (bands, per-cycle delta
+   * caps, interval, auto-propose toggle).
+   *
+   * Hits `GET /governance-tuning/config`.
+   */
+  async getConfig(): Promise<TuningConfig> {
+    const raw = await this.backendRequest<any>("/governance-tuning/config");
+    return mapConfig(raw);
+  }
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -25,6 +25,7 @@ export { TreasuryClient } from "./treasury";
 export { LiquidityClient } from "./liquidity";
 export { AnalyticsClient } from "./analytics";
 export { ReputationClient } from "./reputation";
+export { GovernanceTuningClient } from "./governanceTuning";
 export { WrapperClient } from "./wrapper";
 export type { WrapperConfig } from "./wrapper";
 export { CoSponsorshipClient } from "./coSponsorship";

--- a/sdk/src/types/index.ts
+++ b/sdk/src/types/index.ts
@@ -198,6 +198,8 @@ export interface GovernorConfig {
   simulationAccount?: string;
   /** Indexer base URL for off-chain queries (e.g. getVotingHistory) */
   indexerUrl?: string;
+  /** Backend REST API base URL, for clients that talk to backend/src rather than the indexer or Soroban RPC (e.g. GovernanceTuningClient) */
+  backendUrl?: string;
   /** Maximum number of retry attempts for RPC calls (default: 3) */
   maxAttempts?: number;
   /** Base delay in milliseconds for exponential backoff (default: 1000) */
@@ -860,4 +862,65 @@ export interface ThresholdHistoryPage {
     offset: number;
     hasMore: boolean;
   };
+}
+
+/**
+ * Explanation for one dimension of a governance tuning recommendation, as
+ * returned by the backend's `GET /governance-tuning/recommendations/*`
+ * (issue #998).
+ */
+export interface TuningRationaleEntry {
+  direction: "up" | "down" | "unchanged";
+  reason: string;
+}
+
+/** Full rationale attached to a {@link TuningRecommendation}. */
+export interface TuningRationale {
+  quorumNumerator: TuningRationaleEntry;
+  proposalThreshold: TuningRationaleEntry;
+  votingPeriod: TuningRationaleEntry;
+  /** Raw analytics inputs the recommendation was derived from, for auditability. */
+  inputs: Record<string, unknown>;
+}
+
+/**
+ * One computed governance-tuning recommendation, backend-sourced (never
+ * on-chain) — see the `governance_tuning_recommendations` table.
+ */
+export interface TuningRecommendation {
+  id: number;
+  computedAt: string;
+  currentQuorumNumerator: number;
+  recommendedQuorumNumerator: number;
+  currentProposalThreshold: bigint;
+  recommendedProposalThreshold: bigint;
+  rationale: TuningRationale;
+  /** Whether this recommendation was automatically submitted as an on-chain proposal. */
+  autoProposed: boolean;
+  /** The on-chain proposal id, once/if the indexer observes a matching `ProposalCreated` event. */
+  proposalId: bigint | null;
+}
+
+/** Paginated page of recommendations, as returned by `GET /governance-tuning/recommendations`. */
+export interface TuningRecommendationPage {
+  recommendations: TuningRecommendation[];
+  pagination: {
+    limit: number;
+    offset: number;
+    hasMore: boolean;
+  };
+}
+
+/** The tunable bands/caps for the recommender, as returned by `GET /governance-tuning/config`. */
+export interface TuningConfig {
+  minQuorumNumerator: number;
+  maxQuorumNumerator: number;
+  maxQuorumDeltaBps: number;
+  minProposalThreshold: bigint;
+  maxProposalThreshold: bigint | null;
+  maxThresholdDeltaBps: number;
+  trailingWindow: number;
+  intervalMs: number;
+  autoPropose: boolean;
+  updatedAt: string;
 }


### PR DESCRIPTION
Closes #998

## Summary

Adds a scheduled governance-tuning recommender that reads the indexer's existing governance analytics and config-update history, computes a bounded `quorum_numerator`/`proposal_threshold` suggestion via a documented formula, and packages it as ordinary `update_config` proposal calldata for token holders to review. No changes to `contracts/governor`, and nothing is ever applied on-chain automatically unless `auto_propose` is explicitly turned on via `PUT /governance-tuning/config` with a funded relayer key configured — both off by default.

- **Backend** (`backend/src/governance-tuning/`): pure `computeRecommendation` formula (analyzer.ts) + indexer-only data gathering, Postgres-backed recommendation/config stores, optional on-chain auto-propose path. New job `governance-tuning-analyzer.ts` wired into `bootstrap()` alongside the existing notification jobs. New routes `GET /governance-tuning/recommendations[/latest]`, `GET/PUT /governance-tuning/config` (PUT is admin-only via the existing `isAdmin` middleware). Migration `009_add_governance_tuning.sql`.
- **SDK** (`sdk/src/governanceTuning.ts`): `GovernanceTuningClient` — talks to the **backend**, not the indexer or Soroban RPC (added `backendUrl` to `GovernorConfig`), following the SDK's existing `X`/`XPage` pagination convention (see `ReputationClient`).
- **Frontend**: new `/governance-tuning` page, `TuningRecommendationCard` (its "Propose This Change" button reuses `GovernorClient.buildUpdateConfigProposal` — the same helper `settings/page.tsx` already uses — rather than duplicating calldata encoding), `useGovernanceTuning` hook, nav link.
- **Tests**: `governance-tuning-analyzer.test.ts` (pure-logic, no DB/network — clamping, delta caps, direction for high/low participation and hit-rate scenarios, `voting_period` always untouched) and `governance-tuning-routes.test.ts` (DB-backed route tests, same pattern as `leaderboard.test.ts`).

## Notable scope decisions

- **`quorum_hit_count`/`quorum_miss_count` are always `"0"` today** — a pre-existing, already-documented gap on `/analytics/all-time-stats` (the indexer doesn't track eligible supply at each proposal's start ledger). Rather than fabricate a hit rate, the `proposal_threshold` dimension is a documented no-op until that data exists; the formula is otherwise ready to use it the moment it's populated.
- **Current on-chain settings are sourced from `/config-history`** (mirrors `ConfigUpdated` events), not a fresh on-chain `get_settings()` read, so the recommender stays entirely indexer-backed per the issue's "must not invent new on-chain reads" constraint. If a governor has never had `update_config` called, the indexer can't know its genesis settings — the analyzer logs and skips that cycle rather than guessing.
- **`backend/src/governance-tuning/auto-propose.ts`** is the one place in the backend that takes on `@nebgov/sdk` (and its pinned `@stellar/stellar-sdk` ^12, alongside the backend's own ^15 — see the version-mismatch note already in `backend/src/routes/relayer.ts`) rather than hand-rolling `update_config` calldata encoding a second time. Accepted here since this path is opt-in and off by default, and re-deriving `proposals.ts`'s ScVal map encoding by hand would be a larger correctness risk for a rarely-exercised path.
- `voting_period` is never auto-tuned, per the issue — the hook is exposed in the rationale but always reports "unchanged".

## Test plan

- [ ] `governance-tuning-analyzer.test.ts` (pure-logic, no DB) — ready to run in CI
- [ ] `governance-tuning-routes.test.ts` (DB-backed, same pattern as existing route tests) — not run locally (no Postgres in this environment); ready to run in CI
- [ ] Manual: confirm `/governance-tuning` page renders and "Propose This Change" pre-fills the propose wizard's step 2 with correct calldata