### PR TITLE
fix: make ProposerLeaderboard sort headers keyboard-accessible and render it on /leaderboard route (Fixes #802, #803)

### DIFF
--- a/app/src/app/leaderboard/page.tsx
+++ b/app/src/app/leaderboard/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { ProposerLeaderboard } from "../../components/ProposerLeaderboard";
+
+/**
+ * Leaderboard page — renders the ProposerLeaderboard component on its own
+ * route so the (already fully implemented) top-proposers table is reachable
+ * from the app's primary navigation (Issue #802).
+ */
+export default function LeaderboardPage() {
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+          Proposer Leaderboard
+        </h1>
+        <p className="text-gray-500 dark:text-gray-400 mt-1">
+          Top proposers ranked by reputation score.
+        </p>
+      </div>
+
+      <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-6">
+        <ProposerLeaderboard limit={50} />
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/NavBar.tsx
+++ b/app/src/components/NavBar.tsx
@@ -22,6 +22,7 @@ import {
   Activity,
   Radio,
   SlidersHorizontal,
+  Trophy,
 } from "lucide-react";
 import { useTheme } from "../hooks/useTheme";
 import { useTranslations } from "next-intl";
@@ -46,6 +47,7 @@ const NAV_LINKS = [
   { name: "Notifications", href: "/notifications", icon: Bell },
   { name: "Signals", href: "/signals", icon: Radio },
   { name: "Delegates", href: "/delegates", icon: Users },
+  { name: "Leaderboard", href: "/leaderboard", icon: Trophy },
   { name: "Analytics", href: "/analytics", icon: BarChart3 },
   { name: "Treasury", href: "/treasury", icon: Wallet2 },
   { name: "Governance Tuning", href: "/governance-tuning", icon: SlidersHorizontal },

--- a/app/src/components/ProposerLeaderboard.tsx
+++ b/app/src/components/ProposerLeaderboard.tsx
@@ -108,20 +108,28 @@ export function ProposerLeaderboard({ className = "", limit = 50 }: ProposerLead
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-gray-200 dark:border-gray-700 text-left">
-            <th className="pb-2 pr-4 font-medium text-gray-500 dark:text-gray-400">
+            <th scope="col" className="pb-2 pr-4 font-medium text-gray-500 dark:text-gray-400">
               Proposer
             </th>
             {columns.map((col) => (
               <th
                 key={col.key}
-                onClick={() => toggleSort(col.key)}
-                className="pb-2 px-4 font-medium text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-900 dark:hover:text-white"
+                scope="col"
+                aria-sort={sortKey === col.key ? (sortAsc ? "ascending" : "descending") : "none"}
+                className="pb-2 px-4"
               >
-                {col.label}
-                {sortKey === col.key && (sortAsc ? " ▲" : " ▼")}
+                <button
+                  type="button"
+                  onClick={() => toggleSort(col.key)}
+                  aria-label={`Sort by ${col.label}`}
+                  className="inline-flex items-center gap-1 font-medium text-gray-500 dark:text-gray-400 cursor-pointer select-none hover:text-gray-900 dark:hover:text-white"
+                >
+                  {col.label}
+                  {sortKey === col.key && (sortAsc ? " ▲" : " ▼")}
+                </button>
               </th>
             ))}
-            <th className="pb-2 px-4 font-medium text-gray-500 dark:text-gray-400">
+            <th scope="col" className="pb-2 px-4 font-medium text-gray-500 dark:text-gray-400">
               Last Updated
             </th>
           </tr>


### PR DESCRIPTION
## Description

Two small fixes to make the `ProposerLeaderboard` component reachable and usable:

### fix: sortable column headers keyboard and screen-reader accessible (#803)

- Wrapped each sortable header's content in a `<button type="button">` element with `aria-label`
- Added `aria-sort="ascending" | "descending" | "none"` on the `<th>` based on current sort state
- Added `scope="col"` on all column headers for proper table semantics

### fix: render ProposerLeaderboard on a /leaderboard route (#802)

- Created `/leaderboard` route in `app/src/app/leaderboard/page.tsx` rendering the already working `ProposerLeaderboard` component
- Added "Leaderboard" link to the primary navigation (NavBar) with a Trophy icon
- The component itself was already fully implemented (backed by the indexer's `/reputation/leaderboard` endpoint) — it was just never wired into any page or navigation

## Type of Change

- [x] Bug fix (non-breaking change which fixes an accessibility/UI issue)
- [x] New feature (non-breaking change which adds route + navigation)

## How Has This Been Tested

- TypeScript compilation: `tsc --noEmit` passes (existing `@nebgov/sdk` workspace module errors are pre-existing monorepo build order issues)
- ESLint: `next lint` passes with no new warnings