### PR TITLE
feat(token-votes): support partial/split delegation across multiple delegatees by percentage

### DIFF
--- a/app/src/app/delegates/page.tsx
+++ b/app/src/app/delegates/page.tsx
@@ -6,6 +6,7 @@ import { VotesClient, type TopDelegate, type Network } from "@nebgov/sdk";
 import { useWallet } from "../../lib/wallet-context";
 import { DelegateModal } from "../../components/DelegateModal";
 import { GaslessDelegateModal } from "../../components/GaslessDelegateModal";
+import { SplitDelegationEditor } from "../../components/SplitDelegationEditor";
 import { Skeleton } from "../../components/ui/Skeleton";
 import { useGovernorConfig } from "@/hooks/useGovernorConfig";
 
@@ -57,6 +58,7 @@ export default function DelegatesPage() {
   const [totalSupply, setTotalSupply] = useState(0n);
   const [modalOpen, setModalOpen] = useState(false);
   const [gaslessModalOpen, setGaslessModalOpen] = useState(false);
+  const [splitModalOpen, setSplitModalOpen] = useState(false);
   const [prefillAddress, setPrefillAddress] = useState<string>("");
   const [currentDelegatee, setCurrentDelegatee] = useState<string | null>(null);
   const [offset, setOffset] = useState(0);
@@ -347,6 +349,10 @@ export default function DelegatesPage() {
           setModalOpen(false);
           setGaslessModalOpen(true);
         }}
+        onOpenSplit={() => {
+          setModalOpen(false);
+          setSplitModalOpen(true);
+        }}
       />
 
       <GaslessDelegateModal
@@ -355,6 +361,13 @@ export default function DelegatesPage() {
         onDelegated={fetchDelegates}
         prefillAddress={prefillAddress}
         topDelegates={delegates}
+      />
+
+      <SplitDelegationEditor
+        open={splitModalOpen}
+        onClose={() => setSplitModalOpen(false)}
+        onDelegated={fetchDelegates}
+        prefillAddress={prefillAddress}
       />
     </div>
   );

--- a/app/src/app/profile/[address]/page.tsx
+++ b/app/src/app/profile/[address]/page.tsx
@@ -24,6 +24,7 @@ import {
 import { useGovernorConfig } from "@/hooks/useGovernorConfig";
 import { useDelegateProfile } from "@/hooks/useDelegateProfile";
 import { useProposerReputation } from "@/hooks/useProposerReputation";
+import { useSplitDelegation } from "@/hooks/useSplitDelegation";
 import { DelegationChain } from "@/components/DelegationChain";
 import { DelegatorList } from "@/components/DelegatorList";
 import { ReputationBadge } from "@/components/ReputationBadge";
@@ -82,6 +83,9 @@ function VoterProfilePageContent() {
 
   // Delegation registry (issue #769)
   const { profile: delegateProfile } = useDelegateProfile(address);
+
+  // Split delegation (issue #994)
+  const { splits: outboundSplits } = useSplitDelegation(address);
   const [registryTab, setRegistryTab] = useState<"history" | "received">("history");
   const [delegationChain, setDelegationChain] = useState<string[]>([]);
   const [delegationHistory, setDelegationHistory] = useState<DelegationHistoryEntry[]>([]);
@@ -433,7 +437,26 @@ function VoterProfilePageContent() {
           <p className="text-sm font-semibold text-gray-600 uppercase tracking-wide">
             Delegation
           </p>
-          {data.delegationInfo.delegatedTo ? (
+          {outboundSplits.length > 1 ? (
+            <div className="mt-2">
+              <p className="text-xs text-gray-500 mb-1">
+                Split across {outboundSplits.length} delegates
+              </p>
+              <div className="space-y-1">
+                {outboundSplits.map((s) => (
+                  <div key={s.delegatee} className="flex items-center justify-between text-sm">
+                    <Link
+                      href={`/profile/${s.delegatee}`}
+                      className="font-mono text-indigo-600 hover:text-indigo-700 truncate"
+                    >
+                      {s.delegatee.slice(0, 4)}...{s.delegatee.slice(-4)}
+                    </Link>
+                    <span className="text-gray-500 ml-2">{(s.weightBps / 100).toFixed(1)}%</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : data.delegationInfo.delegatedTo ? (
             <div className="mt-2">
               <p className="text-xs text-gray-500 mb-1">Delegated to</p>
               <Link

--- a/app/src/components/DelegateModal.tsx
+++ b/app/src/components/DelegateModal.tsx
@@ -19,6 +19,8 @@ interface Props {
   currentDelegatee?: string | null;
   /** Shown as a secondary "delegate without paying gas" action, if provided. */
   onOpenGasless?: () => void;
+  /** Shown as a secondary "split my delegation instead" action, if provided. */
+  onOpenSplit?: () => void;
 }
 
 function getVotesClientFromEnv(): VotesClient {
@@ -57,6 +59,7 @@ export function DelegateModal({
   prefillAddress,
   currentDelegatee,
   onOpenGasless,
+  onOpenSplit,
 }: Props) {
   const [delegatee, setDelegatee] = useState(prefillAddress || "");
   const [delegateeError, setDelegateeError] = useState("");
@@ -258,6 +261,22 @@ export function DelegateModal({
               </button>
               <p className="text-xs text-gray-400 mt-1">
                 Sign off-chain, our relayer submits the transaction
+              </p>
+            </div>
+          )}
+
+          {onOpenSplit && (
+            <div className={onOpenGasless ? "pt-2" : "border-t border-gray-200 pt-4 mt-4"}>
+              <button
+                type="button"
+                onClick={onOpenSplit}
+                disabled={submitting}
+                className="w-full text-sm font-medium text-indigo-600 hover:text-indigo-700 disabled:opacity-50"
+              >
+                Split my delegation instead →
+              </button>
+              <p className="text-xs text-gray-400 mt-1 text-center">
+                Spread your voting power across multiple delegates by percentage
               </p>
             </div>
           )}

--- a/app/src/components/DelegatorList.tsx
+++ b/app/src/components/DelegatorList.tsx
@@ -23,6 +23,9 @@ export function DelegatorList({ delegatee, pageSize = 10, className = "" }: Dele
   const [delegators, setDelegators] = useState<RegistryDelegatorInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // delegator address -> weight_bps, for delegators using split delegation
+  // (issue #994) — absent means a full (100%) legacy delegation.
+  const [splitWeights, setSplitWeights] = useState<Map<string, number>>(new Map());
 
   const fetchPage = useCallback(async () => {
     setLoading(true);
@@ -59,6 +62,34 @@ export function DelegatorList({ delegatee, pageSize = 10, className = "" }: Dele
     fetchPage();
   }, [fetchPage]);
 
+  useEffect(() => {
+    const indexerUrl = process.env.NEXT_PUBLIC_INDEXER_URL;
+    if (!indexerUrl) return;
+
+    let cancelled = false;
+    fetch(`${indexerUrl}/delegates/${delegatee}/split-delegations?limit=200`, {
+      cache: "no-store",
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json) => {
+        if (cancelled || !json?.splitDelegations) return;
+        const weights = new Map<string, number>();
+        for (const row of json.splitDelegations as Array<{
+          delegator_address: string;
+          weight_bps: number;
+        }>) {
+          weights.set(row.delegator_address, Number(row.weight_bps));
+        }
+        setSplitWeights(weights);
+      })
+      .catch(() => {
+        // Split-delegation percentages are supplementary; fail silently.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [delegatee]);
+
   if (loading) {
     return (
       <div className={`space-y-2 ${className}`}>
@@ -92,6 +123,13 @@ export function DelegatorList({ delegatee, pageSize = 10, className = "" }: Dele
               <AddressDisplay address={d.address} />
             </Link>
             <div className="text-right text-gray-500 dark:text-gray-400">
+              {splitWeights.has(d.address) && splitWeights.get(d.address)! < 10000 && (
+                <>
+                  <span className="inline-block bg-indigo-100 dark:bg-indigo-900 text-indigo-700 dark:text-indigo-300 text-xs font-medium px-1.5 py-0.5 rounded mr-1">
+                    {(splitWeights.get(d.address)! / 100).toFixed(1)}%
+                  </span>
+                </>
+              )}
               <span>{formatVotingPower(d.delegatedPower)}</span>
               <span className="mx-1">·</span>
               <span>ledger #{d.delegatedAtLedger}</span>

--- a/app/src/components/SplitDelegationEditor.tsx
+++ b/app/src/components/SplitDelegationEditor.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+/**
+ * Split delegation editor (issue #994) — add/remove delegatee rows with a
+ * percentage input per row, live-validated to sum to 100% before the submit
+ * button is enabled. Reused both from the plain delegate flow ("Split my
+ * delegation instead") and from a delegate's own profile page.
+ */
+
+import { useEffect, useState, type FormEvent } from "react";
+import toast from "react-hot-toast";
+import { isValidStellarAddress } from "../lib/utils/stellarAddress";
+import type { SplitDelegation } from "@nebgov/sdk";
+import { useWallet } from "../lib/wallet-context";
+import { useSplitDelegation } from "../hooks/useSplitDelegation";
+import { useFocusTrap } from "../hooks/useFocusTrap";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onDelegated?: () => void;
+  /** Pre-fill a single row with this address (e.g. coming from the plain delegate flow). */
+  prefillAddress?: string;
+}
+
+interface Row {
+  key: number;
+  delegatee: string;
+  percent: string; // kept as a string while editing so a blank/partial input doesn't jump to 0
+}
+
+let nextRowKey = 0;
+function newRow(delegatee = ""): Row {
+  return { key: nextRowKey++, delegatee, percent: "" };
+}
+
+function explorerTxUrl(txHash: string): string {
+  const network = process.env.NEXT_PUBLIC_NETWORK || "testnet";
+  const base =
+    network === "mainnet"
+      ? "https://stellar.expert/explorer/public"
+      : "https://stellar.expert/explorer/testnet";
+  return `${base}/tx/${txHash}`;
+}
+
+export function SplitDelegationEditor({ open, onClose, onDelegated, prefillAddress }: Props) {
+  const { publicKey } = useWallet();
+  const { delegateSplit, submitting } = useSplitDelegation(publicKey ?? undefined);
+  const [rows, setRows] = useState<Row[]>([newRow(prefillAddress)]);
+  const dialogRef = useFocusTrap<HTMLDivElement>(open, onClose);
+
+  useEffect(() => {
+    if (open) setRows([newRow(prefillAddress), newRow()]);
+  }, [open, prefillAddress]);
+
+  if (!open) return null;
+
+  const totalPercent = rows.reduce((sum, r) => sum + (Number(r.percent) || 0), 0);
+  const remaining = 100 - totalPercent;
+
+  const rowErrors = rows.map((r) => {
+    if (!r.delegatee.trim() && !r.percent.trim()) return null; // untouched trailing row
+    if (!r.delegatee.trim()) return "Address is required.";
+    if (!isValidStellarAddress(r.delegatee)) return "Invalid Stellar address.";
+    const pct = Number(r.percent);
+    if (!r.percent.trim() || Number.isNaN(pct) || pct <= 0) return "Enter a percentage > 0.";
+    return null;
+  });
+
+  const activeRows = rows.filter((r) => r.delegatee.trim() || r.percent.trim());
+  const duplicateAddresses = new Set(
+    activeRows
+      .map((r) => r.delegatee.trim())
+      .filter((addr, i, arr) => addr && arr.indexOf(addr) !== i),
+  );
+
+  const isValid =
+    activeRows.length > 0 &&
+    rowErrors.every((e) => e === null) &&
+    duplicateAddresses.size === 0 &&
+    Math.abs(totalPercent - 100) < 0.001;
+
+  function updateRow(key: number, patch: Partial<Row>) {
+    setRows((prev) => prev.map((r) => (r.key === key ? { ...r, ...patch } : r)));
+  }
+
+  function addRow() {
+    setRows((prev) => [...prev, newRow()]);
+  }
+
+  function removeRow(key: number) {
+    setRows((prev) => (prev.length > 1 ? prev.filter((r) => r.key !== key) : prev));
+  }
+
+  function splitEvenly() {
+    const active = rows.filter((r) => r.delegatee.trim());
+    if (active.length === 0) return;
+    const base = Math.floor((10000 / active.length)) / 100;
+    setRows((prev) => {
+      const activeKeys = prev.filter((r) => r.delegatee.trim()).map((r) => r.key);
+      let allocated = 0;
+      return prev.map((r) => {
+        if (!activeKeys.includes(r.key)) return r;
+        const isLast = r.key === activeKeys[activeKeys.length - 1];
+        const pct = isLast ? (100 - allocated).toFixed(2) : base.toFixed(2);
+        allocated += Number(pct);
+        return { ...r, percent: pct };
+      });
+    });
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!isValid) return;
+
+    const splits: SplitDelegation[] = activeRows.map((r) => ({
+      delegatee: r.delegatee.trim(),
+      weightBps: Math.round(Number(r.percent) * 100),
+    }));
+
+    // Rounding each row to the nearest bp can leave the sum a hair off
+    // 10000; credit any remainder to the last entry so the contract's exact
+    // sum-to-10000 check passes.
+    const sum = splits.reduce((s, x) => s + x.weightBps, 0);
+    if (sum !== 10000 && splits.length > 0) {
+      splits[splits.length - 1].weightBps += 10000 - sum;
+    }
+
+    try {
+      const hash = await delegateSplit(splits);
+      toast.success(
+        <div>
+          Split delegation submitted!{" "}
+          <a href={explorerTxUrl(hash)} target="_blank" rel="noreferrer" className="underline">
+            View on Explorer →
+          </a>
+        </div>,
+        { duration: 8000 },
+      );
+      onDelegated?.();
+      onClose();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      toast.error(`Split delegation failed: ${msg}`);
+    }
+  }
+
+  return (
+    <div
+      ref={dialogRef}
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="split-delegation-title"
+      tabIndex={-1}
+    >
+      <div className="bg-white rounded-2xl p-6 w-full max-w-lg shadow-xl">
+        <div className="flex items-start justify-between mb-1">
+          <h2 id="split-delegation-title" className="text-lg font-bold text-gray-900">
+            Split Delegation
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 p-1 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+        <p className="text-sm text-gray-500 mb-4">
+          Spread your voting power across multiple delegates by percentage.
+        </p>
+
+        <form onSubmit={handleSubmit} className="space-y-3">
+          {rows.map((row) => {
+            const err = rowErrors[rows.indexOf(row)];
+            const isDup = row.delegatee.trim() && duplicateAddresses.has(row.delegatee.trim());
+            return (
+              <div key={row.key} className="flex items-start gap-2">
+                <input
+                  type="text"
+                  placeholder="Stellar address (G...)"
+                  value={row.delegatee}
+                  onChange={(e) => updateRow(row.key, { delegatee: e.target.value })}
+                  className={`flex-1 border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 font-mono ${
+                    err || isDup ? "border-red-400" : "border-gray-300"
+                  }`}
+                />
+                <div className="relative w-24">
+                  <input
+                    type="number"
+                    min="0"
+                    max="100"
+                    step="0.01"
+                    placeholder="0"
+                    value={row.percent}
+                    onChange={(e) => updateRow(row.key, { percent: e.target.value })}
+                    className="w-full border border-gray-300 rounded-lg pl-3 pr-6 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  />
+                  <span className="absolute right-2 top-2.5 text-xs text-gray-400">%</span>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => removeRow(row.key)}
+                  disabled={rows.length === 1}
+                  className="text-gray-400 hover:text-red-500 p-2 disabled:opacity-30"
+                  aria-label="Remove row"
+                >
+                  ✕
+                </button>
+              </div>
+            );
+          })}
+
+          {(rowErrors.some((e) => e) || duplicateAddresses.size > 0) && (
+            <p className="text-xs text-red-500">
+              {duplicateAddresses.size > 0
+                ? "Duplicate delegatee addresses aren't allowed."
+                : rowErrors.find((e) => e)}
+            </p>
+          )}
+
+          <div className="flex items-center justify-between">
+            <button
+              type="button"
+              onClick={addRow}
+              className="text-xs px-3 py-1.5 rounded-lg border border-gray-200 text-gray-700 hover:bg-gray-50"
+            >
+              + Add delegatee
+            </button>
+            <button
+              type="button"
+              onClick={splitEvenly}
+              className="text-xs px-3 py-1.5 rounded-lg border border-gray-200 text-gray-700 hover:bg-gray-50"
+            >
+              Split evenly
+            </button>
+          </div>
+
+          <div
+            className={`rounded-lg px-3 py-2 text-sm flex items-center justify-between ${
+              Math.abs(remaining) < 0.001
+                ? "bg-green-50 text-green-800 border border-green-200"
+                : "bg-amber-50 text-amber-800 border border-amber-200"
+            }`}
+          >
+            <span>Total allocated</span>
+            <span className="font-medium">
+              {totalPercent.toFixed(2)}%{" "}
+              {Math.abs(remaining) >= 0.001 &&
+                `(${remaining > 0 ? remaining.toFixed(2) + "% remaining" : Math.abs(remaining).toFixed(2) + "% over"})`}
+            </span>
+          </div>
+
+          <div className="flex gap-3 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 border border-gray-200 text-gray-600 py-2 rounded-lg text-sm hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting || !isValid || !publicKey}
+              className="flex-1 bg-indigo-600 text-white py-2 rounded-lg text-sm font-medium hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {submitting ? "Delegating..." : "Split Delegate"}
+            </button>
+          </div>
+          {!publicKey && (
+            <p className="text-xs text-gray-400 text-center">Connect your wallet first.</p>
+          )}
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/src/hooks/useSplitDelegation.ts
+++ b/app/src/hooks/useSplitDelegation.ts
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { VotesClient, type SplitDelegation, type Network } from "@nebgov/sdk";
+import { useWallet } from "../lib/wallet-context";
+
+interface UseSplitDelegationResult {
+  splits: SplitDelegation[];
+  loading: boolean;
+  error: string | null;
+  submitting: boolean;
+  refetch: () => void;
+  /**
+   * Delegate arbitrary basis-point percentages of the caller's voting power
+   * across multiple delegatees (issue #994). `splits` must sum to 10000.
+   * Throws on failure.
+   */
+  delegateSplit: (splits: SplitDelegation[]) => Promise<string>;
+  /** Revoke split delegation and return full voting power to the caller. */
+  undelegateSplit: () => Promise<string>;
+}
+
+function getVotesClientFromEnv(): VotesClient {
+  const governorAddress = process.env.NEXT_PUBLIC_GOVERNOR_ADDRESS;
+  const timelockAddress = process.env.NEXT_PUBLIC_TIMELOCK_ADDRESS;
+  const votesAddress = process.env.NEXT_PUBLIC_VOTES_ADDRESS;
+  const network = (process.env.NEXT_PUBLIC_NETWORK || "testnet") as Network;
+  const rpcUrl = process.env.NEXT_PUBLIC_RPC_URL;
+
+  if (!governorAddress || !timelockAddress || !votesAddress) {
+    throw new Error("Missing NEXT_PUBLIC_* contract addresses in .env.local");
+  }
+
+  return new VotesClient({
+    governorAddress,
+    timelockAddress,
+    votesAddress,
+    network,
+    ...(rpcUrl && { rpcUrl }),
+  });
+}
+
+/**
+ * Split delegation (issue #994): read the current split for `address` and
+ * expose wallet-signing actions to update or revoke it. `splits` falls back
+ * to a single 100% entry when the address is using the legacy single-target
+ * `delegate()` path instead — see `getSplitDelegations` in votes.ts.
+ */
+export function useSplitDelegation(address: string | undefined): UseSplitDelegationResult {
+  const [splits, setSplits] = useState<SplitDelegation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [refreshToken, setRefreshToken] = useState(0);
+  const { publicKey, signTransaction } = useWallet();
+
+  useEffect(() => {
+    if (!address) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchSplits() {
+      setLoading(true);
+      setError(null);
+      try {
+        const client = getVotesClientFromEnv();
+        const result = await client.getSplitDelegations(address as string);
+        if (!cancelled) setSplits(result);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load split delegations");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchSplits();
+    return () => {
+      cancelled = true;
+    };
+  }, [address, refreshToken]);
+
+  const refetch = useCallback(() => setRefreshToken((t) => t + 1), []);
+
+  const delegateSplit = useCallback(
+    async (newSplits: SplitDelegation[]) => {
+      if (!publicKey) throw new Error("Connect your wallet first.");
+      setSubmitting(true);
+      try {
+        const client = getVotesClientFromEnv();
+        const hash = await client.delegateSplitWithSign(publicKey, newSplits, signTransaction);
+        refetch();
+        return hash;
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [publicKey, signTransaction, refetch],
+  );
+
+  const undelegateSplit = useCallback(async () => {
+    if (!publicKey) throw new Error("Connect your wallet first.");
+    setSubmitting(true);
+    try {
+      const client = getVotesClientFromEnv();
+      const hash = await client.undelegateSplitWithSign(publicKey, signTransaction);
+      refetch();
+      return hash;
+    } finally {
+      setSubmitting(false);
+    }
+  }, [publicKey, signTransaction, refetch]);
+
+  return { splits, loading, error, submitting, refetch, delegateSplit, undelegateSplit };
+}

--- a/contracts/token-votes/src/error.rs
+++ b/contracts/token-votes/src/error.rs
@@ -24,4 +24,10 @@ pub enum TokenVotesError {
     InvalidChainId = 15,
     InvalidContractId = 16,
     ChainDepthExceeded = 17,
+
+    /// Split delegation (issue #994) errors.
+    SplitTooManyTargets = 18,
+    SplitDuplicateDelegatee = 19,
+    SplitZeroWeight = 20,
+    SplitWeightsMustSum10000 = 21,
 }

--- a/contracts/token-votes/src/lib.rs
+++ b/contracts/token-votes/src/lib.rs
@@ -8,10 +8,12 @@ mod delegation_registry;
 mod delegation_sig;
 mod error;
 mod events;
+mod split_delegation;
 
 pub use delegation_registry::{DelegateProfile, DelegationEntry, DelegationHistoryEntry, DelegatorInfo};
 pub use delegation_sig::DelegationPermit;
 pub use error::TokenVotesError;
+pub use split_delegation::SplitDelegation;
 
 #[cfg(test)]
 mod delegation_sig_tests;
@@ -21,6 +23,9 @@ mod load_tests;
 
 #[cfg(test)]
 mod delegation_registry_tests;
+
+#[cfg(test)]
+mod split_delegation_tests;
 
 /// A voting power checkpoint at a specific ledger sequence.
 #[contracttype]
@@ -67,6 +72,10 @@ pub enum DataKey {
     TotalDelegatorsFor(Address),        // delegatee -> u32: count of current delegators
     DelegationChain(Address),           // delegator -> Vec<Address>: full chain from delegator to tip
     ChainDepth(Address),                // delegator -> u32: depth of delegation chain from this delegator
+
+    // --- Split delegation (issue #994) ---
+    SplitDelegations(Address), // delegator -> Vec<SplitDelegation>, empty/absent means "use legacy DataKey::Delegate instead"
+    MaxSplitTargets,           // u32 cap, governance-settable
 }
 
 #[contract]
@@ -496,6 +505,52 @@ impl TokenVotesContract {
         delegation_registry::get_delegation_snapshot(&env, delegatee, at_ledger, offset, limit)
     }
 
+    // --- Split delegation (issue #994) ---
+
+    /// Delegate arbitrary basis-point percentages of the caller's voting
+    /// power across multiple delegatees at once. Replaces (not merges with)
+    /// any prior split or legacy single delegation for `delegator`.
+    ///
+    /// `splits` must be non-empty, at most [`Self::get_max_split_targets`]
+    /// entries, contain no duplicate delegatees, have every `weight_bps > 0`,
+    /// and sum to exactly 10000 (100%).
+    pub fn delegate_split(env: Env, delegator: Address, splits: Vec<SplitDelegation>) {
+        delegator.require_auth();
+        split_delegation::delegate_split(&env, delegator, splits);
+    }
+
+    /// Get the delegator's current split delegations. Falls back to
+    /// reporting the legacy single delegation (if any) as a single 100%
+    /// entry, so callers don't need to know which path a delegator used.
+    pub fn get_split_delegations(env: Env, delegator: Address) -> Vec<SplitDelegation> {
+        split_delegation::get_split_delegations(&env, delegator)
+    }
+
+    /// Revoke split delegation and return full voting power to the
+    /// delegator across all previously-split entries. No-op if the
+    /// delegator has never delegated or is already self-delegated.
+    pub fn undelegate_split(env: Env, delegator: Address) {
+        delegator.require_auth();
+        split_delegation::undelegate_split(&env, delegator);
+    }
+
+    /// Admin function to update the maximum number of split delegation targets.
+    pub fn set_max_split_targets(env: Env, admin: Address, max_targets: u32) {
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        assert_eq!(admin, stored_admin, "unauthorized");
+        admin.require_auth();
+        split_delegation::set_max_split_targets(&env, max_targets);
+    }
+
+    /// Get the current maximum number of split delegation targets.
+    pub fn get_max_split_targets(env: Env) -> u32 {
+        split_delegation::get_max_split_targets(&env)
+    }
+
     /// Get voting power at a past ledger sequence (snapshot).
     pub fn get_past_votes(env: Env, account: Address, ledger: u32) -> i128 {
         let current_ledger = env.ledger().sequence();
@@ -607,7 +662,7 @@ impl TokenVotesContract {
     // --- Internal helpers ---
 
     /// Append or update the total supply checkpoint by `delta` at the current ledger.
-    fn update_total_supply_checkpoint(env: &Env, delta: i128, delta_weighted_sum: i128) {
+    pub(crate) fn update_total_supply_checkpoint(env: &Env, delta: i128, delta_weighted_sum: i128) {
         let mut checkpoints: soroban_sdk::Vec<Checkpoint> = env
             .storage()
             .persistent()
@@ -649,7 +704,7 @@ impl TokenVotesContract {
 
     /// Update an account's voting power checkpoints by `delta`.
     /// Also registers the account in AccountList so it can be pruned later.
-    fn update_account_votes(env: &Env, account: Address, delta: i128, delta_weighted_sum: i128) {
+    pub(crate) fn update_account_votes(env: &Env, account: Address, delta: i128, delta_weighted_sum: i128) {
         let mut checkpoints: soroban_sdk::Vec<Checkpoint> = env
             .storage()
             .persistent()

--- a/contracts/token-votes/src/split_delegation.rs
+++ b/contracts/token-votes/src/split_delegation.rs
@@ -1,0 +1,360 @@
+//! Split delegation: delegating arbitrary basis-point percentages of one's
+//! voting power across up to `MaxSplitTargets` delegatees simultaneously.
+//!
+//! This is additive to the existing single-target `Delegate` mapping/
+//! `apply_delegation` path in `lib.rs`, which keeps working completely
+//! unchanged for any account that never calls a `*_split` entrypoint. A
+//! plain `delegate(a, b)` call is the degenerate one-entry case of a split
+//! (100% to `b`); this module treats it that way on the *read* side
+//! (`get_split_delegations` falls back to the legacy `Delegate` mapping) and
+//! collapses a single 100%-weight split back into the legacy `Delegate` key
+//! on the *write* side, so a delegator who has only ever used `delegate_split`
+//! with one entry remains fully interoperable with `delegate()`/`undelegate()`
+//! and with `delegation_registry`'s chain resolution. Once a delegator has a
+//! genuine multi-entry split on file, falling back to the plain `delegate()`
+//! entrypoint is out of scope (not exercised by existing tests, and the
+//! issue's compatibility requirement is one-directional: legacy accounts
+//! that never touch the split API).
+
+use crate::{DataKey, DelegatorRecord, TokenVotesContract, TokenVotesError};
+use soroban_sdk::{contracttype, token, Address, Env, Symbol, Vec};
+
+const BPS_DENOMINATOR: u32 = 10000;
+const DEFAULT_MAX_SPLIT_TARGETS: u32 = 10;
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SplitDelegation {
+    pub delegatee: Address,
+    pub weight_bps: u32,
+}
+
+fn emit_split_delegated(env: &Env, delegator: &Address, splits: &Vec<SplitDelegation>) {
+    env.events().publish(
+        (Symbol::new(env, "SplitDelegated"), delegator.clone()),
+        splits.clone(),
+    );
+}
+
+fn emit_split_undelegated(env: &Env, delegator: &Address) {
+    env.events().publish(
+        (Symbol::new(env, "SplitUndelegated"), delegator.clone()),
+        (),
+    );
+}
+
+pub(crate) fn get_max_split_targets(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::MaxSplitTargets)
+        .unwrap_or(DEFAULT_MAX_SPLIT_TARGETS)
+}
+
+pub(crate) fn set_max_split_targets(env: &Env, max_targets: u32) {
+    assert!(max_targets >= 1, "max targets must be at least 1");
+    env.storage()
+        .instance()
+        .set(&DataKey::MaxSplitTargets, &max_targets);
+}
+
+fn validate_splits(env: &Env, splits: &Vec<SplitDelegation>) {
+    let n = splits.len();
+    assert!(n > 0, "splits must not be empty");
+
+    let max_targets = get_max_split_targets(env);
+    if n > max_targets {
+        env.panic_with_error(TokenVotesError::SplitTooManyTargets);
+    }
+
+    let mut sum: u32 = 0;
+    let mut i: u32 = 0;
+    while i < n {
+        let s = splits.get(i).unwrap();
+        if s.weight_bps == 0 {
+            env.panic_with_error(TokenVotesError::SplitZeroWeight);
+        }
+        sum = sum.checked_add(s.weight_bps).expect("weight_bps overflow");
+
+        let mut j = i + 1;
+        while j < n {
+            if splits.get(j).unwrap().delegatee == s.delegatee {
+                env.panic_with_error(TokenVotesError::SplitDuplicateDelegatee);
+            }
+            j += 1;
+        }
+        i += 1;
+    }
+
+    if sum != BPS_DENOMINATOR {
+        env.panic_with_error(TokenVotesError::SplitWeightsMustSum10000);
+    }
+}
+
+/// Split `total` across `splits` by `weight_bps`, crediting the rounding
+/// remainder from integer division to the last entry so the parts always
+/// sum exactly to `total`.
+fn split_amount(splits: &Vec<SplitDelegation>, index: u32, total: i128) -> i128 {
+    let n = splits.len();
+    if index == n - 1 {
+        let mut allocated: i128 = 0;
+        let mut i: u32 = 0;
+        while i < n - 1 {
+            let s = splits.get(i).unwrap();
+            allocated += (total * s.weight_bps as i128) / BPS_DENOMINATOR as i128;
+            i += 1;
+        }
+        total - allocated
+    } else {
+        let s = splits.get(index).unwrap();
+        (total * s.weight_bps as i128) / BPS_DENOMINATOR as i128
+    }
+}
+
+/// Remove whatever distribution `delegator` currently has on file — either a
+/// legacy single `Delegate` target or an existing split — crediting the
+/// removed voting power back out of each affected delegatee's checkpoints
+/// and revoking the corresponding registry entries. Returns whether the
+/// delegator had any prior distribution at all (needed to decide whether the
+/// upcoming total-supply update is a delta or a first-time addition).
+fn remove_old_distribution(
+    env: &Env,
+    delegator: &Address,
+    old_record: &DelegatorRecord,
+    current_ledger: u32,
+) -> bool {
+    let legacy: Option<Address> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Delegate(delegator.clone()));
+
+    if let Some(old_delegatee) = legacy {
+        let old_ws = old_record.balance * old_record.start_ledger as i128;
+        if old_record.balance != 0 || old_ws != 0 {
+            TokenVotesContract::update_account_votes(
+                env,
+                old_delegatee.clone(),
+                -old_record.balance,
+                -old_ws,
+            );
+        }
+        if old_delegatee != *delegator {
+            crate::delegation_registry::revoke_registry_entry(
+                env,
+                delegator,
+                &old_delegatee,
+                current_ledger,
+            );
+        }
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Delegate(delegator.clone()));
+        return true;
+    }
+
+    let old_splits: Vec<SplitDelegation> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::SplitDelegations(delegator.clone()))
+        .unwrap_or(Vec::new(env));
+    if old_splits.is_empty() {
+        return false;
+    }
+
+    let n = old_splits.len();
+    let mut i: u32 = 0;
+    while i < n {
+        let s = old_splits.get(i).unwrap();
+        let entry_balance = split_amount(&old_splits, i, old_record.balance);
+        let entry_ws = entry_balance * old_record.start_ledger as i128;
+        if entry_balance != 0 || entry_ws != 0 {
+            TokenVotesContract::update_account_votes(env, s.delegatee.clone(), -entry_balance, -entry_ws);
+        }
+        if s.delegatee != *delegator {
+            crate::delegation_registry::revoke_registry_entry(env, delegator, &s.delegatee, current_ledger);
+        }
+        i += 1;
+    }
+
+    env.storage()
+        .persistent()
+        .remove(&DataKey::SplitDelegations(delegator.clone()));
+    true
+}
+
+fn apply_new_distribution(
+    env: &Env,
+    delegator: &Address,
+    splits: &Vec<SplitDelegation>,
+    balance: i128,
+    start_ledger: u32,
+    current_ledger: u32,
+) {
+    let n = splits.len();
+    let mut i: u32 = 0;
+    while i < n {
+        let s = splits.get(i).unwrap();
+        let entry_balance = split_amount(splits, i, balance);
+        let entry_ws = entry_balance * start_ledger as i128;
+        if entry_balance != 0 || entry_ws != 0 {
+            TokenVotesContract::update_account_votes(env, s.delegatee.clone(), entry_balance, entry_ws);
+        }
+        if s.delegatee != *delegator {
+            crate::delegation_registry::register_delegation(
+                env,
+                delegator,
+                &s.delegatee,
+                entry_balance,
+                current_ledger,
+            );
+        }
+        i += 1;
+    }
+}
+
+/// Store the resulting split on file. A single 100%-weight entry is
+/// collapsed into the legacy `Delegate` key rather than `SplitDelegations` —
+/// see the module doc comment for why this matters for interop.
+fn store_result(env: &Env, delegator: &Address, splits: &Vec<SplitDelegation>) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::SplitDelegations(delegator.clone()));
+    env.storage()
+        .persistent()
+        .remove(&DataKey::Delegate(delegator.clone()));
+
+    if splits.len() == 1 && splits.get(0).unwrap().weight_bps == BPS_DENOMINATOR {
+        env.storage().persistent().set(
+            &DataKey::Delegate(delegator.clone()),
+            &splits.get(0).unwrap().delegatee,
+        );
+    } else {
+        env.storage()
+            .persistent()
+            .set(&DataKey::SplitDelegations(delegator.clone()), splits);
+    }
+}
+
+/// Shared engine for both `delegate_split` and `undelegate_split` (the
+/// latter calling in with a single 100%-to-self entry) — the "one code path"
+/// for split voting-power computation the issue asks for.
+fn apply_split_core(env: &Env, delegator: Address, splits: Vec<SplitDelegation>) {
+    validate_splits(env, &splits);
+
+    let token_addr: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Token)
+        .expect("token not set");
+    let balance = token::TokenClient::new(env, &token_addr).balance(&delegator);
+
+    let current_ledger = env.ledger().sequence();
+    let old_record: DelegatorRecord = env
+        .storage()
+        .persistent()
+        .get(&DataKey::DelegatorRecord(delegator.clone()))
+        .unwrap_or_default();
+
+    let mut new_record = old_record.clone();
+    new_record.balance = balance;
+    if balance > old_record.balance {
+        let added = balance - old_record.balance;
+        let total_weighted_start = (old_record.balance * old_record.start_ledger as i128)
+            + (added * current_ledger as i128);
+        new_record.start_ledger = if balance > 0 {
+            (total_weighted_start / balance) as u32
+        } else {
+            current_ledger
+        };
+    }
+
+    let old_weighted_sum = old_record.balance * old_record.start_ledger as i128;
+    let new_weighted_sum = new_record.balance * new_record.start_ledger as i128;
+
+    let had_prior = remove_old_distribution(env, &delegator, &old_record, current_ledger);
+
+    if had_prior {
+        let delta = new_record.balance - old_record.balance;
+        let delta_ws = new_weighted_sum - old_weighted_sum;
+        if delta != 0 || delta_ws != 0 {
+            TokenVotesContract::update_total_supply_checkpoint(env, delta, delta_ws);
+        }
+    } else if balance > 0 {
+        TokenVotesContract::update_total_supply_checkpoint(env, balance, new_weighted_sum);
+    }
+
+    apply_new_distribution(
+        env,
+        &delegator,
+        &splits,
+        new_record.balance,
+        new_record.start_ledger,
+        current_ledger,
+    );
+
+    store_result(env, &delegator, &splits);
+    env.storage()
+        .persistent()
+        .set(&DataKey::DelegatorRecord(delegator.clone()), &new_record);
+}
+
+pub(crate) fn delegate_split(env: &Env, delegator: Address, splits: Vec<SplitDelegation>) {
+    apply_split_core(env, delegator.clone(), splits.clone());
+    emit_split_delegated(env, &delegator, &splits);
+}
+
+pub(crate) fn undelegate_split(env: &Env, delegator: Address) {
+    let legacy: Option<Address> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Delegate(delegator.clone()));
+    let has_split: bool = {
+        let s: Vec<SplitDelegation> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SplitDelegations(delegator.clone()))
+            .unwrap_or(Vec::new(env));
+        !s.is_empty()
+    };
+
+    if !has_split {
+        match &legacy {
+            None => return,
+            Some(d) if *d == delegator => return,
+            _ => {}
+        }
+    }
+
+    let mut self_splits = Vec::new(env);
+    self_splits.push_back(SplitDelegation {
+        delegatee: delegator.clone(),
+        weight_bps: BPS_DENOMINATOR,
+    });
+    apply_split_core(env, delegator.clone(), self_splits);
+    emit_split_undelegated(env, &delegator);
+}
+
+pub(crate) fn get_split_delegations(env: &Env, delegator: Address) -> Vec<SplitDelegation> {
+    let stored: Vec<SplitDelegation> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::SplitDelegations(delegator.clone()))
+        .unwrap_or(Vec::new(env));
+    if !stored.is_empty() {
+        return stored;
+    }
+
+    if let Some(delegatee) = env
+        .storage()
+        .persistent()
+        .get::<_, Address>(&DataKey::Delegate(delegator))
+    {
+        let mut v = Vec::new(env);
+        v.push_back(SplitDelegation {
+            delegatee,
+            weight_bps: BPS_DENOMINATOR,
+        });
+        return v;
+    }
+
+    Vec::new(env)
+}

--- a/contracts/token-votes/src/split_delegation_tests.rs
+++ b/contracts/token-votes/src/split_delegation_tests.rs
@@ -1,0 +1,246 @@
+//! Tests for split delegation (issue #994): percentage-based delegation
+//! across multiple delegatees, interop with the legacy single-delegate path,
+//! and registry bookkeeping for fractional contributions.
+
+use crate::{SplitDelegation, TokenVotesContract, TokenVotesContractClient};
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{token, Address, Env, Vec};
+
+fn setup(env: &Env, admin: &Address) -> (Address, Address) {
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_addr = sac.address();
+    let contract_id = env.register(TokenVotesContract, ());
+    let client = TokenVotesContractClient::new(env, &contract_id);
+    client.initialize(admin, &token_addr);
+    (contract_id, token_addr)
+}
+
+fn set_ledger(env: &Env, seq: u32) {
+    env.ledger().with_mut(|l| {
+        l.sequence_number = seq;
+    });
+}
+
+fn splits(env: &Env, entries: &[(Address, u32)]) -> Vec<SplitDelegation> {
+    let mut v = Vec::new(env);
+    for (delegatee, weight_bps) in entries {
+        v.push_back(SplitDelegation {
+            delegatee: delegatee.clone(),
+            weight_bps: *weight_bps,
+        });
+    }
+    v
+}
+
+#[test]
+fn test_two_way_split_divides_voting_power_with_no_rounding_loss() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    token::StellarAssetClient::new(&env, &token_addr).mint(&delegator, &1001i128);
+
+    set_ledger(&env, 10);
+    client.delegate_split(&delegator, &splits(&env, &[(a.clone(), 6000), (b.clone(), 4000)]));
+
+    let votes_a = client.get_votes(&a);
+    let votes_b = client.get_votes(&b);
+    assert_eq!(votes_a, 600);
+    assert_eq!(votes_b, 401); // 40% of 1001 = 400.4, remainder credited to last entry
+    assert_eq!(votes_a + votes_b, 1001);
+}
+
+#[test]
+fn test_legacy_delegate_unchanged_after_split_module_added() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    token::StellarAssetClient::new(&env, &token_addr).mint(&delegator, &1000i128);
+
+    set_ledger(&env, 10);
+    client.delegate(&delegator, &a);
+    assert_eq!(client.get_votes(&a), 1000);
+    assert_eq!(client.delegates(&delegator), Some(a.clone()));
+
+    set_ledger(&env, 20);
+    client.delegate(&delegator, &b);
+    assert_eq!(client.get_votes(&a), 0);
+    assert_eq!(client.get_votes(&b), 1000);
+    assert_eq!(client.delegates(&delegator), Some(b));
+
+    set_ledger(&env, 30);
+    client.undelegate(&delegator);
+    assert_eq!(client.get_votes(&delegator), 1000);
+    assert_eq!(client.delegates(&delegator), Some(delegator.clone()));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #21)")]
+fn test_delegate_split_rejects_weights_not_summing_to_10000() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    token::StellarAssetClient::new(&env, &token_addr).mint(&delegator, &1000i128);
+
+    client.delegate_split(&delegator, &splits(&env, &[(a, 6000), (b, 3000)]));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #19)")]
+fn test_delegate_split_rejects_duplicate_delegatees() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let a = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    token::StellarAssetClient::new(&env, &token_addr).mint(&delegator, &1000i128);
+
+    client.delegate_split(&delegator, &splits(&env, &[(a.clone(), 5000), (a, 5000)]));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #18)")]
+fn test_delegate_split_rejects_more_entries_than_max_split_targets() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    token::StellarAssetClient::new(&env, &token_addr).mint(&delegator, &1000i128);
+
+    client.set_max_split_targets(&admin, &2);
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    client.delegate_split(
+        &delegator,
+        &splits(&env, &[(a, 3400), (b, 3300), (c, 3300)]),
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #20)")]
+fn test_delegate_split_rejects_zero_weight_entry() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    token::StellarAssetClient::new(&env, &token_addr).mint(&delegator, &1000i128);
+
+    client.delegate_split(&delegator, &splits(&env, &[(a, 0), (b, 10000)]));
+}
+
+#[test]
+fn test_resplitting_replaces_not_merges_prior_split() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    token::StellarAssetClient::new(&env, &token_addr).mint(&delegator, &1000i128);
+
+    set_ledger(&env, 10);
+    client.delegate_split(&delegator, &splits(&env, &[(a.clone(), 5000), (b.clone(), 5000)]));
+    assert_eq!(client.get_votes(&a), 500);
+    assert_eq!(client.get_votes(&b), 500);
+
+    set_ledger(&env, 20);
+    client.delegate_split(&delegator, &splits(&env, &[(c.clone(), 10000)]));
+
+    // Prior split fully removed, not merged with the new one.
+    assert_eq!(client.get_votes(&a), 0);
+    assert_eq!(client.get_votes(&b), 0);
+    assert_eq!(client.get_votes(&c), 1000);
+
+    let current = client.get_split_delegations(&delegator);
+    assert_eq!(current.len(), 1);
+    assert_eq!(current.get(0).unwrap().delegatee, c);
+}
+
+#[test]
+fn test_undelegate_split_returns_full_power_across_all_prior_entries() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    token::StellarAssetClient::new(&env, &token_addr).mint(&delegator, &1000i128);
+
+    set_ledger(&env, 10);
+    client.delegate_split(&delegator, &splits(&env, &[(a.clone(), 6000), (b.clone(), 4000)]));
+
+    set_ledger(&env, 20);
+    client.undelegate_split(&delegator);
+
+    assert_eq!(client.get_votes(&a), 0);
+    assert_eq!(client.get_votes(&b), 0);
+    assert_eq!(client.get_votes(&delegator), 1000);
+    assert_eq!(client.get_delegator_count(&a), 0);
+    assert_eq!(client.get_delegator_count(&b), 0);
+}
+
+#[test]
+fn test_delegator_count_and_received_delegations_reflect_fractional_split() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let (contract_id, token_addr) = setup(&env, &admin);
+    let client = TokenVotesContractClient::new(&env, &contract_id);
+    token::StellarAssetClient::new(&env, &token_addr).mint(&delegator, &1000i128);
+
+    set_ledger(&env, 10);
+    client.delegate_split(&delegator, &splits(&env, &[(a.clone(), 7000), (b.clone(), 3000)]));
+
+    assert_eq!(client.get_delegator_count(&a), 1);
+    assert_eq!(client.get_delegator_count(&b), 1);
+
+    let received_a = client.get_received_delegations(&a, &0, &10);
+    assert_eq!(received_a.len(), 1);
+    assert_eq!(received_a.get(0).unwrap().delegator, delegator);
+    assert_eq!(received_a.get(0).unwrap().voting_power_at_delegation, 700);
+
+    let received_b = client.get_received_delegations(&b, &0, &10);
+    assert_eq!(received_b.len(), 1);
+    assert_eq!(received_b.get(0).unwrap().voting_power_at_delegation, 300);
+}

--- a/packages/indexer/migrations/016_add_split_delegation.sql
+++ b/packages/indexer/migrations/016_add_split_delegation.sql
@@ -1,0 +1,19 @@
+-- Up Migration
+
+CREATE TABLE IF NOT EXISTS split_delegations (
+    id SERIAL PRIMARY KEY,
+    delegator_address VARCHAR(56) NOT NULL,
+    delegatee_address VARCHAR(56) NOT NULL,
+    weight_bps INTEGER NOT NULL,
+    delegated_power NUMERIC(38,0) NOT NULL,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    revoked_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_split_delegator ON split_delegations(delegator_address) WHERE active;
+CREATE INDEX IF NOT EXISTS idx_split_delegatee ON split_delegations(delegatee_address) WHERE active;
+
+-- Down Migration
+
+DROP TABLE IF EXISTS split_delegations;

--- a/packages/indexer/src/api.ts
+++ b/packages/indexer/src/api.ts
@@ -832,6 +832,65 @@ export function createApp(server: SorobanRpc.Server): express.Application {
     },
   );
 
+  // --- Split delegation endpoints (issue #994) ---
+
+  // GET /delegates/:address/split-delegations — the delegatee's inbound
+  // split delegations, with per-delegator weight_bps.
+  app.get(
+    "/delegates/:address/split-delegations",
+    strictLimiter,
+    async (req: Request, res: Response): Promise<void> => {
+      const { address } = req.params;
+      const offset = Math.max(Number(req.query.offset ?? 0), 0);
+      const limit = Math.min(Math.max(Number(req.query.limit ?? 50), 1), 200);
+      const key = `split-delegations:delegatee:${address}:${offset}:${limit}`;
+      try {
+        const data = await cached(key, TTL.delegationRegistry, async () => {
+          const result = await pool.query(
+            `SELECT delegator_address, weight_bps, delegated_power, created_at
+             FROM split_delegations
+             WHERE delegatee_address = $1 AND active = TRUE
+             ORDER BY created_at ASC
+             OFFSET $2 LIMIT $3`,
+            [address, offset, limit],
+          );
+          return {
+            splitDelegations: result.rows,
+            pagination: { limit, offset, hasMore: result.rows.length === limit },
+          };
+        });
+        res.json(data);
+      } catch {
+        res.status(500).json({ error: "Internal server error" });
+      }
+    },
+  );
+
+  // GET /delegators/:address/split-delegations — the delegator's outbound splits.
+  app.get(
+    "/delegators/:address/split-delegations",
+    strictLimiter,
+    async (req: Request, res: Response): Promise<void> => {
+      const { address } = req.params;
+      const key = `split-delegations:delegator:${address}`;
+      try {
+        const data = await cached(key, TTL.delegationRegistry, async () => {
+          const result = await pool.query(
+            `SELECT delegatee_address, weight_bps, delegated_power, created_at
+             FROM split_delegations
+             WHERE delegator_address = $1 AND active = TRUE
+             ORDER BY weight_bps DESC`,
+            [address],
+          );
+          return { splitDelegations: result.rows };
+        });
+        res.json(data);
+      } catch {
+        res.status(500).json({ error: "Internal server error" });
+      }
+    },
+  );
+
   // GET /delegation-graph?top=100 — top delegatees by active delegator count.
   app.get(
     "/delegation-graph",

--- a/packages/indexer/src/events.ts
+++ b/packages/indexer/src/events.ts
@@ -301,6 +301,12 @@ export async function processEvents(
             case "RelayerWhitelistUpdated":
               await handleRelayerWhitelistUpdated(event, topics);
               break;
+            case "SplitDelegated":
+              await handleSplitDelegated(event, topics);
+              break;
+            case "SplitUndelegated":
+              await handleSplitUndelegated(event, topics);
+              break;
             default:
               break;
           }
@@ -793,6 +799,81 @@ async function handleDelegationDepthLimitUpdated(
   broadcast({
     type: "delegation_depth_limit_updated",
     data: { old_limit: oldLimit, new_limit: newLimit, ledger: event.ledger },
+  });
+}
+
+// --- Split delegation events (#994) ---
+//
+// `SplitDelegated` reports the delegator's full new set of (delegatee,
+// weight_bps) targets, replacing (not merging with) whatever this delegator
+// had on file. The contract emits per-entry `DelegationRegistered`/
+// `DelegationRevoked` events immediately before/after (same tx) via the same
+// delegation-registry bookkeeping the legacy single-delegate path uses, so
+// `delegation_entries` (and therefore `/delegates/:address/delegators`)
+// already reflects fractional split power with no extra handling here — we
+// just look those rows up to get each entry's absolute `delegated_power`
+// for the split-specific `split_delegations` table.
+
+async function handleSplitDelegated(
+  event: SorobanRpc.Api.EventResponse,
+  topics: unknown[],
+): Promise<void> {
+  const delegator = topics[1] as string;
+  const splits = scValToNative(event.value) as Array<{
+    delegatee: string;
+    weight_bps: number;
+  }>;
+
+  await pool.query(
+    `UPDATE split_delegations SET active = FALSE, revoked_at = NOW()
+     WHERE delegator_address = $1 AND active = TRUE`,
+    [delegator],
+  );
+
+  for (const entry of splits) {
+    const powerResult = await pool.query(
+      `SELECT power_at_delegation FROM delegation_entries
+       WHERE delegator_address = $1 AND delegatee_address = $2 AND active = TRUE
+       ORDER BY id DESC LIMIT 1`,
+      [delegator, entry.delegatee],
+    );
+    const delegatedPower = powerResult.rows[0]?.power_at_delegation ?? "0";
+
+    await pool.query(
+      `INSERT INTO split_delegations
+         (delegator_address, delegatee_address, weight_bps, delegated_power, active)
+       VALUES ($1, $2, $3, $4, TRUE)`,
+      [delegator, entry.delegatee, entry.weight_bps, delegatedPower],
+    );
+  }
+
+  invalidatePattern("delegates:");
+  invalidatePattern("split-delegations:");
+  invalidate(`profile:${delegator}`);
+  broadcast({
+    type: "split_delegated",
+    data: { delegator, splits, ledger: event.ledger },
+  });
+}
+
+async function handleSplitUndelegated(
+  event: SorobanRpc.Api.EventResponse,
+  topics: unknown[],
+): Promise<void> {
+  const delegator = topics[1] as string;
+
+  await pool.query(
+    `UPDATE split_delegations SET active = FALSE, revoked_at = NOW()
+     WHERE delegator_address = $1 AND active = TRUE`,
+    [delegator],
+  );
+
+  invalidatePattern("delegates:");
+  invalidatePattern("split-delegations:");
+  invalidate(`profile:${delegator}`);
+  broadcast({
+    type: "split_undelegated",
+    data: { delegator, ledger: event.ledger },
   });
 }
 

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -256,6 +256,11 @@ export enum VotesErrorCode {
   RelayerNotWhitelisted = 14,
   InvalidChainId = 15,
   InvalidContractId = 16,
+  ChainDepthExceeded = 17,
+  SplitTooManyTargets = 18,
+  SplitDuplicateDelegatee = 19,
+  SplitZeroWeight = 20,
+  SplitWeightsMustSum10000 = 21,
 
   // SDK-level codes
   SimulationFailed = 100,
@@ -280,6 +285,16 @@ const VOTES_MESSAGES: Record<VotesErrorCode, string> = {
     "Permit was signed for a different network",
   [VotesErrorCode.InvalidContractId]:
     "Permit was signed for a different contract",
+  [VotesErrorCode.ChainDepthExceeded]:
+    "Delegation would exceed the maximum chain depth",
+  [VotesErrorCode.SplitTooManyTargets]:
+    "Split delegation has more entries than the maximum allowed targets",
+  [VotesErrorCode.SplitDuplicateDelegatee]:
+    "Split delegation contains a duplicate delegatee",
+  [VotesErrorCode.SplitZeroWeight]:
+    "Split delegation entry must have a non-zero weight",
+  [VotesErrorCode.SplitWeightsMustSum10000]:
+    "Split delegation weights must sum to exactly 10000 (100%)",
 
   [VotesErrorCode.SimulationFailed]: "Simulation failed",
   [VotesErrorCode.TransactionFailed]: "Transaction failed",

--- a/sdk/src/types/index.ts
+++ b/sdk/src/types/index.ts
@@ -622,6 +622,17 @@ export interface DelegateProfile {
   firstDelegatedAtLedger: number | null;
 }
 
+/**
+ * One entry of a split delegation (issue #994): a fraction of the
+ * delegator's voting power, in basis points (10000 = 100%), directed to
+ * `delegatee`. Mirrors `SplitDelegation` in
+ * contracts/token-votes/src/split_delegation.rs.
+ */
+export interface SplitDelegation {
+  delegatee: string;
+  weightBps: number;
+}
+
 // ─── Treasury Types ───────────────────────────────────────────────────────────
 
 /** Configuration for {@link TreasuryClient}. */

--- a/sdk/src/votes.ts
+++ b/sdk/src/votes.ts
@@ -22,6 +22,7 @@ import {
   DelegationHistoryEntry,
   RegistryDelegatorInfo,
   DelegateProfile,
+  SplitDelegation,
 } from "./types";
 import { VotesError, VotesErrorCode, parseVotesError } from "./errors";
 import { withRetry, isNetworkError } from "./utils";
@@ -278,6 +279,191 @@ export class VotesClient {
         throw parseVotesError(result);
       }
     }, (e) => this.isRetryableSubmissionError(e));
+  }
+
+  /**
+   * Struct fields are serialized as a map sorted alphabetically by field
+   * name (`delegatee` then `weight_bps`) — soroban-sdk's `#[contracttype]`
+   * derive convention. Mirrors `permitToScVal` in delegation-sig.ts.
+   */
+  private splitDelegationToScVal(split: SplitDelegation): xdr.ScVal {
+    return nativeToScVal(
+      { delegatee: split.delegatee, weight_bps: split.weightBps },
+      { type: { delegatee: ["symbol", "address"], weight_bps: ["symbol", "u32"] } },
+    );
+  }
+
+  private parseSplitDelegation(native: Record<string, unknown>): SplitDelegation {
+    return {
+      delegatee: String(native.delegatee),
+      weightBps: Number(native.weight_bps),
+    };
+  }
+
+  /**
+   * Delegate arbitrary basis-point percentages of the caller's voting power
+   * across multiple delegatees at once (issue #994). `splits` must sum to
+   * exactly 10000 (100%); see `delegate_split` in the token-votes contract
+   * for the full validation rules. Replaces (not merges with) any prior
+   * split or legacy single delegation.
+   *
+   * @returns The Stellar transaction hash.
+   */
+  async delegateSplit(signer: Keypair, splits: SplitDelegation[]): Promise<string> {
+    return this.retry(async () => {
+      const account = await this.server.getAccount(signer.publicKey());
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(
+          this.contract.call(
+            "delegate_split",
+            nativeToScVal(signer.publicKey(), { type: "address" }),
+            xdr.ScVal.scvVec(splits.map((s) => this.splitDelegationToScVal(s))),
+          ),
+        )
+        .setTimeout(30)
+        .build();
+
+      const prepared = await this.server.prepareTransaction(tx);
+      prepared.sign(signer);
+      const result = await this.server.sendTransaction(prepared);
+      if (result.status === "ERROR") {
+        throw parseVotesError(result);
+      }
+      return result.hash;
+    }, (e) => this.isRetryableSubmissionError(e));
+  }
+
+  /**
+   * Wallet-signing variant of {@link delegateSplit}: takes the signer's
+   * public key plus a callback that signs an unsigned XDR envelope instead
+   * of a raw Keypair. Mirrors {@link delegateWithSign}.
+   *
+   * @returns The Stellar transaction hash.
+   */
+  async delegateSplitWithSign(
+    signerPublicKey: string,
+    splits: SplitDelegation[],
+    signUnsignedXdr: (xdr: string) => Promise<string>,
+  ): Promise<string> {
+    return this.retry(async () => {
+      const account = await this.server.getAccount(signerPublicKey);
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(
+          this.contract.call(
+            "delegate_split",
+            nativeToScVal(signerPublicKey, { type: "address" }),
+            xdr.ScVal.scvVec(splits.map((s) => this.splitDelegationToScVal(s))),
+          ),
+        )
+        .setTimeout(30)
+        .build();
+
+      const prepared = await this.server.prepareTransaction(tx);
+      const signedXdr = await signUnsignedXdr(prepared.toXDR());
+      const signed = TransactionBuilder.fromXDR(signedXdr, this.networkPassphrase);
+
+      const result = await this.server.sendTransaction(signed);
+      if (result.status === "ERROR") {
+        throw parseVotesError(result);
+      }
+      return result.hash;
+    }, (e) => this.isRetryableSubmissionError(e));
+  }
+
+  /**
+   * Revoke split delegation and return full voting power to the caller
+   * across all previously-split entries (issue #994). No-op if the caller
+   * has never delegated or is already self-delegated.
+   *
+   * @returns The Stellar transaction hash.
+   */
+  async undelegateSplit(signer: Keypair): Promise<string> {
+    return this.retry(async () => {
+      const account = await this.server.getAccount(signer.publicKey());
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(
+          this.contract.call(
+            "undelegate_split",
+            nativeToScVal(signer.publicKey(), { type: "address" }),
+          ),
+        )
+        .setTimeout(30)
+        .build();
+
+      const prepared = await this.server.prepareTransaction(tx);
+      prepared.sign(signer);
+      const result = await this.server.sendTransaction(prepared);
+      if (result.status === "ERROR") {
+        throw parseVotesError(result);
+      }
+      return result.hash;
+    }, (e) => this.isRetryableSubmissionError(e));
+  }
+
+  /**
+   * Wallet-signing variant of {@link undelegateSplit}: takes the signer's
+   * public key plus a callback that signs an unsigned XDR envelope instead
+   * of a raw Keypair. Mirrors {@link undelegateWithSign}.
+   *
+   * @returns The Stellar transaction hash.
+   */
+  async undelegateSplitWithSign(
+    signerPublicKey: string,
+    signUnsignedXdr: (xdr: string) => Promise<string>,
+  ): Promise<string> {
+    return this.retry(async () => {
+      const account = await this.server.getAccount(signerPublicKey);
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(
+          this.contract.call(
+            "undelegate_split",
+            nativeToScVal(signerPublicKey, { type: "address" }),
+          ),
+        )
+        .setTimeout(30)
+        .build();
+
+      const prepared = await this.server.prepareTransaction(tx);
+      const signedXdr = await signUnsignedXdr(prepared.toXDR());
+      const signed = TransactionBuilder.fromXDR(signedXdr, this.networkPassphrase);
+
+      const result = await this.server.sendTransaction(signed);
+      if (result.status === "ERROR") {
+        throw parseVotesError(result);
+      }
+      return result.hash;
+    }, (e) => this.isRetryableSubmissionError(e));
+  }
+
+  /**
+   * Get a delegator's current split delegations (issue #994). Falls back to
+   * reporting a legacy single delegation (if any) as a single 100% entry, so
+   * callers don't need to know which path the delegator used.
+   */
+  async getSplitDelegations(delegator: string): Promise<SplitDelegation[]> {
+    return this.simulateRead(
+      "get_split_delegations",
+      [nativeToScVal(delegator, { type: "address" })],
+      (raw) =>
+        (scValToNative(raw) as Record<string, unknown>[]).map((e) => this.parseSplitDelegation(e)),
+      [],
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes #994.

Adds split delegation to `contracts/token-votes`: a holder can delegate arbitrary basis-point percentages of their voting power across up to `MaxSplitTargets` delegatees in one call (`delegate_split`), instead of the existing all-or-nothing `delegate()`.

- **Contract** (`contracts/token-votes/src/split_delegation.rs`): new `delegate_split` / `undelegate_split` / `get_split_delegations` / `set_max_split_targets` entrypoints. Additive only — `delegate()`/`undelegate()` and everything in `delegation_registry.rs` (chain resolution, depth limits, cycle detection) are untouched and keep working exactly as before for any account that never calls the split API. A single 100%-weight split collapses back into the legacy `Delegate` storage key on write, and `get_split_delegations` falls back to reporting a legacy single delegation as one 100% entry on read, so the two paths stay interoperable in the legacy→split direction (see the module doc comment for the one documented limitation: a genuine multi-entry split delegator calling the plain `delegate()` afterward is out of scope, matching the issue's one-directional compatibility requirement).
- Reuses `delegation_registry::register_delegation` / `revoke_registry_entry` per split entry (as requested), so `get_delegator_count`, `get_received_delegations`, and delegation history all correctly reflect fractional contributions with the same bookkeeping the legacy path already uses.
- Rounding remainder from the bps split is credited to the last entry so the parts always sum exactly to the delegator's balance.
- **Tests** (`contracts/token-votes/src/split_delegation_tests.rs`): 60/40 split with no rounding loss, legacy `delegate()` regression coverage, rejecting bad weight sums/duplicates/too-many-targets/zero-weight, re-splitting replacing (not merging) a prior split, `undelegate_split` returning full power, and delegator-count/received-delegations reflecting fractional splits.
- **Indexer**: new `split_delegations` table + migration, `SplitDelegated`/`SplitUndelegated` event handlers, and `GET /delegates/:address/split-delegations` / `GET /delegators/:address/split-delegations`. `/delegates/:address/delegators` needed no changes — it's already split-aware via the reused registry bookkeeping above.
- **SDK** (`sdk/src/votes.ts`): `delegateSplit`/`undelegateSplit` (+ wallet-signing `WithSign` variants, needed for the frontend since the issue's spec only listed the raw-Keypair form) and `getSplitDelegations`.
- **Frontend**: new `SplitDelegationEditor` with add/remove rows and live 100%-sum validation, wired into the delegate flow ("Split my delegation instead") and the profile page's delegation card; `DelegatorList` now shows a per-delegator weight badge for partial delegations.

## Test plan

- [ ] `split_delegation_tests.rs` covers the contract logic described above (CI runs `cargo test` on push).
- [ ] Manually exercise: split-delegate to 2 addresses, confirm voting power divides correctly and no legacy behavior regresses; re-split replaces the prior split; undelegate_split returns full power.