### PR TITLE
feat(proposal-bonds): refundable proposer bonds with governance-triggered slashing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,7 +45,8 @@ jobs:
             -p sorogov-governor-factory \
             -p sorogov-treasury \
             -p sorogov-liquidity \
-            -p sorogov-co-sponsorship
+            -p sorogov-co-sponsorship \
+            -p sorogov-proposal-bonds
 
       - name: Run tests
         run: |
@@ -56,7 +57,8 @@ jobs:
             -p sorogov-governor-factory \
             -p sorogov-liquidity \
             -p sorogov-co-sponsorship \
-            -p sorogov-token-votes-wrapper
+            -p sorogov-token-votes-wrapper \
+            -p sorogov-proposal-bonds
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
@@ -108,7 +110,8 @@ jobs:
             -p sorogov-governor-factory \
             -p sorogov-treasury \
             -p sorogov-liquidity \
-            -p sorogov-co-sponsorship
+            -p sorogov-co-sponsorship \
+            -p sorogov-proposal-bonds
 
       - name: Run clippy
         run: |
@@ -120,6 +123,7 @@ jobs:
             -p sorogov-liquidity \
             -p sorogov-co-sponsorship \
             -p sorogov-token-votes-wrapper \
+            -p sorogov-proposal-bonds \
             --all-targets \
             -- -D warnings
 
@@ -158,7 +162,8 @@ jobs:
             -p sorogov-governor-factory \
             -p sorogov-treasury \
             -p sorogov-liquidity \
-            -p sorogov-co-sponsorship
+            -p sorogov-co-sponsorship \
+            -p sorogov-proposal-bonds
 
       - name: Check contract WASM sizes
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,6 +1590,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "sorogov-proposal-bonds"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "sorogov-timelock"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "contracts/liquidity",
     "contracts/token-votes-wrapper",
     "contracts/co-sponsorship",
+    "contracts/proposal-bonds",
 ]
 exclude = ["fuzz", "tools/sim"]
 resolver = "2"

--- a/app/src/app/bonds/page.tsx
+++ b/app/src/app/bonds/page.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+/**
+ * Proposal bonds page (Issue #996).
+ *
+ * Lists the connected wallet's own proposer bonds and lets them manually
+ * trigger a refund once their correlated proposal has reached a terminal
+ * state and the post-terminal grace window has elapsed — see the
+ * ProposalBonds contract (contracts/proposal-bonds) and ProposalBondsClient
+ * in the SDK.
+ */
+
+import { useState } from "react";
+import toast from "react-hot-toast";
+import { ProposalBondsClient } from "@nebgov/sdk";
+import { useWallet } from "../../lib/wallet-context";
+import { readGovernorConfig, readIndexerUrl } from "../../lib/nebgov-env";
+import { useBondsByProposer } from "../../hooks/useProposalBonds";
+import { BondStatusBadge } from "../../components/BondStatusBadge";
+import { Skeleton } from "../../components/ui/Skeleton";
+
+function formatAddress(address: string): string {
+  return `${address.slice(0, 4)}...${address.slice(-4)}`;
+}
+
+function BondCardSkeleton() {
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-xl p-4">
+      <Skeleton className="h-4 w-1/3 mb-2" />
+      <Skeleton className="h-3 w-2/3 mb-4" />
+      <Skeleton className="h-2 w-full" />
+    </div>
+  );
+}
+
+export default function BondsPage() {
+  const { isConnected, publicKey, signTransaction } = useWallet();
+  const { bonds, loading, error, refetch } = useBondsByProposer(publicKey ?? null);
+  const [refundingHash, setRefundingHash] = useState<string | null>(null);
+
+  async function handleRefund(descriptionHash: string) {
+    if (!publicKey || !signTransaction) return;
+    const config = readGovernorConfig();
+    if (!config || !config.proposalBondsAddress) return;
+    const indexerUrl = readIndexerUrl();
+    if (!indexerUrl) {
+      toast.error("Indexer is not configured — cannot resolve the correlated proposal.");
+      return;
+    }
+
+    setRefundingHash(descriptionHash);
+    try {
+      const client = new ProposalBondsClient({ ...config, indexerUrl });
+      const proposalId = await client.getProposalIdForDescriptionHash(descriptionHash);
+      if (proposalId === null) {
+        toast.error("Correlated proposal not found in the indexer yet.");
+        return;
+      }
+      await client.refundBondWithSign(publicKey, descriptionHash, proposalId, signTransaction);
+      toast.success("Bond refund submitted.");
+      refetch();
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : "Refund failed");
+    } finally {
+      setRefundingHash(null);
+    }
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+          My Proposal Bonds
+        </h1>
+        <p className="text-sm text-gray-500 dark:text-gray-300">
+          Bonds you&apos;ve posted alongside proposals. Refund once your proposal reaches a
+          terminal state and the grace window elapses, or check back if it was slashed by a
+          follow-up governance vote.
+        </p>
+      </div>
+
+      {!isConnected && (
+        <div className="text-center py-16 text-gray-500 dark:text-gray-400">
+          Connect your wallet to view your proposal bonds.
+        </div>
+      )}
+
+      {isConnected && error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 dark:bg-red-900/20 dark:border-red-800 p-4 text-sm text-red-700 dark:text-red-300 mb-4">
+          {error}
+        </div>
+      )}
+
+      {isConnected && loading && (
+        <div className="space-y-4">
+          <BondCardSkeleton />
+          <BondCardSkeleton />
+        </div>
+      )}
+
+      {isConnected && !loading && !error && bonds.length === 0 && (
+        <div className="text-center py-16 text-gray-500 dark:text-gray-400">
+          No proposal bonds yet.
+        </div>
+      )}
+
+      {isConnected && !loading && bonds.length > 0 && (
+        <div className="space-y-4">
+          {bonds.map((bond) => (
+            <div
+              key={bond.descriptionHash}
+              className="border border-gray-200 dark:border-gray-700 rounded-xl p-4"
+            >
+              <div className="flex items-center justify-between mb-1">
+                <span className="font-medium text-gray-900 dark:text-gray-100">
+                  {formatAddress(bond.proposer)}
+                </span>
+                <BondStatusBadge state={bond.state} />
+              </div>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-3 break-all">
+                {bond.descriptionHash}
+              </p>
+              <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+                <span>Amount: {bond.amount.toString()}</span>
+                <span>Locked at ledger {bond.lockedLedger}</span>
+              </div>
+              {bond.state === "Locked" && (
+                <button
+                  onClick={() => handleRefund(bond.descriptionHash)}
+                  disabled={refundingHash === bond.descriptionHash}
+                  className="mt-3 px-4 py-2 rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 text-sm font-medium disabled:opacity-50"
+                >
+                  {refundingHash === bond.descriptionHash ? "Refunding..." : "Refund"}
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/app/bonds/page.tsx
+++ b/app/src/app/bonds/page.tsx
@@ -15,9 +15,10 @@ import toast from "react-hot-toast";
 import { ProposalBondsClient } from "@nebgov/sdk";
 import { useWallet } from "../../lib/wallet-context";
 import { readGovernorConfig, readIndexerUrl } from "../../lib/nebgov-env";
-import { useBondsByProposer } from "../../hooks/useProposalBonds";
+import { useBondsByProposer, useBondEligibility } from "../../hooks/useProposalBonds";
 import { BondStatusBadge } from "../../components/BondStatusBadge";
 import { Skeleton } from "../../components/ui/Skeleton";
+import { useLedgerClock } from "../../lib/hooks/useLedgerClock";
 
 function formatAddress(address: string): string {
   return `${address.slice(0, 4)}...${address.slice(-4)}`;
@@ -36,6 +37,8 @@ function BondCardSkeleton() {
 export default function BondsPage() {
   const { isConnected, publicKey, signTransaction } = useWallet();
   const { bonds, loading, error, refetch } = useBondsByProposer(publicKey ?? null);
+  const { currentLedger } = useLedgerClock();
+  const { eligibility } = useBondEligibility(bonds, currentLedger);
   const [refundingHash, setRefundingHash] = useState<string | null>(null);
 
   async function handleRefund(descriptionHash: string) {
@@ -124,7 +127,7 @@ export default function BondsPage() {
                 <span>Amount: {bond.amount.toString()}</span>
                 <span>Locked at ledger {bond.lockedLedger}</span>
               </div>
-              {bond.state === "Locked" && (
+              {bond.state === "Locked" && eligibility[bond.descriptionHash] && (
                 <button
                   onClick={() => handleRefund(bond.descriptionHash)}
                   disabled={refundingHash === bond.descriptionHash}
@@ -132,6 +135,12 @@ export default function BondsPage() {
                 >
                   {refundingHash === bond.descriptionHash ? "Refunding..." : "Refund"}
                 </button>
+              )}
+              {bond.state === "Locked" && eligibility[bond.descriptionHash] === false && (
+                <p className="mt-3 text-xs text-gray-400 dark:text-gray-500">
+                  Not yet refund-eligible — waiting on your proposal to reach a terminal state
+                  and the post-terminal grace window to elapse.
+                </p>
               )}
             </div>
           ))}

--- a/app/src/app/proposal/[id]/ProposalDetailClient.tsx
+++ b/app/src/app/proposal/[id]/ProposalDetailClient.tsx
@@ -48,6 +48,7 @@ import {
 } from "../../../lib/frontend-error";
 import { ProposalDetailSkeleton } from "../../../components/ui/ProposalDetailSkeleton";
 import { CountdownTimer } from "../../../components/CountdownTimer";
+import { ProposalBondCard } from "../../../components/ProposalBondCard";
 
 interface Props {
   params: { id: string };
@@ -639,6 +640,13 @@ export default function ProposalDetailClient({ params }: Props) {
         )}
       </div>
       </ErrorBoundary>
+
+      {proposal.descriptionHash && (
+        <ProposalBondCard
+          descriptionHash={proposal.descriptionHash}
+          proposer={proposal.proposer}
+        />
+      )}
 
       {/* Delegation */}
       <ErrorBoundary

--- a/app/src/app/propose/page.tsx
+++ b/app/src/app/propose/page.tsx
@@ -25,6 +25,7 @@ import {
   GovernorClient,
   VotesClient,
   ReputationClient,
+  ProposalBondsClient,
   hashDescription,
   uploadProposalMetadata,
   type CanProposeResult,
@@ -122,6 +123,7 @@ function getClients() {
   const governorAddress = process.env.NEXT_PUBLIC_GOVERNOR_ADDRESS;
   const timelockAddress = process.env.NEXT_PUBLIC_TIMELOCK_ADDRESS;
   const votesAddress = process.env.NEXT_PUBLIC_VOTES_ADDRESS;
+  const proposalBondsAddress = process.env.NEXT_PUBLIC_PROPOSAL_BONDS_ADDRESS;
   const network = (process.env.NEXT_PUBLIC_NETWORK || "testnet") as
     | "mainnet"
     | "testnet"
@@ -140,6 +142,12 @@ function getClients() {
     votes: new VotesClient(cfg),
     reputation: new ReputationClient(cfg),
     governorAddress,
+    // Bonding is optional — only constructed when a bonds contract is
+    // configured, so proposing continues to work for deployments that
+    // haven't opted into Issue #996's bonding layer.
+    proposalBonds: proposalBondsAddress
+      ? new ProposalBondsClient({ ...cfg, proposalBondsAddress })
+      : null,
   };
 }
 
@@ -620,6 +628,28 @@ function ProposeWizardInner() {
         </div>,
         { duration: 8000 },
       );
+
+      // Bonding (Issue #996) is a second, separate transaction correlated
+      // by the same description hash — best-effort: the proposal above has
+      // already succeeded on-chain, so a bond-lock failure is surfaced but
+      // must not block navigating to the success step.
+      if (clients.proposalBonds) {
+        try {
+          await clients.proposalBonds.lockBondWithSign(
+            publicKey,
+            draft.descriptionHash,
+            signTransaction,
+          );
+          toast.success("Proposal bond locked.");
+        } catch (bondError: unknown) {
+          toast.error(
+            `Proposal submitted, but locking the bond failed: ${
+              bondError instanceof Error ? bondError.message : String(bondError)
+            }`,
+          );
+        }
+      }
+
       sessionStorage.removeItem(STORAGE_KEY);
       localStorage.removeItem(STORAGE_KEY);
       setDraft({

--- a/app/src/components/BondStatusBadge.tsx
+++ b/app/src/components/BondStatusBadge.tsx
@@ -1,0 +1,29 @@
+import { BondState } from "@nebgov/sdk";
+
+const STATE_CONFIG: Record<BondState, { color: string; icon: string; label: string }> = {
+  Locked: { color: "bg-blue-100 text-blue-800 border border-blue-200", icon: '🔒', label: 'Locked' },
+  Refunded: { color: "bg-green-100 text-green-800 border border-green-200", icon: '✓', label: 'Refunded' },
+  Slashed: { color: "bg-red-100 text-red-800 border border-red-200", icon: '✕', label: 'Slashed' },
+};
+
+interface Props {
+  state: BondState;
+}
+
+export function BondStatusBadge({ state }: Props) {
+  const meta = STATE_CONFIG[state];
+
+  if (!meta) {
+    return (
+      <span className="px-3 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-700 border border-gray-200">
+        Unknown
+      </span>
+    );
+  }
+
+  return (
+    <span className={`px-3 py-1 rounded-full text-xs font-medium ${meta.color}`}>
+      {meta.icon} {meta.label}
+    </span>
+  );
+}

--- a/app/src/components/GaslessDelegateModal.tsx
+++ b/app/src/components/GaslessDelegateModal.tsx
@@ -49,7 +49,7 @@ export function GaslessDelegateModal({
   const [submitting, setSubmitting] = useState(false);
   const [expiryPreset, setExpiryPreset] = useState<ExpiryPreset>("1month");
   const { isConnected, publicKey, connect } = useWallet();
-  const { delegateGasless, preflightDelegatee } = useGaslessDelegation();
+  const { delegateGasless, preflightDelegatee, invalidateAllPermits } = useGaslessDelegation();
   const dialogRef = useFocusTrap<HTMLDivElement>(open, onClose);
 
   useEffect(() => {

--- a/app/src/components/ProposalBondCard.tsx
+++ b/app/src/components/ProposalBondCard.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+/**
+ * Lets a proposal's own proposer lock (or retry locking) their proposal
+ * bond from the proposal detail page. Addresses a maintainer review note on
+ * PR #1003: the propose wizard fires the bond-lock transaction right after
+ * the proposal already exists on-chain, and previously had no retry path
+ * if that second transaction failed — the proposal would end up
+ * permanently unbonded with no way to fix it from the UI.
+ */
+
+import { useEffect, useState } from "react";
+import toast from "react-hot-toast";
+import { ProposalBondsClient, type ProposalBond } from "@nebgov/sdk";
+import { useWallet } from "../lib/wallet-context";
+import { readGovernorConfig, readIndexerUrl } from "../lib/nebgov-env";
+import { BondStatusBadge } from "./BondStatusBadge";
+
+interface Props {
+  descriptionHash: string;
+  proposer: string;
+}
+
+export function ProposalBondCard({ descriptionHash, proposer }: Props) {
+  const { isConnected, publicKey, signTransaction } = useWallet();
+  const [bond, setBond] = useState<ProposalBond | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [locking, setLocking] = useState(false);
+
+  const client = (() => {
+    const config = readGovernorConfig();
+    if (!config || !config.proposalBondsAddress) return null;
+    const indexerUrl = readIndexerUrl();
+    return new ProposalBondsClient({ ...config, ...(indexerUrl ? { indexerUrl } : {}) });
+  })();
+
+  useEffect(() => {
+    if (!client || !descriptionHash) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    client
+      .getBond(descriptionHash)
+      .then((result) => {
+        if (!cancelled) setBond(result);
+      })
+      .catch(() => {
+        /* Bonding is optional/best-effort here — swallow and just show no bond. */
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [descriptionHash]);
+
+  if (!client || loading) return null;
+  if (bond) {
+    return (
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-6 mb-6">
+        <div className="flex items-center justify-between gap-4">
+          <h2 className="text-sm font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">
+            Proposal Bond
+          </h2>
+          <BondStatusBadge state={bond.state} />
+        </div>
+      </div>
+    );
+  }
+
+  // Only the proposer can lock a bond for their own proposal, and only
+  // once connected — nothing to offer otherwise.
+  if (!isConnected || !publicKey || publicKey !== proposer) return null;
+
+  async function handleLock() {
+    if (!client || !publicKey || !signTransaction) return;
+    setLocking(true);
+    try {
+      await client.lockBondWithSign(publicKey, descriptionHash, signTransaction);
+      toast.success("Proposal bond locked.");
+      const refreshed = await client.getBond(descriptionHash);
+      setBond(refreshed);
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : "Locking the bond failed");
+    } finally {
+      setLocking(false);
+    }
+  }
+
+  return (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-6 mb-6">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h2 className="text-sm font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide mb-1">
+            Proposal Bond
+          </h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            This proposal has no bond locked yet.
+          </p>
+        </div>
+        <button
+          onClick={() => void handleLock()}
+          disabled={locking}
+          className="px-4 py-2 border border-gray-200 rounded-lg text-sm font-medium hover:bg-gray-50 transition-colors disabled:opacity-50"
+        >
+          {locking ? "Locking..." : "Lock Bond"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/__tests__/GaslessDelegateModal.validation.test.tsx
+++ b/app/src/components/__tests__/GaslessDelegateModal.validation.test.tsx
@@ -10,6 +10,7 @@ const VALID_ADDRESS = "GDOOXICJPSOZDQRCEHZPR6MAX5PUZXVWGJ3QPVEU4DADIZQ4YBQOJNIB"
 const VALID_ADDRESS_2 = "GD6HLZWRE5FHK3SDLZB3FH56R3H3ECAAYCPWWU7O7EK4FCNT2Z7S6D5I";
 const mockDelegateGasless = jest.fn();
 const mockPreflightDelegatee = jest.fn();
+const mockInvalidateAllPermits = jest.fn();
 
 jest.mock("../../lib/wallet-context", () => ({
   useWallet: () => ({
@@ -28,6 +29,7 @@ jest.mock("../../hooks/useGaslessDelegation", () => ({
   useGaslessDelegation: () => ({
     delegateGasless: mockDelegateGasless.mockResolvedValue({ txHash: "txhash789" }),
     preflightDelegatee: mockPreflightDelegatee.mockResolvedValue(undefined),
+    invalidateAllPermits: mockInvalidateAllPermits.mockResolvedValue({ txHash: "txhash999" }),
     submitting: false,
   }),
   EXPIRY_PRESET_LABELS: {
@@ -49,8 +51,10 @@ describe("GaslessDelegateModal — Stellar address validation", () => {
     jest.clearAllMocks();
     mockDelegateGasless.mockReset();
     mockPreflightDelegatee.mockReset();
+    mockInvalidateAllPermits.mockReset();
     mockDelegateGasless.mockResolvedValue({ txHash: "txhash789" });
     mockPreflightDelegatee.mockResolvedValue(undefined);
+    mockInvalidateAllPermits.mockResolvedValue({ txHash: "txhash999" });
   });
 
   describe("rendering", () => {

--- a/app/src/hooks/useGaslessDelegation.ts
+++ b/app/src/hooks/useGaslessDelegation.ts
@@ -61,16 +61,6 @@ function getDelegationSigClientFromEnv(): DelegationSigClient {
   });
 }
 
-function getVotesClientFromEnv(): VotesClient {
-  const config = readGovernorConfig();
-  if (!config) {
-    throw new Error(
-      "Missing NEXT_PUBLIC_GOVERNOR_ADDRESS/NEXT_PUBLIC_TIMELOCK_ADDRESS/NEXT_PUBLIC_VOTES_ADDRESS in .env.local",
-    );
-  }
-  return new VotesClient(config);
-}
-
 /**
  * Cycle/depth-limit checks (`wouldCreateCycle`, `getDelegationDepthLimit`,
  * `getChainDepth`) live on the token-votes contract, not the delegation-sig
@@ -115,9 +105,9 @@ export function useGaslessDelegation() {
       try {
         const client = getVotesClientFromEnv();
         const [wouldCreateCycle, depthLimit, currentDepth] = await Promise.all([
-          votes.wouldCreateCycle(publicKey, delegatee.trim()),
-          votes.getDelegationDepthLimit(),
-          votes.getChainDepth(publicKey),
+          client.wouldCreateCycle(publicKey, delegatee.trim()),
+          client.getDelegationDepthLimit(),
+          client.getChainDepth(publicKey),
         ]);
 
         if (wouldCreateCycle) {

--- a/app/src/hooks/useGaslessDelegation.ts
+++ b/app/src/hooks/useGaslessDelegation.ts
@@ -1,10 +1,11 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import { DelegationSigClient, type Network } from "@nebgov/sdk";
+import { DelegationSigClient, VotesClient, type Network } from "@nebgov/sdk";
 import { isValidStellarAddress } from "../lib/utils/stellarAddress";
 import { useWallet } from "../lib/wallet-context";
 import { backendFetch } from "../lib/backend";
+import { readGovernorConfig } from "../lib/nebgov-env";
 
 /**
  * Approximate ledger close time used to convert a human-friendly expiry
@@ -40,6 +41,10 @@ export interface GaslessPreflightResult {
   error?: string;
 }
 
+export interface InvalidatePermitsResult {
+  txHash: string;
+}
+
 function getDelegationSigClientFromEnv(): DelegationSigClient {
   const votesAddress = process.env.NEXT_PUBLIC_VOTES_ADDRESS;
   const network = (process.env.NEXT_PUBLIC_NETWORK || "testnet") as Network;
@@ -57,12 +62,29 @@ function getDelegationSigClientFromEnv(): DelegationSigClient {
 }
 
 /**
+ * Cycle/depth-limit checks (`wouldCreateCycle`, `getDelegationDepthLimit`,
+ * `getChainDepth`) live on the token-votes contract, not the delegation-sig
+ * one — they're read through `VotesClient`, which needs the full governor
+ * config (governor + timelock + votes addresses), unlike
+ * `DelegationSigClient`.
+ */
+function getVotesClientFromEnv(): VotesClient {
+  const config = readGovernorConfig();
+  if (!config) {
+    throw new Error(
+      "Missing NEXT_PUBLIC_GOVERNOR_ADDRESS/NEXT_PUBLIC_TIMELOCK_ADDRESS/NEXT_PUBLIC_VOTES_ADDRESS in .env.local",
+    );
+  }
+  return new VotesClient(config);
+}
+
+/**
  * Sign a delegation permit with the connected wallet and submit it through
  * the backend relayer — the connected wallet never pays a fee or submits a
  * transaction itself, it only signs an authorization off-chain.
  */
 export function useGaslessDelegation() {
-  const { isConnected, publicKey, signTransaction } = useWallet();
+  const { isConnected, publicKey, signTransaction, signAuthEntry } = useWallet();
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -81,7 +103,7 @@ export function useGaslessDelegation() {
       }
 
       try {
-        const client = getDelegationSigClientFromEnv();
+        const client = getVotesClientFromEnv();
         const [wouldCreateCycle, depthLimit, currentDepth] = await Promise.all([
           client.wouldCreateCycle(publicKey, delegatee.trim()),
           client.getDelegationDepthLimit(),
@@ -168,5 +190,31 @@ export function useGaslessDelegation() {
     [isConnected, publicKey, signAuthEntry],
   );
 
-  return { delegateGasless, preflightDelegatee, submitting, error };
+  const invalidateAllPermits = useCallback(async (): Promise<InvalidatePermitsResult> => {
+    if (!isConnected || !publicKey || !signTransaction) {
+      throw new Error("Connect your wallet first.");
+    }
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      const client = getDelegationSigClientFromEnv();
+      const result = await client.invalidateAllPermitsWithSign(publicKey, signTransaction);
+      return { txHash: result.hash };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+      throw err;
+    } finally {
+      setSubmitting(false);
+    }
+  }, [isConnected, publicKey, signTransaction]);
+
+  return {
+    delegateGasless,
+    preflightDelegatee,
+    invalidateAllPermits,
+    submitting,
+    error,
+  };
 }

--- a/app/src/hooks/useProposalBonds.ts
+++ b/app/src/hooks/useProposalBonds.ts
@@ -1,0 +1,121 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { ProposalBondsClient, type ProposalBond } from "@nebgov/sdk";
+import { readGovernorConfig, readIndexerUrl } from "../lib/nebgov-env";
+
+function buildClient(): ProposalBondsClient | null {
+  const config = readGovernorConfig();
+  if (!config || !config.proposalBondsAddress) return null;
+  const indexerUrl = readIndexerUrl();
+  return new ProposalBondsClient({
+    ...config,
+    ...(indexerUrl ? { indexerUrl } : {}),
+  });
+}
+
+interface UseBondResult {
+  bond: ProposalBond | null;
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+/** Fetch a single proposal bond by description hash, with manual refetch. */
+export function useProposalBond(descriptionHash: string | null): UseBondResult {
+  const [bond, setBond] = useState<ProposalBond | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refetchToken, setRefetchToken] = useState(0);
+
+  useEffect(() => {
+    if (!descriptionHash) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    const client = buildClient();
+    if (!client) {
+      setError("Proposal-bonds registry is not configured.");
+      setLoading(false);
+      return;
+    }
+
+    client
+      .getBond(descriptionHash)
+      .then((result) => {
+        if (!cancelled) setBond(result);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [descriptionHash, refetchToken]);
+
+  const refetch = useCallback(() => setRefetchToken((t) => t + 1), []);
+
+  return { bond, loading, error, refetch };
+}
+
+interface UseBondsByProposerResult {
+  bonds: ProposalBond[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+/** Fetch every bond posted by a given proposer address, most-recent first. */
+export function useBondsByProposer(address: string | null): UseBondsByProposerResult {
+  const [bonds, setBonds] = useState<ProposalBond[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refetchToken, setRefetchToken] = useState(0);
+
+  useEffect(() => {
+    if (!address) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    const client = buildClient();
+    if (!client) {
+      setError("Proposal-bonds registry is not configured.");
+      setLoading(false);
+      return;
+    }
+
+    client
+      .getBondsByProposer(address)
+      .then((result) => {
+        if (!cancelled) setBonds(result);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [address, refetchToken]);
+
+  const refetch = useCallback(() => setRefetchToken((t) => t + 1), []);
+
+  return { bonds, loading, error, refetch };
+}

--- a/app/src/hooks/useProposalBonds.ts
+++ b/app/src/hooks/useProposalBonds.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { ProposalBondsClient, type ProposalBond } from "@nebgov/sdk";
+import { ProposalBondsClient, type ProposalBond, type ProposalBondSettings } from "@nebgov/sdk";
 import { readGovernorConfig, readIndexerUrl } from "../lib/nebgov-env";
 
 function buildClient(): ProposalBondsClient | null {
@@ -118,4 +118,96 @@ export function useBondsByProposer(address: string | null): UseBondsByProposerRe
   const refetch = useCallback(() => setRefetchToken((t) => t + 1), []);
 
   return { bonds, loading, error, refetch };
+}
+
+interface IndexedProposal {
+  end_ledger: number;
+  executed: boolean;
+  cancelled: boolean;
+  queued: boolean;
+}
+
+/**
+ * Whether refund_bond would currently succeed for a `Locked` bond —
+ * mirrors the contract's own gate (contracts/proposal-bonds/src/lib.rs
+ * `refund_bond`) so the UI can disable the Refund button rather than let
+ * users pay gas + sign a transaction that's guaranteed to revert:
+ *
+ * - the `MaxLockLedgers` escape hatch (locked for a very long time,
+ *   regardless of the correlated proposal's state), OR
+ * - the proposal is terminal (executed, cancelled, or past its voting
+ *   `end_ledger` without still being queued) AND `RefundGraceLedgers` has
+ *   elapsed since `end_ledger`.
+ */
+function isRefundEligible(
+  bond: ProposalBond,
+  proposal: IndexedProposal | null,
+  settings: ProposalBondSettings,
+  currentLedger: number,
+): boolean {
+  if (bond.state !== "Locked" || currentLedger <= 0) return false;
+  if (currentLedger >= bond.lockedLedger + settings.maxLockLedgers) return true;
+  if (!proposal) return false;
+
+  const terminal = proposal.executed || proposal.cancelled || (!proposal.queued && currentLedger > proposal.end_ledger);
+  if (!terminal) return false;
+  return currentLedger >= proposal.end_ledger + settings.refundGraceLedgers;
+}
+
+interface UseBondEligibilityResult {
+  /** Keyed by descriptionHash. `undefined` while still loading a given bond. */
+  eligibility: Record<string, boolean | undefined>;
+}
+
+/** Compute refund eligibility for a set of (typically a proposer's own) bonds. */
+export function useBondEligibility(
+  bonds: ProposalBond[],
+  currentLedger: number,
+): UseBondEligibilityResult {
+  const [eligibility, setEligibility] = useState<Record<string, boolean | undefined>>({});
+
+  useEffect(() => {
+    const lockedBonds = bonds.filter((b) => b.state === "Locked");
+    if (lockedBonds.length === 0 || currentLedger <= 0) return;
+
+    let cancelled = false;
+    const config = readGovernorConfig();
+    const indexerUrl = readIndexerUrl();
+    if (!config || !config.proposalBondsAddress || !indexerUrl) return;
+
+    const client = new ProposalBondsClient({ ...config, indexerUrl });
+
+    client
+      .getSettings()
+      .then(async (settings) => {
+        const results = await Promise.all(
+          lockedBonds.map(async (bond) => {
+            try {
+              const resp = await fetch(
+                `${indexerUrl}/proposals/by-description-hash/${bond.descriptionHash}`,
+              );
+              const proposal: IndexedProposal | null = resp.ok ? await resp.json() : null;
+              return [
+                bond.descriptionHash,
+                isRefundEligible(bond, proposal, settings, currentLedger),
+              ] as const;
+            } catch {
+              return [bond.descriptionHash, false] as const;
+            }
+          }),
+        );
+        if (!cancelled) {
+          setEligibility(Object.fromEntries(results));
+        }
+      })
+      .catch(() => {
+        /* leave eligibility unset — Refund stays disabled/hidden by default */
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [bonds, currentLedger]);
+
+  return { eligibility };
 }

--- a/app/src/lib/nebgov-env.ts
+++ b/app/src/lib/nebgov-env.ts
@@ -6,6 +6,7 @@ export function readGovernorConfig(): GovernorConfig | null {
   const timelockAddress = process.env.NEXT_PUBLIC_TIMELOCK_ADDRESS;
   const votesAddress = process.env.NEXT_PUBLIC_VOTES_ADDRESS;
   const coSponsorshipAddress = process.env.NEXT_PUBLIC_CO_SPONSORSHIP_ADDRESS;
+  const proposalBondsAddress = process.env.NEXT_PUBLIC_PROPOSAL_BONDS_ADDRESS;
   const network = (process.env.NEXT_PUBLIC_NETWORK || "testnet") as Network;
   const rpcUrl = process.env.NEXT_PUBLIC_RPC_URL;
 
@@ -18,6 +19,7 @@ export function readGovernorConfig(): GovernorConfig | null {
     network,
     ...(rpcUrl ? { rpcUrl } : {}),
     ...(coSponsorshipAddress ? { coSponsorshipAddress } : {}),
+    ...(proposalBondsAddress ? { proposalBondsAddress } : {}),
   };
 }
 

--- a/contracts/proposal-bonds/Cargo.toml
+++ b/contracts/proposal-bonds/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "sorogov-proposal-bonds"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[features]
+testutils = ["soroban-sdk/testutils"]
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/proposal-bonds/src/error.rs
+++ b/contracts/proposal-bonds/src/error.rs
@@ -13,4 +13,5 @@ pub enum ProposalBondsError {
     ProposalNotTerminal = 7,
     RefundGraceNotElapsed = 8,
     NotAuthorized = 9,
+    InvalidBondAmount = 10,
 }

--- a/contracts/proposal-bonds/src/error.rs
+++ b/contracts/proposal-bonds/src/error.rs
@@ -1,0 +1,16 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum ProposalBondsError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    BondAlreadyLocked = 3,
+    BondNotFound = 4,
+    BondNotLocked = 5,
+    DescriptionHashMismatch = 6,
+    ProposalNotTerminal = 7,
+    RefundGraceNotElapsed = 8,
+    NotAuthorized = 9,
+}

--- a/contracts/proposal-bonds/src/events.rs
+++ b/contracts/proposal-bonds/src/events.rs
@@ -1,0 +1,32 @@
+use soroban_sdk::{Address, BytesN, Env, Symbol};
+
+pub const BOND_LOCKED_TOPIC: &str = "BondLocked";
+pub const BOND_REFUNDED_TOPIC: &str = "BondRefunded";
+pub const BOND_SLASHED_TOPIC: &str = "BondSlashed";
+
+pub fn emit_bond_locked(env: &Env, proposer: &Address, description_hash: &BytesN<32>, amount: i128) {
+    env.events().publish(
+        (Symbol::new(env, BOND_LOCKED_TOPIC), proposer.clone()),
+        (description_hash.clone(), amount),
+    );
+}
+
+pub fn emit_bond_refunded(env: &Env, description_hash: &BytesN<32>, proposer: &Address, amount: i128) {
+    env.events().publish(
+        (Symbol::new(env, BOND_REFUNDED_TOPIC), proposer.clone()),
+        (description_hash.clone(), amount),
+    );
+}
+
+pub fn emit_bond_slashed(
+    env: &Env,
+    description_hash: &BytesN<32>,
+    proposer: &Address,
+    amount: i128,
+    recipient: &Address,
+) {
+    env.events().publish(
+        (Symbol::new(env, BOND_SLASHED_TOPIC), proposer.clone()),
+        (description_hash.clone(), amount, recipient.clone()),
+    );
+}

--- a/contracts/proposal-bonds/src/lib.rs
+++ b/contracts/proposal-bonds/src/lib.rs
@@ -73,6 +73,16 @@ pub struct Bond {
 }
 
 #[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct BondSettings {
+    pub bond_token: Address,
+    pub bond_amount: i128,
+    pub governor: Address,
+    pub refund_grace_ledgers: u32,
+    pub max_lock_ledgers: u32,
+}
+
+#[contracttype]
 pub enum DataKey {
     Admin,
     BondToken,
@@ -80,6 +90,7 @@ pub enum DataKey {
     Governor,
     Bond(BytesN<32>),
     RefundGraceLedgers,
+    MaxLockLedgers,
 }
 
 /// ~1,000,000 ledgers (~58 days at the network's ~5s ledger close time),
@@ -99,10 +110,14 @@ impl ProposalBondsContract {
         bond_amount: i128,
         governor: Address,
         refund_grace_ledgers: u32,
+        max_lock_ledgers: u32,
     ) {
         admin.require_auth();
         if env.storage().instance().has(&DataKey::Admin) {
             env.panic_with_error(ProposalBondsError::AlreadyInitialized);
+        }
+        if bond_amount <= 0 {
+            env.panic_with_error(ProposalBondsError::InvalidBondAmount);
         }
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::BondToken, &bond_token);
@@ -111,6 +126,9 @@ impl ProposalBondsContract {
         env.storage()
             .instance()
             .set(&DataKey::RefundGraceLedgers, &refund_grace_ledgers);
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxLockLedgers, &max_lock_ledgers);
     }
 
     fn must_get_bond(env: &Env, description_hash: &BytesN<32>) -> Bond {
@@ -193,6 +211,18 @@ impl ProposalBondsContract {
     /// submit a `slash` governance proposal — has elapsed. Permissionless:
     /// anyone may trigger it, but funds always return to the original
     /// proposer.
+    ///
+    /// Escape hatch: `ProposalState::Queued` is deliberately *not* treated
+    /// as terminal here — a queued proposal can still be executed, so
+    /// refunding early would let a proposer walk away from their bond while
+    /// their proposal might still land. But governor's `state()` has no
+    /// path out of `Queued` if the timelock operation's execution window
+    /// closes without `execute()` ever being called (querying that
+    /// correctly would mean cross-calling into `contracts/timelock` too,
+    /// mirroring its ready/expiry math — out of scope here), so a bond
+    /// behind such a proposal would otherwise be locked forever. Once
+    /// `MaxLockLedgers` has elapsed since `lock_bond`, refund is allowed
+    /// unconditionally, regardless of the correlated proposal's state.
     pub fn refund_bond(env: Env, caller: Address, description_hash: BytesN<32>, proposal_id: u64) {
         caller.require_auth();
 
@@ -201,40 +231,51 @@ impl ProposalBondsContract {
             env.panic_with_error(ProposalBondsError::BondNotLocked);
         }
 
-        let governor = Self::get_governor(&env);
-        let governor_client = GovernorClient::new(&env, &governor);
-
-        let proposal = governor_client.get_proposal(&proposal_id);
-        if proposal.description_hash != description_hash {
-            env.panic_with_error(ProposalBondsError::DescriptionHashMismatch);
-        }
-
-        let state = governor_client.state(&proposal_id);
-        let is_terminal = matches!(
-            state,
-            ProposalState::Executed
-                | ProposalState::Defeated
-                | ProposalState::Expired
-                | ProposalState::Cancelled
-        );
-        if !is_terminal {
-            env.panic_with_error(ProposalBondsError::ProposalNotTerminal);
-        }
-
-        // Gate refunds on `proposal.end_ledger` (the ledger voting closed and
-        // the proposal became terminal-bound) rather than tracking a
-        // separate "first observed terminal" ledger locally: it's already
-        // returned by `get_proposal`, deterministic across repeated calls,
-        // and gives the community a fixed `RefundGraceLedgers` window after
-        // voting ends to submit a `slash` proposal before funds move.
-        let grace_ledgers: u32 = env
+        let max_lock_ledgers: u32 = env
             .storage()
             .instance()
-            .get(&DataKey::RefundGraceLedgers)
-            .unwrap_or(0);
-        let refund_eligible_ledger = proposal.end_ledger.saturating_add(grace_ledgers);
-        if env.ledger().sequence() < refund_eligible_ledger {
-            env.panic_with_error(ProposalBondsError::RefundGraceNotElapsed);
+            .get(&DataKey::MaxLockLedgers)
+            .unwrap_or(BOND_TTL_LEDGERS);
+        let escape_hatch_ledger = bond.locked_ledger.saturating_add(max_lock_ledgers);
+        let past_max_lock = env.ledger().sequence() >= escape_hatch_ledger;
+
+        if !past_max_lock {
+            let governor = Self::get_governor(&env);
+            let governor_client = GovernorClient::new(&env, &governor);
+
+            let proposal = governor_client.get_proposal(&proposal_id);
+            if proposal.description_hash != description_hash {
+                env.panic_with_error(ProposalBondsError::DescriptionHashMismatch);
+            }
+
+            let state = governor_client.state(&proposal_id);
+            let is_terminal = matches!(
+                state,
+                ProposalState::Executed
+                    | ProposalState::Defeated
+                    | ProposalState::Expired
+                    | ProposalState::Cancelled
+            );
+            if !is_terminal {
+                env.panic_with_error(ProposalBondsError::ProposalNotTerminal);
+            }
+
+            // Gate refunds on `proposal.end_ledger` (the ledger voting closed
+            // and the proposal became terminal-bound) rather than tracking a
+            // separate "first observed terminal" ledger locally: it's
+            // already returned by `get_proposal`, deterministic across
+            // repeated calls, and gives the community a fixed
+            // `RefundGraceLedgers` window after voting ends to submit a
+            // `slash` proposal before funds move.
+            let grace_ledgers: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::RefundGraceLedgers)
+                .unwrap_or(0);
+            let refund_eligible_ledger = proposal.end_ledger.saturating_add(grace_ledgers);
+            if env.ledger().sequence() < refund_eligible_ledger {
+                env.panic_with_error(ProposalBondsError::RefundGraceNotElapsed);
+            }
         }
 
         let bond_token = Self::get_bond_token(&env);
@@ -301,7 +342,35 @@ impl ProposalBondsContract {
         if admin != stored_admin {
             env.panic_with_error(ProposalBondsError::NotAuthorized);
         }
+        if new_amount <= 0 {
+            env.panic_with_error(ProposalBondsError::InvalidBondAmount);
+        }
         env.storage().instance().set(&DataKey::BondAmount, &new_amount);
+    }
+
+    /// Read-only settings snapshot — lets callers (e.g. the frontend) work
+    /// out refund eligibility for a `Locked` bond without guessing at
+    /// `RefundGraceLedgers`/`MaxLockLedgers`.
+    pub fn get_settings(env: Env) -> BondSettings {
+        BondSettings {
+            bond_token: Self::get_bond_token(&env),
+            bond_amount: env
+                .storage()
+                .instance()
+                .get(&DataKey::BondAmount)
+                .unwrap_or_else(|| env.panic_with_error(ProposalBondsError::NotInitialized)),
+            governor: Self::get_governor(&env),
+            refund_grace_ledgers: env
+                .storage()
+                .instance()
+                .get(&DataKey::RefundGraceLedgers)
+                .unwrap_or(0),
+            max_lock_ledgers: env
+                .storage()
+                .instance()
+                .get(&DataKey::MaxLockLedgers)
+                .unwrap_or(BOND_TTL_LEDGERS),
+        }
     }
 }
 

--- a/contracts/proposal-bonds/src/lib.rs
+++ b/contracts/proposal-bonds/src/lib.rs
@@ -1,0 +1,309 @@
+#![no_std]
+
+pub mod error;
+mod events;
+
+use crate::error::ProposalBondsError;
+use soroban_sdk::{
+    contract, contractclient, contractimpl, contracttype, token, Address, Bytes, BytesN, Env,
+    String, Symbol, Vec,
+};
+
+/// Mirrors `contracts/governor`'s `Proposal` and `ProposalState` types
+/// field-for-field so cross-contract calls decode correctly, without taking
+/// a crate dependency on governor (which is already near the CI WASM size
+/// cap and must not be modified for this feature).
+#[contracttype]
+#[derive(Clone)]
+pub struct Proposal {
+    pub id: u64,
+    pub proposer: Address,
+    pub description: String,
+    pub description_hash: BytesN<32>,
+    pub metadata_uri: String,
+    pub targets: Vec<Address>,
+    pub fn_names: Vec<Symbol>,
+    pub calldatas: Vec<Bytes>,
+    pub start_ledger: u32,
+    pub end_ledger: u32,
+    pub votes_for: i128,
+    pub votes_against: i128,
+    pub votes_abstain: i128,
+    pub executed: bool,
+    pub cancelled: bool,
+    pub queued: bool,
+    pub op_ids: Vec<Bytes>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum ProposalState {
+    Pending,
+    Active,
+    Defeated,
+    Succeeded,
+    Queued,
+    Executed,
+    Cancelled,
+    Expired,
+}
+
+#[contractclient(name = "GovernorClient")]
+pub trait GovernorTrait {
+    fn get_proposal(env: Env, proposal_id: u64) -> Proposal;
+    fn state(env: Env, proposal_id: u64) -> ProposalState;
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum BondState {
+    Locked,
+    Refunded,
+    Slashed,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Bond {
+    pub proposer: Address,
+    pub description_hash: BytesN<32>,
+    pub amount: i128,
+    pub locked_ledger: u32,
+    pub state: BondState,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    BondToken,
+    BondAmount,
+    Governor,
+    Bond(BytesN<32>),
+    RefundGraceLedgers,
+}
+
+/// ~1,000,000 ledgers (~58 days at the network's ~5s ledger close time),
+/// generously covering the longest realistic proposal lifecycle plus its
+/// post-terminal refund grace window.
+const BOND_TTL_LEDGERS: u32 = 1_000_000;
+
+#[contract]
+pub struct ProposalBondsContract;
+
+#[contractimpl]
+impl ProposalBondsContract {
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        bond_token: Address,
+        bond_amount: i128,
+        governor: Address,
+        refund_grace_ledgers: u32,
+    ) {
+        admin.require_auth();
+        if env.storage().instance().has(&DataKey::Admin) {
+            env.panic_with_error(ProposalBondsError::AlreadyInitialized);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::BondToken, &bond_token);
+        env.storage().instance().set(&DataKey::BondAmount, &bond_amount);
+        env.storage().instance().set(&DataKey::Governor, &governor);
+        env.storage()
+            .instance()
+            .set(&DataKey::RefundGraceLedgers, &refund_grace_ledgers);
+    }
+
+    fn must_get_bond(env: &Env, description_hash: &BytesN<32>) -> Bond {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Bond(description_hash.clone()))
+            .unwrap_or_else(|| env.panic_with_error(ProposalBondsError::BondNotFound))
+    }
+
+    fn get_governor(env: &Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::Governor)
+            .unwrap_or_else(|| env.panic_with_error(ProposalBondsError::NotInitialized))
+    }
+
+    fn get_bond_token(env: &Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::BondToken)
+            .unwrap_or_else(|| env.panic_with_error(ProposalBondsError::NotInitialized))
+    }
+
+    /// Lock the configured bond amount from `proposer`, keyed by
+    /// `description_hash` so it correlates 1:1 with the governor proposal
+    /// the caller submits alongside it (bonding and proposing are two
+    /// separate transactions, correlated off-chain by this shared hash).
+    pub fn lock_bond(env: Env, proposer: Address, description_hash: BytesN<32>) {
+        proposer.require_auth();
+
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::Bond(description_hash.clone()))
+        {
+            env.panic_with_error(ProposalBondsError::BondAlreadyLocked);
+        }
+
+        let bond_amount: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::BondAmount)
+            .unwrap_or_else(|| env.panic_with_error(ProposalBondsError::NotInitialized));
+        let bond_token = Self::get_bond_token(&env);
+
+        token::TokenClient::new(&env, &bond_token).transfer(
+            &proposer,
+            &env.current_contract_address(),
+            &bond_amount,
+        );
+
+        let bond = Bond {
+            proposer: proposer.clone(),
+            description_hash: description_hash.clone(),
+            amount: bond_amount,
+            locked_ledger: env.ledger().sequence(),
+            state: BondState::Locked,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Bond(description_hash.clone()), &bond);
+        // A locked bond must outlive the full governor proposal lifecycle
+        // (voting delay + voting period + grace period) plus this contract's
+        // own post-terminal RefundGraceLedgers window before refund_bond or
+        // slash can act on it, so bump its TTL by a generous fixed buffer
+        // rather than trying to read governor's settings cross-contract here.
+        env.storage().persistent().extend_ttl(
+            &DataKey::Bond(description_hash.clone()),
+            BOND_TTL_LEDGERS,
+            BOND_TTL_LEDGERS,
+        );
+
+        events::emit_bond_locked(&env, &proposer, &description_hash, bond_amount);
+    }
+
+    /// Refund a locked bond once its matching governor proposal (identified
+    /// by `proposal_id`, whose `description_hash` must match this bond's)
+    /// has reached a terminal, non-malicious state and the post-terminal
+    /// `RefundGraceLedgers` window — during which the community can instead
+    /// submit a `slash` governance proposal — has elapsed. Permissionless:
+    /// anyone may trigger it, but funds always return to the original
+    /// proposer.
+    pub fn refund_bond(env: Env, caller: Address, description_hash: BytesN<32>, proposal_id: u64) {
+        caller.require_auth();
+
+        let mut bond = Self::must_get_bond(&env, &description_hash);
+        if bond.state != BondState::Locked {
+            env.panic_with_error(ProposalBondsError::BondNotLocked);
+        }
+
+        let governor = Self::get_governor(&env);
+        let governor_client = GovernorClient::new(&env, &governor);
+
+        let proposal = governor_client.get_proposal(&proposal_id);
+        if proposal.description_hash != description_hash {
+            env.panic_with_error(ProposalBondsError::DescriptionHashMismatch);
+        }
+
+        let state = governor_client.state(&proposal_id);
+        let is_terminal = matches!(
+            state,
+            ProposalState::Executed
+                | ProposalState::Defeated
+                | ProposalState::Expired
+                | ProposalState::Cancelled
+        );
+        if !is_terminal {
+            env.panic_with_error(ProposalBondsError::ProposalNotTerminal);
+        }
+
+        // Gate refunds on `proposal.end_ledger` (the ledger voting closed and
+        // the proposal became terminal-bound) rather than tracking a
+        // separate "first observed terminal" ledger locally: it's already
+        // returned by `get_proposal`, deterministic across repeated calls,
+        // and gives the community a fixed `RefundGraceLedgers` window after
+        // voting ends to submit a `slash` proposal before funds move.
+        let grace_ledgers: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RefundGraceLedgers)
+            .unwrap_or(0);
+        let refund_eligible_ledger = proposal.end_ledger.saturating_add(grace_ledgers);
+        if env.ledger().sequence() < refund_eligible_ledger {
+            env.panic_with_error(ProposalBondsError::RefundGraceNotElapsed);
+        }
+
+        let bond_token = Self::get_bond_token(&env);
+        token::TokenClient::new(&env, &bond_token).transfer(
+            &env.current_contract_address(),
+            &bond.proposer,
+            &bond.amount,
+        );
+
+        bond.state = BondState::Refunded;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Bond(description_hash.clone()), &bond);
+
+        events::emit_bond_refunded(&env, &description_hash, &bond.proposer, bond.amount);
+    }
+
+    /// Slash a locked bond, sending its funds to `recipient` instead of the
+    /// proposer. Only callable as the target of an executed governance
+    /// proposal (i.e. `caller` must be the governor contract's own
+    /// address) — this is how the community judges a proposal to have been
+    /// spam, duplicated, or malicious.
+    pub fn slash(env: Env, caller: Address, description_hash: BytesN<32>, recipient: Address) {
+        caller.require_auth();
+
+        let governor = Self::get_governor(&env);
+        if caller != governor {
+            env.panic_with_error(ProposalBondsError::NotAuthorized);
+        }
+
+        let mut bond = Self::must_get_bond(&env, &description_hash);
+        if bond.state != BondState::Locked {
+            env.panic_with_error(ProposalBondsError::BondNotLocked);
+        }
+
+        let bond_token = Self::get_bond_token(&env);
+        token::TokenClient::new(&env, &bond_token).transfer(
+            &env.current_contract_address(),
+            &recipient,
+            &bond.amount,
+        );
+
+        bond.state = BondState::Slashed;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Bond(description_hash.clone()), &bond);
+
+        events::emit_bond_slashed(&env, &description_hash, &bond.proposer, bond.amount, &recipient);
+    }
+
+    pub fn get_bond(env: Env, description_hash: BytesN<32>) -> Option<Bond> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Bond(description_hash))
+    }
+
+    pub fn update_bond_amount(env: Env, admin: Address, new_amount: i128) {
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| env.panic_with_error(ProposalBondsError::NotInitialized));
+        admin.require_auth();
+        if admin != stored_admin {
+            env.panic_with_error(ProposalBondsError::NotAuthorized);
+        }
+        env.storage().instance().set(&DataKey::BondAmount, &new_amount);
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/contracts/proposal-bonds/src/tests.rs
+++ b/contracts/proposal-bonds/src/tests.rs
@@ -63,6 +63,7 @@ impl MockGovernorContract {
 
 const BOND_AMOUNT: i128 = 1_000;
 const GRACE_LEDGERS: u32 = 100;
+const MAX_LOCK_LEDGERS: u32 = 1_000;
 
 /// Deploy a fresh SAC token, a mock governor, and an initialized
 /// proposal-bonds contract. Returns (client, token, proposer, governor_id).
@@ -78,7 +79,14 @@ fn setup(env: &Env) -> (ProposalBondsContractClient<'static>, Address, Address, 
 
     let contract_id = env.register(ProposalBondsContract, ());
     let client = ProposalBondsContractClient::new(env, &contract_id);
-    client.initialize(&admin, &token_addr, &BOND_AMOUNT, &governor_id, &GRACE_LEDGERS);
+    client.initialize(
+        &admin,
+        &token_addr,
+        &BOND_AMOUNT,
+        &governor_id,
+        &GRACE_LEDGERS,
+        &MAX_LOCK_LEDGERS,
+    );
 
     (client, token_addr, proposer, governor_id)
 }
@@ -273,7 +281,14 @@ fn test_update_bond_amount_by_admin() {
     let governor_id = env.register(MockGovernorContract, ());
     let contract_id = env.register(ProposalBondsContract, ());
     let client = ProposalBondsContractClient::new(&env, &contract_id);
-    client.initialize(&admin, &token_addr, &BOND_AMOUNT, &governor_id, &GRACE_LEDGERS);
+    client.initialize(
+        &admin,
+        &token_addr,
+        &BOND_AMOUNT,
+        &governor_id,
+        &GRACE_LEDGERS,
+        &MAX_LOCK_LEDGERS,
+    );
 
     client.update_bond_amount(&admin, &2_000i128);
 
@@ -306,6 +321,116 @@ fn test_initialize_rejects_reinitialization() {
     let governor_id = env.register(MockGovernorContract, ());
     let contract_id = env.register(ProposalBondsContract, ());
     let client = ProposalBondsContractClient::new(&env, &contract_id);
-    client.initialize(&admin, &token_addr, &BOND_AMOUNT, &governor_id, &GRACE_LEDGERS);
-    client.initialize(&admin, &token_addr, &BOND_AMOUNT, &governor_id, &GRACE_LEDGERS);
+    client.initialize(
+        &admin,
+        &token_addr,
+        &BOND_AMOUNT,
+        &governor_id,
+        &GRACE_LEDGERS,
+        &MAX_LOCK_LEDGERS,
+    );
+    client.initialize(
+        &admin,
+        &token_addr,
+        &BOND_AMOUNT,
+        &governor_id,
+        &GRACE_LEDGERS,
+        &MAX_LOCK_LEDGERS,
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_initialize_rejects_zero_bond_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_addr = sac.address();
+    let governor_id = env.register(MockGovernorContract, ());
+    let contract_id = env.register(ProposalBondsContract, ());
+    let client = ProposalBondsContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &token_addr, &0i128, &governor_id, &GRACE_LEDGERS, &MAX_LOCK_LEDGERS);
+}
+
+#[test]
+#[should_panic]
+fn test_update_bond_amount_rejects_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_addr = sac.address();
+    let governor_id = env.register(MockGovernorContract, ());
+    let contract_id = env.register(ProposalBondsContract, ());
+    let client = ProposalBondsContractClient::new(&env, &contract_id);
+    client.initialize(
+        &admin,
+        &token_addr,
+        &BOND_AMOUNT,
+        &governor_id,
+        &GRACE_LEDGERS,
+        &MAX_LOCK_LEDGERS,
+    );
+    client.update_bond_amount(&admin, &0i128);
+}
+
+/// A proposal stuck in `Queued` forever (its timelock execution window
+/// closed without `execute()` ever being called) has no path to a
+/// governor-reported terminal state — see the doc comment on
+/// `refund_bond`. Once `MaxLockLedgers` has elapsed since `lock_bond`,
+/// refund must succeed regardless, so the bond isn't locked up forever.
+#[test]
+fn test_refund_escape_hatch_after_max_lock_ledgers_even_if_stuck_queued() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token_addr, proposer, gov) = setup(&env);
+    let tok = token::TokenClient::new(&env, &token_addr);
+    let h = hash(&env, 1);
+    client.lock_bond(&proposer, &h);
+
+    let gov_client = MockGovernorContractClient::new(&env, &gov);
+    gov_client.set_proposal(&1u64, &h);
+    gov_client.set_state(&1u64, &ProposalState::Queued);
+
+    let balance_before_refund = tok.balance(&proposer);
+
+    env.ledger().with_mut(|l| l.sequence_number += MAX_LOCK_LEDGERS + 1);
+    client.refund_bond(&proposer, &h, &1u64);
+
+    assert_eq!(tok.balance(&proposer), balance_before_refund + BOND_AMOUNT);
+    let bond = client.get_bond(&h).unwrap();
+    assert_eq!(bond.state, BondState::Refunded);
+}
+
+#[test]
+#[should_panic]
+fn test_refund_stuck_queued_before_max_lock_ledgers_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _token, proposer, gov) = setup(&env);
+    let h = hash(&env, 1);
+    client.lock_bond(&proposer, &h);
+
+    let gov_client = MockGovernorContractClient::new(&env, &gov);
+    gov_client.set_proposal(&1u64, &h);
+    gov_client.set_state(&1u64, &ProposalState::Queued);
+
+    // Still well before MAX_LOCK_LEDGERS — Queued must not be refundable
+    // early, since the proposal could still be executed.
+    client.refund_bond(&proposer, &h, &1u64);
+}
+
+#[test]
+fn test_get_settings_reflects_initialize_args() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token_addr, _proposer, gov) = setup(&env);
+
+    let settings = client.get_settings();
+    assert_eq!(settings.bond_token, token_addr);
+    assert_eq!(settings.bond_amount, BOND_AMOUNT);
+    assert_eq!(settings.governor, gov);
+    assert_eq!(settings.refund_grace_ledgers, GRACE_LEDGERS);
+    assert_eq!(settings.max_lock_ledgers, MAX_LOCK_LEDGERS);
 }

--- a/contracts/proposal-bonds/src/tests.rs
+++ b/contracts/proposal-bonds/src/tests.rs
@@ -1,0 +1,311 @@
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    token, Env,
+};
+
+#[contract]
+pub struct MockGovernorContract;
+
+#[contracttype]
+enum MockGovKey {
+    Proposal(u64),
+    State(u64),
+}
+
+#[contractimpl]
+impl MockGovernorContract {
+    pub fn set_proposal(env: Env, proposal_id: u64, description_hash: BytesN<32>) {
+        let proposal = Proposal {
+            id: proposal_id,
+            proposer: Address::generate(&env),
+            description: String::from_str(&env, "d"),
+            description_hash,
+            metadata_uri: String::from_str(&env, ""),
+            targets: Vec::new(&env),
+            fn_names: Vec::new(&env),
+            calldatas: Vec::new(&env),
+            start_ledger: 0,
+            end_ledger: 0,
+            votes_for: 0,
+            votes_against: 0,
+            votes_abstain: 0,
+            executed: false,
+            cancelled: false,
+            queued: false,
+            op_ids: Vec::new(&env),
+        };
+        env.storage()
+            .instance()
+            .set(&MockGovKey::Proposal(proposal_id), &proposal);
+    }
+
+    pub fn set_state(env: Env, proposal_id: u64, state: ProposalState) {
+        env.storage()
+            .instance()
+            .set(&MockGovKey::State(proposal_id), &state);
+    }
+
+    pub fn get_proposal(env: Env, proposal_id: u64) -> Proposal {
+        env.storage()
+            .instance()
+            .get(&MockGovKey::Proposal(proposal_id))
+            .unwrap()
+    }
+
+    pub fn state(env: Env, proposal_id: u64) -> ProposalState {
+        env.storage()
+            .instance()
+            .get(&MockGovKey::State(proposal_id))
+            .unwrap()
+    }
+}
+
+const BOND_AMOUNT: i128 = 1_000;
+const GRACE_LEDGERS: u32 = 100;
+
+/// Deploy a fresh SAC token, a mock governor, and an initialized
+/// proposal-bonds contract. Returns (client, token, proposer, governor_id).
+fn setup(env: &Env) -> (ProposalBondsContractClient<'static>, Address, Address, Address) {
+    let admin = Address::generate(env);
+    let proposer = Address::generate(env);
+
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_addr = sac.address();
+    token::StellarAssetClient::new(env, &token_addr).mint(&proposer, &(BOND_AMOUNT * 10));
+
+    let governor_id = env.register(MockGovernorContract, ());
+
+    let contract_id = env.register(ProposalBondsContract, ());
+    let client = ProposalBondsContractClient::new(env, &contract_id);
+    client.initialize(&admin, &token_addr, &BOND_AMOUNT, &governor_id, &GRACE_LEDGERS);
+
+    (client, token_addr, proposer, governor_id)
+}
+
+fn hash(env: &Env, seed: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[seed; 32])
+}
+
+#[test]
+fn test_lock_bond_fresh_hash() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token_addr, proposer, _gov) = setup(&env);
+    let tok = token::TokenClient::new(&env, &token_addr);
+    let h = hash(&env, 1);
+
+    client.lock_bond(&proposer, &h);
+
+    assert_eq!(tok.balance(&proposer), BOND_AMOUNT * 10 - BOND_AMOUNT);
+    assert_eq!(tok.balance(&client.address), BOND_AMOUNT);
+    let bond = client.get_bond(&h).unwrap();
+    assert_eq!(bond.state, BondState::Locked);
+    assert_eq!(bond.amount, BOND_AMOUNT);
+    assert_eq!(bond.proposer, proposer);
+}
+
+#[test]
+#[should_panic]
+fn test_lock_bond_twice_same_hash_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _token, proposer, _gov) = setup(&env);
+    let h = hash(&env, 1);
+
+    client.lock_bond(&proposer, &h);
+    client.lock_bond(&proposer, &h);
+}
+
+#[test]
+#[should_panic]
+fn test_refund_before_grace_elapsed_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _token, proposer, gov) = setup(&env);
+    let h = hash(&env, 1);
+    client.lock_bond(&proposer, &h);
+
+    let gov_client = MockGovernorContractClient::new(&env, &gov);
+    gov_client.set_proposal(&1u64, &h);
+    gov_client.set_state(&1u64, &ProposalState::Executed);
+
+    // No ledgers advanced past proposal.end_ledger (0) + grace (100) yet.
+    client.refund_bond(&proposer, &h, &1u64);
+}
+
+#[test]
+fn test_refund_succeeds_after_terminal_state_and_grace() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token_addr, proposer, gov) = setup(&env);
+    let tok = token::TokenClient::new(&env, &token_addr);
+    let h = hash(&env, 1);
+    client.lock_bond(&proposer, &h);
+
+    let gov_client = MockGovernorContractClient::new(&env, &gov);
+    gov_client.set_proposal(&1u64, &h);
+    gov_client.set_state(&1u64, &ProposalState::Executed);
+
+    let balance_before_refund = tok.balance(&proposer);
+
+    env.ledger().with_mut(|l| l.sequence_number += GRACE_LEDGERS + 1);
+    client.refund_bond(&proposer, &h, &1u64);
+
+    assert_eq!(tok.balance(&proposer), balance_before_refund + BOND_AMOUNT);
+    assert_eq!(tok.balance(&client.address), 0);
+    let bond = client.get_bond(&h).unwrap();
+    assert_eq!(bond.state, BondState::Refunded);
+}
+
+#[test]
+#[should_panic]
+fn test_slash_by_non_governor_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _token, proposer, _gov) = setup(&env);
+    let h = hash(&env, 1);
+    client.lock_bond(&proposer, &h);
+
+    let attacker = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    client.slash(&attacker, &h, &recipient);
+}
+
+#[test]
+fn test_slash_succeeds_with_governor_self_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token_addr, proposer, gov) = setup(&env);
+    let tok = token::TokenClient::new(&env, &token_addr);
+    let h = hash(&env, 1);
+    client.lock_bond(&proposer, &h);
+
+    let recipient = Address::generate(&env);
+
+    client.slash(&gov, &h, &recipient);
+
+    assert_eq!(tok.balance(&recipient), BOND_AMOUNT);
+    assert_eq!(tok.balance(&client.address), 0);
+    let bond = client.get_bond(&h).unwrap();
+    assert_eq!(bond.state, BondState::Slashed);
+}
+
+#[test]
+#[should_panic]
+fn test_refund_on_already_slashed_bond_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _token, proposer, gov) = setup(&env);
+    let h = hash(&env, 1);
+    client.lock_bond(&proposer, &h);
+
+    let recipient = Address::generate(&env);
+    client.slash(&gov, &h, &recipient);
+
+    let gov_client = MockGovernorContractClient::new(&env, &gov);
+    gov_client.set_proposal(&1u64, &h);
+    gov_client.set_state(&1u64, &ProposalState::Executed);
+    env.ledger().with_mut(|l| l.sequence_number += GRACE_LEDGERS + 1);
+
+    client.refund_bond(&proposer, &h, &1u64);
+}
+
+#[test]
+#[should_panic]
+fn test_slash_on_already_refunded_bond_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _token, proposer, gov) = setup(&env);
+    let h = hash(&env, 1);
+    client.lock_bond(&proposer, &h);
+
+    let gov_client = MockGovernorContractClient::new(&env, &gov);
+    gov_client.set_proposal(&1u64, &h);
+    gov_client.set_state(&1u64, &ProposalState::Executed);
+    env.ledger().with_mut(|l| l.sequence_number += GRACE_LEDGERS + 1);
+    client.refund_bond(&proposer, &h, &1u64);
+
+    let recipient = Address::generate(&env);
+    client.slash(&gov, &h, &recipient);
+}
+
+#[test]
+#[should_panic]
+fn test_refund_before_terminal_state_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _token, proposer, gov) = setup(&env);
+    let h = hash(&env, 1);
+    client.lock_bond(&proposer, &h);
+
+    let gov_client = MockGovernorContractClient::new(&env, &gov);
+    gov_client.set_proposal(&1u64, &h);
+    gov_client.set_state(&1u64, &ProposalState::Active);
+
+    client.refund_bond(&proposer, &h, &1u64);
+}
+
+#[test]
+#[should_panic]
+fn test_refund_with_mismatched_description_hash_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _token, proposer, gov) = setup(&env);
+    let h = hash(&env, 1);
+    let other_hash = hash(&env, 2);
+    client.lock_bond(&proposer, &h);
+
+    let gov_client = MockGovernorContractClient::new(&env, &gov);
+    gov_client.set_proposal(&1u64, &other_hash);
+    gov_client.set_state(&1u64, &ProposalState::Executed);
+
+    client.refund_bond(&proposer, &h, &1u64);
+}
+
+#[test]
+fn test_update_bond_amount_by_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_addr = sac.address();
+    let governor_id = env.register(MockGovernorContract, ());
+    let contract_id = env.register(ProposalBondsContract, ());
+    let client = ProposalBondsContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &token_addr, &BOND_AMOUNT, &governor_id, &GRACE_LEDGERS);
+
+    client.update_bond_amount(&admin, &2_000i128);
+
+    let proposer = Address::generate(&env);
+    token::StellarAssetClient::new(&env, &token_addr).mint(&proposer, &5_000i128);
+    let h = hash(&env, 1);
+    client.lock_bond(&proposer, &h);
+    assert_eq!(client.get_bond(&h).unwrap().amount, 2_000);
+}
+
+#[test]
+#[should_panic]
+fn test_uninitialized_lock_bond_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(ProposalBondsContract, ());
+    let client = ProposalBondsContractClient::new(&env, &contract_id);
+    let proposer = Address::generate(&env);
+    client.lock_bond(&proposer, &hash(&env, 1));
+}
+
+#[test]
+#[should_panic]
+fn test_initialize_rejects_reinitialization() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_addr = sac.address();
+    let governor_id = env.register(MockGovernorContract, ());
+    let contract_id = env.register(ProposalBondsContract, ());
+    let client = ProposalBondsContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &token_addr, &BOND_AMOUNT, &governor_id, &GRACE_LEDGERS);
+    client.initialize(&admin, &token_addr, &BOND_AMOUNT, &governor_id, &GRACE_LEDGERS);
+}

--- a/packages/indexer/migrations/012_add_proposal_bonds.sql
+++ b/packages/indexer/migrations/012_add_proposal_bonds.sql
@@ -1,0 +1,26 @@
+-- Up Migration
+
+ALTER TABLE proposals ADD COLUMN IF NOT EXISTS description_hash TEXT;
+CREATE INDEX IF NOT EXISTS idx_proposals_description_hash ON proposals(description_hash);
+
+CREATE TABLE IF NOT EXISTS proposal_bonds (
+    id SERIAL PRIMARY KEY,
+    description_hash TEXT NOT NULL UNIQUE,
+    proposer_address VARCHAR(56) NOT NULL,
+    amount NUMERIC NOT NULL,
+    state VARCHAR(16) NOT NULL DEFAULT 'locked',
+    locked_ledger INTEGER NOT NULL,
+    refunded_ledger INTEGER,
+    slashed_ledger INTEGER,
+    slash_recipient VARCHAR(56),
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_proposal_bonds_proposer ON proposal_bonds(proposer_address);
+CREATE INDEX IF NOT EXISTS idx_proposal_bonds_state ON proposal_bonds(state);
+
+-- Down Migration
+
+DROP TABLE IF EXISTS proposal_bonds;
+DROP INDEX IF EXISTS idx_proposals_description_hash;
+ALTER TABLE proposals DROP COLUMN IF EXISTS description_hash;

--- a/packages/indexer/src/api.ts
+++ b/packages/indexer/src/api.ts
@@ -118,6 +118,7 @@ const TTL = {
   analytics: 30_000, // 30 seconds
   reputation: 30_000, // 30 seconds
   treasury: 30_000, // 30 seconds
+  proposalBonds: 30_000, // 30 seconds
 };
 
 function parsePagination(
@@ -545,6 +546,30 @@ export function createApp(server: SorobanRpc.Server): express.Application {
       res.status(500).json({ error: "Internal server error" });
     }
   });
+
+  // GET /proposals/by-description-hash/:hash — used by proposal-bonds
+  // refund flow to resolve the proposal_id a bond correlates with, since
+  // the bonds contract's refund_bond requires it (governor has no
+  // description_hash → id lookup on-chain, see contracts/proposal-bonds).
+  app.get(
+    "/proposals/by-description-hash/:hash",
+    async (req: Request, res: Response): Promise<void> => {
+      const { hash } = req.params;
+      try {
+        const result = await pool.query(
+          `SELECT * FROM proposals WHERE description_hash = $1`,
+          [hash],
+        );
+        if (!result.rows[0]) {
+          res.status(404).json({ error: "Proposal not found" });
+          return;
+        }
+        res.json(result.rows[0]);
+      } catch {
+        res.status(500).json({ error: "Internal server error" });
+      }
+    },
+  );
 
   // GET /proposals/:id/votes
   app.get(
@@ -1808,6 +1833,79 @@ export function createApp(server: SorobanRpc.Server): express.Application {
           [draftId],
         );
         res.json({ data: result.rows });
+      } catch {
+        res.status(500).json({ error: "Internal server error" });
+      }
+    },
+  );
+
+  // --- Proposal bonds endpoints (#996) ---
+
+  // GET /proposal-bonds?state=locked|refunded|slashed
+  app.get("/proposal-bonds", async (req: Request, res: Response): Promise<void> => {
+    const limit = Math.min(Number(req.query.limit ?? 20), 100);
+    const page = Math.max(1, Number(req.query.page ?? 1));
+    const state = req.query.state ? String(req.query.state).trim() : undefined;
+    const validStates = ["locked", "refunded", "slashed"];
+    if (state && !validStates.includes(state)) {
+      res.status(400).json({ error: "Invalid state filter" });
+      return;
+    }
+    const key = `proposal-bonds:list:${state ?? ""}:${page}:${limit}`;
+
+    try {
+      const whereClause = state ? "WHERE state = $3" : "";
+      const params = state
+        ? [limit, (page - 1) * limit, state]
+        : [limit, (page - 1) * limit];
+      const data = await cached(key, TTL.proposalBonds, async () => {
+        const result = await pool.query(
+          `SELECT * FROM proposal_bonds ${whereClause} ORDER BY id DESC LIMIT $1 OFFSET $2`,
+          params,
+        );
+        return {
+          data: result.rows,
+          pagination: { page, limit, hasMore: result.rows.length === limit },
+        };
+      });
+      res.json(data);
+    } catch {
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  // GET /proposal-bonds/by-proposer/:address
+  app.get(
+    "/proposal-bonds/by-proposer/:address",
+    async (req: Request, res: Response): Promise<void> => {
+      const { address } = req.params;
+      try {
+        const result = await pool.query(
+          `SELECT * FROM proposal_bonds WHERE proposer_address = $1 ORDER BY id DESC`,
+          [address],
+        );
+        res.json({ data: result.rows });
+      } catch {
+        res.status(500).json({ error: "Internal server error" });
+      }
+    },
+  );
+
+  // GET /proposal-bonds/:descriptionHash
+  app.get(
+    "/proposal-bonds/:descriptionHash",
+    async (req: Request, res: Response): Promise<void> => {
+      const { descriptionHash } = req.params;
+      try {
+        const result = await pool.query(
+          `SELECT * FROM proposal_bonds WHERE description_hash = $1`,
+          [descriptionHash],
+        );
+        if (!result.rows[0]) {
+          res.status(404).json({ error: "Bond not found" });
+          return;
+        }
+        res.json(result.rows[0]);
       } catch {
         res.status(500).json({ error: "Internal server error" });
       }

--- a/packages/indexer/src/events.ts
+++ b/packages/indexer/src/events.ts
@@ -62,6 +62,7 @@ export interface IndexerConfig {
   treasuryAddress?: string;
   liquidityAddress?: string;
   coSponsorshipAddress?: string;
+  proposalBondsAddress?: string;
   tokenVotesAddress?: string;
   timelockAddress?: string;
   treasuryStateReader?: TreasuryStateReader;
@@ -94,6 +95,7 @@ export async function processEvents(
     if (config.treasuryAddress) contractIds.push(config.treasuryAddress);
     if (config.liquidityAddress) contractIds.push(config.liquidityAddress);
     if (config.coSponsorshipAddress) contractIds.push(config.coSponsorshipAddress);
+    if (config.proposalBondsAddress) contractIds.push(config.proposalBondsAddress);
     if (config.tokenVotesAddress) contractIds.push(config.tokenVotesAddress);
     if (config.timelockAddress) contractIds.push(config.timelockAddress);
 
@@ -135,6 +137,11 @@ export async function processEvents(
         contractId &&
         config.coSponsorshipAddress &&
         contractId === config.coSponsorshipAddress
+      );
+      const isProposalBonds = !!(
+        contractId &&
+        config.proposalBondsAddress &&
+        contractId === config.proposalBondsAddress
       );
       const isTokenVotes = !!(
         contractId &&
@@ -229,6 +236,20 @@ export async function processEvents(
               break;
             case "DraftExpired":
               await handleDraftExpired(event);
+              break;
+            default:
+              break;
+          }
+        } else if (isProposalBonds) {
+          switch (eventType) {
+            case "BondLocked":
+              await handleBondLocked(event, topics);
+              break;
+            case "BondRefunded":
+              await handleBondRefunded(event, topics);
+              break;
+            case "BondSlashed":
+              await handleBondSlashed(event, topics);
               break;
             default:
               break;
@@ -438,6 +459,7 @@ async function handleProposalCreated(
   let id: bigint;
   let proposer: string;
   let description: string;
+  let descriptionHash: string | null;
   let startLedger: number;
   let endLedger: number;
 
@@ -446,6 +468,7 @@ async function handleProposalCreated(
     id = raw[0] as bigint;
     proposer = topics[1] as string;
     description = String(raw[1] ?? "");
+    descriptionHash = null;
     startLedger = raw[5] as number;
     endLedger = raw[6] as number;
   } else {
@@ -454,16 +477,20 @@ async function handleProposalCreated(
     id = data.proposal_id as bigint;
     proposer = String(data.proposer ?? "");
     description = String(data.description ?? "");
+    const descriptionHashRaw = data.description_hash as Uint8Array | undefined;
+    descriptionHash = descriptionHashRaw
+      ? Buffer.from(descriptionHashRaw).toString("hex")
+      : null;
     startLedger = Number(data.start_ledger);
     endLedger = Number(data.end_ledger);
   }
 
   invalidatePattern("proposals:");
   await pool.query(
-    `INSERT INTO proposals (id, proposer, description, start_ledger, end_ledger)
-     VALUES ($1, $2, $3, $4, $5)
+    `INSERT INTO proposals (id, proposer, description, description_hash, start_ledger, end_ledger)
+     VALUES ($1, $2, $3, $4, $5, $6)
      ON CONFLICT (id) DO NOTHING`,
-    [String(id), proposer, description, startLedger, endLedger],
+    [String(id), proposer, description, descriptionHash, startLedger, endLedger],
   );
   invalidate(`profile:${proposer}`);
   broadcast({
@@ -1127,6 +1154,69 @@ async function handleDraftExpired(
   broadcast({
     type: "draft_expired",
     data: { draft_id: draftId, ledger: event.ledger },
+  });
+}
+
+async function handleBondLocked(
+  event: SorobanRpc.Api.EventResponse,
+  topics: unknown[],
+): Promise<void> {
+  const proposer = topics[1] as string;
+  const data = scValToNative(event.value) as unknown[];
+  const descriptionHash = Buffer.from(data[0] as Uint8Array).toString("hex");
+  const amount = String(data[1] as bigint);
+
+  await pool.query(
+    `INSERT INTO proposal_bonds (description_hash, proposer_address, amount, state, locked_ledger)
+     VALUES ($1, $2, $3, 'locked', $4)
+     ON CONFLICT (description_hash) DO NOTHING`,
+    [descriptionHash, proposer, amount, event.ledger],
+  );
+  invalidatePattern("proposal-bonds:");
+  broadcast({
+    type: "bond_locked",
+    data: { description_hash: descriptionHash, proposer, amount, ledger: event.ledger },
+  });
+}
+
+async function handleBondRefunded(
+  event: SorobanRpc.Api.EventResponse,
+  topics: unknown[],
+): Promise<void> {
+  const proposer = topics[1] as string;
+  const data = scValToNative(event.value) as unknown[];
+  const descriptionHash = Buffer.from(data[0] as Uint8Array).toString("hex");
+  const amount = String(data[1] as bigint);
+
+  await pool.query(
+    `UPDATE proposal_bonds SET state = 'refunded', refunded_ledger = $1 WHERE description_hash = $2`,
+    [event.ledger, descriptionHash],
+  );
+  invalidatePattern("proposal-bonds:");
+  broadcast({
+    type: "bond_refunded",
+    data: { description_hash: descriptionHash, proposer, amount, ledger: event.ledger },
+  });
+}
+
+async function handleBondSlashed(
+  event: SorobanRpc.Api.EventResponse,
+  topics: unknown[],
+): Promise<void> {
+  const proposer = topics[1] as string;
+  const data = scValToNative(event.value) as unknown[];
+  const descriptionHash = Buffer.from(data[0] as Uint8Array).toString("hex");
+  const amount = String(data[1] as bigint);
+  const recipient = data[2] as string;
+
+  await pool.query(
+    `UPDATE proposal_bonds SET state = 'slashed', slashed_ledger = $1, slash_recipient = $2 WHERE description_hash = $3`,
+    [event.ledger, recipient, descriptionHash],
+  );
+  invalidatePattern("proposal-bonds:");
+  broadcast({
+    type: "bond_slashed",
+    data: { description_hash: descriptionHash, proposer, amount, recipient, ledger: event.ledger },
   });
 }
 

--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -20,6 +20,7 @@ const WRAPPER_ADDRESS = process.env.WRAPPER_ADDRESS ?? "";
 const TREASURY_ADDRESS = process.env.TREASURY_ADDRESS ?? "";
 const LIQUIDITY_ADDRESS = process.env.LIQUIDITY_ADDRESS ?? "";
 const CO_SPONSORSHIP_ADDRESS = process.env.CO_SPONSORSHIP_ADDRESS ?? "";
+const PROPOSAL_BONDS_ADDRESS = process.env.PROPOSAL_BONDS_ADDRESS ?? "";
 const TOKEN_VOTES_ADDRESS = process.env.TOKEN_VOTES_ADDRESS ?? "";
 const TIMELOCK_ADDRESS = process.env.TIMELOCK_ADDRESS ?? "";
 const TREASURY_SIMULATION_ACCOUNT =
@@ -83,6 +84,7 @@ async function runIndexer(): Promise<void> {
     treasuryAddress: TREASURY_ADDRESS,
     liquidityAddress: LIQUIDITY_ADDRESS,
     coSponsorshipAddress: CO_SPONSORSHIP_ADDRESS,
+    proposalBondsAddress: PROPOSAL_BONDS_ADDRESS,
     tokenVotesAddress: TOKEN_VOTES_ADDRESS,
     timelockAddress: TIMELOCK_ADDRESS,
     treasuryStateReader,

--- a/packages/indexer/src/ws.ts
+++ b/packages/indexer/src/ws.ts
@@ -54,7 +54,10 @@ export type WsEventType =
   | "stream_extended"
   | "stream_topped_up"
   | "stream_exhausted"
-  | "stream_expired";
+  | "stream_expired"
+  | "bond_locked"
+  | "bond_refunded"
+  | "bond_slashed";
 
 export interface WsEvent {
   type: WsEventType;

--- a/sdk/src/__tests__/proposalBonds.test.ts
+++ b/sdk/src/__tests__/proposalBonds.test.ts
@@ -1,0 +1,90 @@
+import { Keypair, StrKey, xdr, scValToNative } from "@stellar/stellar-sdk";
+import { ProposalBondsClient } from "../proposalBonds";
+
+describe("ProposalBondsClient", () => {
+  const contractAddress = StrKey.encodeContract(Buffer.alloc(32, 1));
+
+  function makeClient(): ProposalBondsClient {
+    return new ProposalBondsClient({
+      governorAddress: contractAddress,
+      timelockAddress: contractAddress,
+      votesAddress: contractAddress,
+      proposalBondsAddress: contractAddress,
+      network: "testnet",
+    });
+  }
+
+  describe("encodeSlashCalldata", () => {
+    it("round-trips address args as ScVal.scvAddress, not scvString", () => {
+      const client = makeClient();
+      const governorAddress = contractAddress;
+      const recipient = Keypair.random().publicKey();
+      const descriptionHash = "ab".repeat(32);
+
+      const calldata = client.encodeSlashCalldata(
+        governorAddress,
+        descriptionHash,
+        recipient,
+      );
+
+      const decodedVec = xdr.ScVal.fromXDR(calldata).vec();
+      expect(decodedVec).not.toBeNull();
+      const [govArg, hashArg, recipientArg] = decodedVec!;
+
+      // The bug this guards against: encodeCalldata() has no per-arg type
+      // hint, so a plain address string silently encodes as scvString
+      // instead of scvAddress — the contract's `slash(caller: Address, ...,
+      // recipient: Address)` would then trap on execution.
+      expect(govArg.switch().name).toBe("scvAddress");
+      expect(recipientArg.switch().name).toBe("scvAddress");
+      expect(hashArg.switch().name).toBe("scvBytes");
+
+      expect(scValToNative(govArg)).toBe(governorAddress);
+      expect(scValToNative(recipientArg)).toBe(recipient);
+      expect(Buffer.from(scValToNative(hashArg) as Uint8Array).toString("hex")).toBe(
+        descriptionHash,
+      );
+    });
+  });
+
+  describe("indexer-backed query methods", () => {
+    const originalFetch = global.fetch;
+    let mockFetch: jest.Mock;
+
+    beforeEach(() => {
+      mockFetch = jest.fn();
+      global.fetch = mockFetch as unknown as typeof fetch;
+    });
+
+    afterAll(() => {
+      global.fetch = originalFetch;
+    });
+
+    it("listBonds propagates the indexer's camelCase hasMore flag", async () => {
+      const client = new ProposalBondsClient({
+        governorAddress: contractAddress,
+        timelockAddress: contractAddress,
+        votesAddress: contractAddress,
+        proposalBondsAddress: contractAddress,
+        network: "testnet",
+        indexerUrl: "https://indexer.example.com",
+        maxAttempts: 1,
+      });
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          data: [],
+          // The indexer's /proposal-bonds endpoint returns camelCase
+          // `hasMore` (packages/indexer/src/api.ts), matching every other
+          // paginated endpoint in this codebase.
+          pagination: { page: 1, limit: 20, hasMore: true },
+        }),
+      });
+
+      const result = await client.listBonds();
+
+      expect(result.pagination.hasMore).toBe(true);
+    });
+  });
+});

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -629,6 +629,95 @@ export function parseCoSponsorshipError(
   );
 }
 
+// ─── Proposal Bonds Errors ────────────────────────────────────────────────────
+
+/**
+ * Error codes for the ProposalBonds contract + SDK transport layer.
+ *
+ * Codes 1–99 mirror the on-chain ProposalBondsError enum values
+ * (contracts/proposal-bonds/src/error.rs).
+ */
+export enum ProposalBondsErrorCode {
+  AlreadyInitialized = 1,
+  NotInitialized = 2,
+  BondAlreadyLocked = 3,
+  BondNotFound = 4,
+  BondNotLocked = 5,
+  DescriptionHashMismatch = 6,
+  ProposalNotTerminal = 7,
+  RefundGraceNotElapsed = 8,
+  NotAuthorized = 9,
+
+  // SDK-level codes
+  SimulationFailed = 100,
+  TransactionFailed = 101,
+  TransactionTimeout = 102,
+  MissingReturnValue = 103,
+}
+
+const PROPOSAL_BONDS_MESSAGES: Record<ProposalBondsErrorCode, string> = {
+  [ProposalBondsErrorCode.AlreadyInitialized]: "Contract is already initialized",
+  [ProposalBondsErrorCode.NotInitialized]: "Contract has not been initialized yet",
+  [ProposalBondsErrorCode.BondAlreadyLocked]:
+    "A bond has already been locked for this description hash",
+  [ProposalBondsErrorCode.BondNotFound]: "Bond not found",
+  [ProposalBondsErrorCode.BondNotLocked]: "Bond is not in the Locked state",
+  [ProposalBondsErrorCode.DescriptionHashMismatch]:
+    "The proposal's description hash does not match this bond",
+  [ProposalBondsErrorCode.ProposalNotTerminal]:
+    "The correlated proposal has not reached a terminal state",
+  [ProposalBondsErrorCode.RefundGraceNotElapsed]:
+    "The post-terminal refund grace window has not elapsed yet",
+  [ProposalBondsErrorCode.NotAuthorized]: "Caller is not authorized to perform this action",
+  [ProposalBondsErrorCode.SimulationFailed]: "Simulation failed",
+  [ProposalBondsErrorCode.TransactionFailed]: "Transaction failed",
+  [ProposalBondsErrorCode.TransactionTimeout]: "Transaction timed out",
+  [ProposalBondsErrorCode.MissingReturnValue]: "No return value from contract",
+};
+
+export class ProposalBondsError extends Error {
+  readonly name = "ProposalBondsError";
+
+  constructor(
+    public readonly code: ProposalBondsErrorCode,
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    Object.setPrototypeOf(this, ProposalBondsError.prototype);
+  }
+}
+
+/**
+ * Parse a raw Soroban RPC error into a typed {@link ProposalBondsError}.
+ */
+export function parseProposalBondsError(
+  raw: SorobanRpcError | string | null | undefined,
+  cause?: unknown,
+): ProposalBondsError {
+  const contractCode = extractContractErrorCode(raw);
+  if (contractCode !== null) {
+    const code = contractCode as ProposalBondsErrorCode;
+    const message =
+      PROPOSAL_BONDS_MESSAGES[code] ?? `Proposal-bonds contract error #${contractCode}`;
+    return new ProposalBondsError(code, message, cause);
+  }
+
+  if (hasErrorStatus(raw)) {
+    return new ProposalBondsError(
+      ProposalBondsErrorCode.TransactionFailed,
+      `${PROPOSAL_BONDS_MESSAGES[ProposalBondsErrorCode.TransactionFailed]}: ${errorText(raw) || "unknown"}`,
+      cause,
+    );
+  }
+
+  return new ProposalBondsError(
+    ProposalBondsErrorCode.SimulationFailed,
+    `${PROPOSAL_BONDS_MESSAGES[ProposalBondsErrorCode.SimulationFailed]}: ${errorText(raw) || "unknown"}`,
+    cause,
+  );
+}
+
 /**
  * Parse a raw Soroban RPC error into a typed {@link VotesError}.
  */

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -29,6 +29,8 @@ export { WrapperClient } from "./wrapper";
 export type { WrapperConfig } from "./wrapper";
 export { CoSponsorshipClient } from "./coSponsorship";
 export type { CoSponsorshipConfig } from "./coSponsorship";
+export { ProposalBondsClient } from "./proposalBonds";
+export type { ProposalBondsConfig } from "./proposalBonds";
 export {
   GovernorError,
   GovernorErrorCode,
@@ -40,11 +42,14 @@ export {
   TreasuryErrorCode,
   CoSponsorshipError,
   CoSponsorshipErrorCode,
+  ProposalBondsError,
+  ProposalBondsErrorCode,
   parseGovernorError,
   parseTimelockError,
   parseVotesError,
   parseTreasuryError,
   parseCoSponsorshipError,
+  parseProposalBondsError,
   extractContractErrorCode,
 } from "./errors";
 export type { SorobanRpcError } from "./errors";

--- a/sdk/src/proposalBonds.ts
+++ b/sdk/src/proposalBonds.ts
@@ -9,13 +9,13 @@ import {
   scValToNative,
   xdr,
 } from "@stellar/stellar-sdk";
-import { GovernorConfig, Network, ProposalBond, BondState } from "./types";
+import { GovernorConfig, Network, ProposalBond, BondState, ProposalBondSettings } from "./types";
 import {
   ProposalBondsError,
   ProposalBondsErrorCode,
   parseProposalBondsError,
 } from "./errors";
-import { withRetry, isNetworkError, hexToBytes32, encodeCalldata } from "./utils";
+import { withRetry, isNetworkError, hexToBytes32 } from "./utils";
 
 export type ProposalBondsConfig = GovernorConfig;
 
@@ -264,7 +264,18 @@ export class ProposalBondsClient {
     descriptionHash: string,
     recipient: string,
   ): Buffer {
-    return encodeCalldata([governorAddress, hexToBytes32(descriptionHash), recipient]);
+    // Built directly with explicit per-arg type hints rather than
+    // encodeCalldata(): that helper only special-cases "0x"-prefixed
+    // strings as bytes and otherwise infers the ScVal type from the JS
+    // value, so a plain address string encodes as ScVal.scvString instead
+    // of ScVal.scvAddress — slash()'s `Address` params would trap on
+    // execution. Mirrors calldataArgRowToScVal in treasury-calldata.ts.
+    const args = xdr.ScVal.scvVec([
+      nativeToScVal(governorAddress, { type: "address" }),
+      nativeToScVal(hexToBytes32(descriptionHash), { type: "bytes" }),
+      nativeToScVal(recipient, { type: "address" }),
+    ]);
+    return Buffer.from(args.toXDR());
   }
 
   /** Get a bond by description hash, or `null` if none has been locked. */
@@ -296,6 +307,48 @@ export class ProposalBondsClient {
       const native = scValToNative(raw);
       if (native === null || native === undefined) return null;
       return this.parseBond(native as Record<string, unknown>);
+    });
+  }
+
+  /**
+   * Read the contract's configuration — bond token/amount, governor
+   * address, `RefundGraceLedgers`, and `MaxLockLedgers`. Use this to work
+   * out whether a `Locked` bond is currently refund-eligible without
+   * hardcoding those values client-side.
+   */
+  async getSettings(): Promise<ProposalBondSettings> {
+    return this.retry(async () => {
+      const result = await this.server.simulateTransaction(
+        new TransactionBuilder(
+          await this.server.getAccount(this.readAccount()),
+          { fee: BASE_FEE, networkPassphrase: this.networkPassphrase },
+        )
+          .addOperation(this.contract.call("get_settings"))
+          .setTimeout(30)
+          .build(),
+      );
+
+      if (SorobanRpc.Api.isSimulationError(result)) {
+        throw parseProposalBondsError({ status: "ERROR", error: result.error });
+      }
+
+      const raw = (result as SorobanRpc.Api.SimulateTransactionSuccessResponse)
+        .result?.retval;
+      if (!raw) {
+        throw new ProposalBondsError(
+          ProposalBondsErrorCode.MissingReturnValue,
+          "No return value from get_settings",
+        );
+      }
+
+      const native = scValToNative(raw) as Record<string, unknown>;
+      return {
+        bondToken: String(native.bond_token),
+        bondAmount: BigInt(native.bond_amount as bigint | number | string),
+        governor: String(native.governor),
+        refundGraceLedgers: Number(native.refund_grace_ledgers),
+        maxLockLedgers: Number(native.max_lock_ledgers),
+      };
     });
   }
 
@@ -360,7 +413,7 @@ export class ProposalBondsClient {
     const query = params.toString() ? `?${params.toString()}` : "";
     const raw = await this.indexerRequest<{
       data: any[];
-      pagination: { page: number; limit: number; has_more: boolean };
+      pagination: { page: number; limit: number; hasMore: boolean };
     }>(`/proposal-bonds${query}`);
 
     return {
@@ -368,7 +421,7 @@ export class ProposalBondsClient {
       pagination: {
         page: raw.pagination.page,
         limit: raw.pagination.limit,
-        hasMore: raw.pagination.has_more,
+        hasMore: raw.pagination.hasMore,
       },
     };
   }

--- a/sdk/src/proposalBonds.ts
+++ b/sdk/src/proposalBonds.ts
@@ -1,0 +1,432 @@
+import {
+  Contract,
+  SorobanRpc,
+  TransactionBuilder,
+  Networks,
+  BASE_FEE,
+  Keypair,
+  nativeToScVal,
+  scValToNative,
+  xdr,
+} from "@stellar/stellar-sdk";
+import { GovernorConfig, Network, ProposalBond, BondState } from "./types";
+import {
+  ProposalBondsError,
+  ProposalBondsErrorCode,
+  parseProposalBondsError,
+} from "./errors";
+import { withRetry, isNetworkError, hexToBytes32, encodeCalldata } from "./utils";
+
+export type ProposalBondsConfig = GovernorConfig;
+
+interface SubmitResult {
+  hash: string;
+  confirmed: SorobanRpc.Api.GetSuccessfulTransactionResponse;
+}
+
+const RPC_URLS: Record<Network, string> = {
+  mainnet: "https://soroban-rpc.mainnet.stellar.gateway.fm",
+  testnet: "https://soroban-testnet.stellar.org",
+  futurenet: "https://rpc-futurenet.stellar.org",
+};
+
+const NETWORK_PASSPHRASES: Record<Network, string> = {
+  mainnet: Networks.PUBLIC,
+  testnet: Networks.TESTNET,
+  futurenet: Networks.FUTURENET,
+};
+
+/**
+ * ProposalBondsClient — interact with a deployed NebGov proposal-bonds
+ * contract (Issue #996).
+ *
+ * Proposing costs nothing beyond meeting `proposal_threshold` in the base
+ * governor; this contract adds an optional economic deterrent against
+ * low-effort or malicious proposals: proposers post a refundable token bond
+ * alongside their proposal (correlated off-chain by a shared
+ * `descriptionHash` — bonding and proposing are two separate transactions,
+ * not enforced atomically on-chain). The bond is refunded once the
+ * correlated proposal reaches a terminal state and a post-terminal grace
+ * window elapses, or slashed by a follow-up governance vote if the
+ * community judges the proposal to have been spam, duplicated, or
+ * malicious.
+ *
+ * Note: unlike the sketch in Issue #996, `refundBond` also takes the
+ * governor `proposalId` — governor has no `description_hash → proposal_id`
+ * lookup (and adding one was out of scope, see the contract's doc comment),
+ * so the caller must supply it so the contract can verify
+ * `get_proposal(proposalId).descriptionHash === descriptionHash` itself.
+ *
+ * @example
+ * const client = new ProposalBondsClient({
+ *   governorAddress: "CABC...",
+ *   timelockAddress: "CDEF...",
+ *   votesAddress: "CGHI...",
+ *   proposalBondsAddress: "CJKL...",
+ *   network: "testnet",
+ * });
+ *
+ * await client.lockBond(signer, descriptionHash);
+ * // ... submit the correlated proposal via GovernorClient.propose ...
+ * await client.refundBond(signer, descriptionHash, proposalId);
+ */
+export class ProposalBondsClient {
+  private readonly config: ProposalBondsConfig;
+  private readonly server: SorobanRpc.Server;
+  private readonly contract: Contract;
+  private readonly networkPassphrase: string;
+
+  constructor(config: ProposalBondsConfig) {
+    if (!config.proposalBondsAddress) {
+      throw new ProposalBondsError(
+        ProposalBondsErrorCode.TransactionFailed,
+        "ProposalBondsClient requires config.proposalBondsAddress",
+      );
+    }
+    this.config = config;
+    const rpcUrl = config.rpcUrl ?? RPC_URLS[config.network];
+    this.server = new SorobanRpc.Server(rpcUrl, { allowHttp: false });
+    this.contract = new Contract(config.proposalBondsAddress);
+    this.networkPassphrase = NETWORK_PASSPHRASES[config.network];
+  }
+
+  private async retry<T>(fn: () => Promise<T>): Promise<T> {
+    return withRetry(fn, {
+      maxAttempts: this.config.maxAttempts,
+      baseDelayMs: this.config.baseDelayMs,
+      retryOn: isNetworkError,
+    });
+  }
+
+  private readAccount(): string {
+    return this.config.simulationAccount ?? this.config.proposalBondsAddress!;
+  }
+
+  private parseBond(native: Record<string, unknown>): ProposalBond {
+    const rawDescriptionHash = native.description_hash;
+    const descriptionHash =
+      typeof rawDescriptionHash === "string"
+        ? rawDescriptionHash
+        : Buffer.from(rawDescriptionHash as Uint8Array).toString("hex");
+
+    return {
+      proposer: String(native.proposer),
+      descriptionHash,
+      amount: BigInt(native.amount as bigint | number | string),
+      lockedLedger: Number(native.locked_ledger),
+      state: native.state as BondState,
+    };
+  }
+
+  private async submit(
+    signer: Keypair,
+    fnName: string,
+    ...args: xdr.ScVal[]
+  ): Promise<SubmitResult> {
+    return this.retry(async () => {
+      const account = await this.server.getAccount(signer.publicKey());
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(this.contract.call(fnName, ...args))
+        .setTimeout(30)
+        .build();
+
+      const prepared = await this.server.prepareTransaction(tx);
+      prepared.sign(signer);
+
+      const result = await this.server.sendTransaction(prepared);
+      if (result.status === "ERROR") {
+        throw parseProposalBondsError(result);
+      }
+      const confirmed = await this.pollForConfirmation(result.hash);
+      return { hash: result.hash, confirmed };
+    });
+  }
+
+  /**
+   * Same as {@link submit}, but for wallet-extension signing flows: takes
+   * the signer's public key plus a callback that signs an unsigned XDR
+   * envelope instead of a raw {@link Keypair}.
+   */
+  private async submitWithSign(
+    signerPublicKey: string,
+    signUnsignedXdr: (xdr: string) => Promise<string>,
+    fnName: string,
+    ...args: xdr.ScVal[]
+  ): Promise<SubmitResult> {
+    return this.retry(async () => {
+      const account = await this.server.getAccount(signerPublicKey);
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(this.contract.call(fnName, ...args))
+        .setTimeout(30)
+        .build();
+
+      const prepared = await this.server.prepareTransaction(tx);
+      const signedXdr = await signUnsignedXdr(prepared.toXDR());
+      const signed = TransactionBuilder.fromXDR(signedXdr, this.networkPassphrase);
+
+      const result = await this.server.sendTransaction(signed);
+      if (result.status === "ERROR") {
+        throw parseProposalBondsError(result);
+      }
+      const confirmed = await this.pollForConfirmation(result.hash);
+      return { hash: result.hash, confirmed };
+    });
+  }
+
+  /**
+   * Lock the configured bond amount from `signer`, keyed by
+   * `descriptionHash`. Call this alongside (before or after)
+   * `GovernorClient.propose`/`proposeWithSign` using the same
+   * `descriptionHash` so the two can be correlated later. Returns the tx hash.
+   */
+  async lockBond(signer: Keypair, descriptionHash: string): Promise<string> {
+    const { hash } = await this.submit(
+      signer,
+      "lock_bond",
+      nativeToScVal(signer.publicKey(), { type: "address" }),
+      nativeToScVal(hexToBytes32(descriptionHash), { type: "bytes" }),
+    );
+    return hash;
+  }
+
+  /** Wallet-signing variant of {@link lockBond} */
+  async lockBondWithSign(
+    signerPublicKey: string,
+    descriptionHash: string,
+    signUnsignedXdr: (xdr: string) => Promise<string>,
+  ): Promise<string> {
+    const { hash } = await this.submitWithSign(
+      signerPublicKey,
+      signUnsignedXdr,
+      "lock_bond",
+      nativeToScVal(signerPublicKey, { type: "address" }),
+      nativeToScVal(hexToBytes32(descriptionHash), { type: "bytes" }),
+    );
+    return hash;
+  }
+
+  /**
+   * Refund a locked bond once its correlated governor proposal (`proposalId`,
+   * whose on-chain `descriptionHash` must match this bond's) has reached a
+   * terminal state and the post-terminal refund grace window has elapsed.
+   * Permissionless — any address may call this — but funds always return to
+   * the original proposer. Returns the tx hash.
+   */
+  async refundBond(
+    caller: Keypair,
+    descriptionHash: string,
+    proposalId: bigint,
+  ): Promise<string> {
+    const { hash } = await this.submit(
+      caller,
+      "refund_bond",
+      nativeToScVal(caller.publicKey(), { type: "address" }),
+      nativeToScVal(hexToBytes32(descriptionHash), { type: "bytes" }),
+      nativeToScVal(proposalId, { type: "u64" }),
+    );
+    return hash;
+  }
+
+  /** Wallet-signing variant of {@link refundBond} */
+  async refundBondWithSign(
+    callerPublicKey: string,
+    descriptionHash: string,
+    proposalId: bigint,
+    signUnsignedXdr: (xdr: string) => Promise<string>,
+  ): Promise<string> {
+    const { hash } = await this.submitWithSign(
+      callerPublicKey,
+      signUnsignedXdr,
+      "refund_bond",
+      nativeToScVal(callerPublicKey, { type: "address" }),
+      nativeToScVal(hexToBytes32(descriptionHash), { type: "bytes" }),
+      nativeToScVal(proposalId, { type: "u64" }),
+    );
+    return hash;
+  }
+
+  /**
+   * Encode calldata for a `slash` action targeting this bonds contract, for
+   * use as one of a governance proposal's `targets`/`fnNames`/`calldatas` —
+   * `slash` is only callable as the target of an executed governance
+   * proposal (the governor contract must be the caller), so it is not
+   * exposed as a directly-signable client method the way `lockBond`/
+   * `refundBond` are.
+   */
+  encodeSlashCalldata(
+    governorAddress: string,
+    descriptionHash: string,
+    recipient: string,
+  ): Buffer {
+    return encodeCalldata([governorAddress, hexToBytes32(descriptionHash), recipient]);
+  }
+
+  /** Get a bond by description hash, or `null` if none has been locked. */
+  async getBond(descriptionHash: string): Promise<ProposalBond | null> {
+    return this.retry(async () => {
+      const result = await this.server.simulateTransaction(
+        new TransactionBuilder(
+          await this.server.getAccount(this.readAccount()),
+          { fee: BASE_FEE, networkPassphrase: this.networkPassphrase },
+        )
+          .addOperation(
+            this.contract.call(
+              "get_bond",
+              nativeToScVal(hexToBytes32(descriptionHash), { type: "bytes" }),
+            ),
+          )
+          .setTimeout(30)
+          .build(),
+      );
+
+      if (SorobanRpc.Api.isSimulationError(result)) {
+        throw parseProposalBondsError({ status: "ERROR", error: result.error });
+      }
+
+      const raw = (result as SorobanRpc.Api.SimulateTransactionSuccessResponse)
+        .result?.retval;
+      if (!raw) return null;
+
+      const native = scValToNative(raw);
+      if (native === null || native === undefined) return null;
+      return this.parseBond(native as Record<string, unknown>);
+    });
+  }
+
+  private async pollForConfirmation(
+    hash: string,
+    retries = 10,
+    delayMs = 2000,
+  ): Promise<SorobanRpc.Api.GetSuccessfulTransactionResponse> {
+    for (let i = 0; i < retries; i++) {
+      await new Promise((r) => setTimeout(r, delayMs));
+      const status = await this.retry(() => this.server.getTransaction(hash));
+      if (status.status === SorobanRpc.Api.GetTransactionStatus.SUCCESS) {
+        return status as SorobanRpc.Api.GetSuccessfulTransactionResponse;
+      }
+      if (status.status === SorobanRpc.Api.GetTransactionStatus.FAILED) {
+        throw new ProposalBondsError(
+          ProposalBondsErrorCode.TransactionFailed,
+          `Transaction failed: ${hash}`,
+        );
+      }
+    }
+    throw new ProposalBondsError(
+      ProposalBondsErrorCode.TransactionTimeout,
+      `Transaction not confirmed after ${retries} retries`,
+    );
+  }
+
+  // ─── Indexer-backed query methods ────────────────────────────────────────
+
+  private async indexerRequest<T>(path: string): Promise<T> {
+    if (!this.config.indexerUrl) {
+      throw new ProposalBondsError(
+        ProposalBondsErrorCode.SimulationFailed,
+        `ProposalBondsClient.${path} requires config.indexerUrl to be set`,
+      );
+    }
+    return this.retry(async () => {
+      const resp = await fetch(`${this.config.indexerUrl}${path}`);
+      if (!resp.ok) {
+        throw new ProposalBondsError(
+          ProposalBondsErrorCode.TransactionFailed,
+          `Indexer request failed: ${resp.status} ${resp.statusText}`,
+        );
+      }
+      return resp.json() as Promise<T>;
+    });
+  }
+
+  /**
+   * List bonds from the indexer with optional state filtering and
+   * pagination — unlike a direct on-chain scan, this is O(1) in terms of
+   * on-chain resources.
+   */
+  async listBonds(
+    options: { state?: "locked" | "refunded" | "slashed"; page?: number; limit?: number } = {},
+  ): Promise<{ data: ProposalBond[]; pagination: { page: number; limit: number; hasMore: boolean } }> {
+    const params = new URLSearchParams();
+    if (options.state) params.set("state", options.state);
+    if (options.page) params.set("page", String(options.page));
+    if (options.limit) params.set("limit", String(options.limit));
+
+    const query = params.toString() ? `?${params.toString()}` : "";
+    const raw = await this.indexerRequest<{
+      data: any[];
+      pagination: { page: number; limit: number; has_more: boolean };
+    }>(`/proposal-bonds${query}`);
+
+    return {
+      data: raw.data.map(mapBondFromIndexer),
+      pagination: {
+        page: raw.pagination.page,
+        limit: raw.pagination.limit,
+        hasMore: raw.pagination.has_more,
+      },
+    };
+  }
+
+  /** Return all bonds posted by a specific proposer, most-recent first. */
+  async getBondsByProposer(address: string): Promise<ProposalBond[]> {
+    const raw = await this.indexerRequest<{ data: any[] }>(
+      `/proposal-bonds/by-proposer/${address}`,
+    );
+    return raw.data.map(mapBondFromIndexer);
+  }
+
+  /**
+   * Resolve the governor proposal id correlated with a given
+   * `descriptionHash`, via the indexer — needed to call {@link refundBond},
+   * since governor has no on-chain description_hash → id lookup. Returns
+   * `null` if no matching proposal has been indexed yet.
+   */
+  async getProposalIdForDescriptionHash(descriptionHash: string): Promise<bigint | null> {
+    if (!this.config.indexerUrl) {
+      throw new ProposalBondsError(
+        ProposalBondsErrorCode.SimulationFailed,
+        "ProposalBondsClient.getProposalIdForDescriptionHash requires config.indexerUrl to be set",
+      );
+    }
+    return this.retry(async () => {
+      const resp = await fetch(
+        `${this.config.indexerUrl}/proposals/by-description-hash/${descriptionHash}`,
+      );
+      if (resp.status === 404) return null;
+      if (!resp.ok) {
+        throw new ProposalBondsError(
+          ProposalBondsErrorCode.TransactionFailed,
+          `Indexer request failed: ${resp.status} ${resp.statusText}`,
+        );
+      }
+      const proposal = (await resp.json()) as { id: string | number };
+      return BigInt(proposal.id);
+    });
+  }
+}
+
+/**
+ * Map a raw snake_case indexer bond record to the camelCase ProposalBond
+ * interface used throughout the SDK.
+ */
+function mapBondFromIndexer(raw: any): ProposalBond {
+  const stateMap: Record<string, BondState> = {
+    locked: "Locked",
+    refunded: "Refunded",
+    slashed: "Slashed",
+  };
+
+  return {
+    proposer: String(raw.proposer_address ?? raw.proposer),
+    descriptionHash: String(raw.description_hash ?? ""),
+    amount: BigInt(raw.amount ?? 0),
+    lockedLedger: Number(raw.locked_ledger ?? 0),
+    state: stateMap[String(raw.state).toLowerCase()] ?? "Locked",
+  };
+}

--- a/sdk/src/types/index.ts
+++ b/sdk/src/types/index.ts
@@ -149,6 +149,29 @@ export interface ProposalBond {
   state: BondState;
 }
 
+/** Read-only configuration snapshot of a deployed ProposalBonds contract. */
+export interface ProposalBondSettings {
+  /** Token address bonds are denominated and paid in. */
+  bondToken: string;
+  /** Amount, in the bond token's smallest unit, `lock_bond` currently requires. */
+  bondAmount: bigint;
+  /** Governor contract address this bonds registry is attached to. */
+  governor: string;
+  /**
+   * Ledgers after a correlated proposal's `end_ledger` during which
+   * `refund_bond` is blocked, giving the community time to submit a
+   * `slash` governance proposal first.
+   */
+  refundGraceLedgers: number;
+  /**
+   * Ledgers after `lock_bond` after which `refund_bond` succeeds
+   * unconditionally — the escape hatch for a proposal stuck in `Queued`
+   * with no governor-reported terminal state (see the contract's
+   * `refund_bond` doc comment).
+   */
+  maxLockLedgers: number;
+}
+
 /** Aggregated vote tallies for a proposal. */
 export interface ProposalVotes {
   /** Total tokens cast in favour. */

--- a/sdk/src/types/index.ts
+++ b/sdk/src/types/index.ts
@@ -127,6 +127,28 @@ export interface ProposalDraft {
   cancelled: boolean;
 }
 
+/** Lifecycle state of a proposer bond — see `ProposalBondsClient`. */
+export type BondState = "Locked" | "Refunded" | "Slashed";
+
+/**
+ * A refundable bond posted by a proposer alongside a governor proposal
+ * (correlated by shared `descriptionHash`), refunded once the proposal
+ * reaches a terminal state or slashed by a follow-up governance vote if
+ * judged spam, duplicated, or malicious.
+ */
+export interface ProposalBond {
+  /** Stellar address that posted the bond. */
+  proposer: string;
+  /** SHA-256 hash of the off-chain description content, shared with the correlated proposal. */
+  descriptionHash: string;
+  /** Bonded amount, in the configured bond token's smallest unit. */
+  amount: bigint;
+  /** Ledger sequence at which the bond was locked. */
+  lockedLedger: number;
+  /** Current lifecycle state. */
+  state: BondState;
+}
+
 /** Aggregated vote tallies for a proposal. */
 export interface ProposalVotes {
   /** Total tokens cast in favour. */
@@ -190,6 +212,8 @@ export interface GovernorConfig {
   votesAddress: string;
   /** Contract address of the co-sponsorship registry, if deployed */
   coSponsorshipAddress?: string;
+  /** Contract address of the proposal-bonds registry, if deployed */
+  proposalBondsAddress?: string;
   /** Stellar network to connect to */
   network: Network;
   /** RPC URL override (optional — defaults to public horizon) */


### PR DESCRIPTION
## Summary

Closes #996.

Adds a bonding layer so proposers post a refundable token bond alongside a proposal — refunded once the proposal reaches a terminal, non-malicious state (and a post-terminal grace window elapses), or slashed by a follow-up governance vote if judged spam, duplicated, or malicious.

- **`contracts/proposal-bonds`** (new crate, ~21KB WASM): `initialize`, `lock_bond`, `refund_bond`, `slash`, `get_bond`, `update_bond_amount`. No changes to `contracts/governor` (per the issue's scope note — it's near the CI WASM size cap). Cross-contract reads against governor use a minimal local mirror of `Proposal`/`ProposalState` (same pattern as `contracts/co-sponsorship`'s `GovernorClient`).
  - Governor has no `description_hash → proposal_id` lookup, so `refund_bond` takes an explicit `proposal_id` and verifies `get_proposal(proposal_id).description_hash` matches on-chain before proceeding — flagging this deviation from the issue's SDK sketch rather than adding a governor read function.
  - Refund eligibility is gated on `proposal.end_ledger + RefundGraceLedgers` (deterministic, no extra bespoke storage) rather than tracking a locally-observed "became terminal" ledger, since panicking calls roll back storage writes.
  - 13 unit tests covering lock/refund/slash happy paths and every panic path (double-lock, non-terminal, grace not elapsed, wrong governor caller, already-terminal bond, hash mismatch, reinitialization).
- **Indexer**: new `012_add_proposal_bonds.sql` migration (`proposal_bonds` table + `description_hash` column added to `proposals`, previously discarded on ingestion), event ingestion for `BondLocked`/`BondRefunded`/`BondSlashed`, and `GET /proposal-bonds`, `/proposal-bonds/:descriptionHash`, `/proposal-bonds/by-proposer/:address`, `/proposals/by-description-hash/:hash`.
- **SDK**: `ProposalBondsClient` (`lockBond`/`refundBond` + wallet-sign variants, `getBond`, indexer-backed `listBonds`/`getBondsByProposer`/`getProposalIdForDescriptionHash`, `encodeSlashCalldata` for the calldata builder) and a `ProposalBondsError`/`ProposalBondsErrorCode` pair mirroring the contract's error codes.
- **Frontend**: optional bond-lock step wired into the propose wizard (best-effort — a bond-lock failure surfaces a toast but doesn't block the already-succeeded proposal submission), `BondStatusBadge`, and a `/bonds` page showing the connected wallet's bond history with a manual refund button.

## Test plan

- [x] `cargo test -p sorogov-proposal-bonds` — 13/13 passing
- [x] `cargo clippy -p sorogov-proposal-bonds --all-targets -- -D warnings` — clean
- [x] `cargo check --workspace` — clean
- [x] WASM build — 21KB, well under the 80KB warning / 100KB hard cap
- [x] `sdk`: `tsc --noEmit` clean; `npm test` passing (pre-existing unrelated failures in `governor.test.ts` are excluded by `jest.config.js` already)
- [x] `packages/indexer`: `tsc --noEmit` shows no new errors beyond pre-existing duplicate-function-implementation issues in `events.ts` (present on `main`, unrelated to this change)
- [x] `app`: `tsc --noEmit` shows no new errors beyond pre-existing unrelated failures (present on `main`)