### PR TITLE
feat: validate snapshot ledger, tuning distributed lock & deduplication, and non-admin strategy test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,6 +1597,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "sorogov-optimistic-governor"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "sorogov-proposal-bonds"
 version = "0.1.0"
 dependencies = [

--- a/backend/src/__tests__/governance-tuning-service.test.ts
+++ b/backend/src/__tests__/governance-tuning-service.test.ts
@@ -1,0 +1,142 @@
+import pool from "../db/pool";
+import { GovernanceTuningAnalyzerService } from "../jobs/governance-tuning-analyzer";
+import * as analyzerMod from "../governance-tuning/analyzer";
+import * as configStoreMod from "../governance-tuning/config-store";
+import * as autoProposeMod from "../governance-tuning/auto-propose";
+
+describe("GovernanceTuningAnalyzerService Deduplication and Distributed Lock (Issues #1125, #1126)", () => {
+  let service: GovernanceTuningAnalyzerService;
+  const createdIds: number[] = [];
+
+  beforeEach(() => {
+    service = new GovernanceTuningAnalyzerService();
+    jest.restoreAllMocks();
+  });
+
+  afterEach(async () => {
+    if (createdIds.length > 0) {
+      await pool.query("DELETE FROM governance_tuning_recommendations WHERE id = ANY($1)", [createdIds]);
+      createdIds.length = 0;
+    }
+  });
+
+  it("inserts a new recommendation when recommendation is changed", async () => {
+    jest.spyOn(configStoreMod, "getGovernanceTuningConfig").mockResolvedValue({
+      minQuorumNumerator: 100,
+      maxQuorumNumerator: 5000,
+      maxQuorumDeltaBps: 200,
+      minProposalThreshold: 0n,
+      maxProposalThreshold: null,
+      maxThresholdDeltaBps: 1000,
+      trailingWindow: 10,
+      intervalMs: 60000,
+      autoPropose: false,
+      updatedAt: new Date().toISOString(),
+    });
+
+    jest.spyOn(analyzerMod, "gatherAnalyzerInputs").mockResolvedValue({
+      currentQuorumNumerator: 1000,
+      currentProposalThreshold: 1000000n,
+      quorumHitCount: 10n,
+      quorumMissCount: 0n,
+      snapshotVotesCast: [100n, 200n, 300n],
+    });
+
+    jest.spyOn(analyzerMod, "computeRecommendation").mockReturnValue({
+      recommendedQuorumNumerator: 1200, // changed
+      recommendedProposalThreshold: 900000n, // changed
+      rationale: {
+        quorumNumerator: { direction: "up", reason: "Participation rising" },
+        proposalThreshold: { direction: "down", reason: "Quorum hit high" },
+        votingPeriod: { direction: "unchanged", reason: "Fixed" },
+        inputs: {},
+      },
+    });
+
+    await service.runCycle();
+
+    const { rows } = await pool.query(
+      "SELECT * FROM governance_tuning_recommendations ORDER BY id DESC LIMIT 1",
+    );
+    expect(rows.length).toBe(1);
+    expect(rows[0].recommended_quorum_numerator).toBe(1200);
+    createdIds.push(rows[0].id);
+  });
+
+  it("does not insert a duplicate row on consecutive unchanged cycles, but updates computed_at", async () => {
+    jest.spyOn(configStoreMod, "getGovernanceTuningConfig").mockResolvedValue({
+      minQuorumNumerator: 100,
+      maxQuorumNumerator: 5000,
+      maxQuorumDeltaBps: 200,
+      minProposalThreshold: 0n,
+      maxProposalThreshold: null,
+      maxThresholdDeltaBps: 1000,
+      trailingWindow: 10,
+      intervalMs: 60000,
+      autoPropose: false,
+      updatedAt: new Date().toISOString(),
+    });
+
+    jest.spyOn(analyzerMod, "gatherAnalyzerInputs").mockResolvedValue({
+      currentQuorumNumerator: 1000,
+      currentProposalThreshold: 1000000n,
+      quorumHitCount: 5n,
+      quorumMissCount: 5n,
+      snapshotVotesCast: [100n, 100n, 100n],
+    });
+
+    // Unchanged recommendation
+    jest.spyOn(analyzerMod, "computeRecommendation").mockReturnValue({
+      recommendedQuorumNumerator: 1000,
+      recommendedProposalThreshold: 1000000n,
+      rationale: {
+        quorumNumerator: { direction: "unchanged", reason: "Stable" },
+        proposalThreshold: { direction: "unchanged", reason: "Stable" },
+        votingPeriod: { direction: "unchanged", reason: "Fixed" },
+        inputs: {},
+      },
+    });
+
+    // Cycle 1: inserts the initial unchanged row
+    await service.runCycle();
+    const { rows: firstRows } = await pool.query(
+      "SELECT * FROM governance_tuning_recommendations ORDER BY id DESC LIMIT 1",
+    );
+    expect(firstRows.length).toBe(1);
+    const firstId = firstRows[0].id;
+    createdIds.push(firstId);
+
+    // Count before Cycle 2
+    const { rows: countBefore } = await pool.query(
+      "SELECT count(*)::int as cnt FROM governance_tuning_recommendations",
+    );
+
+    // Cycle 2: unchanged recommendation again
+    await service.runCycle();
+
+    const { rows: countAfter } = await pool.query(
+      "SELECT count(*)::int as cnt FROM governance_tuning_recommendations",
+    );
+
+    // No new row inserted
+    expect(countAfter[0].cnt).toBe(countBefore[0].cnt);
+  });
+
+  it("skips execution when advisory lock is held by another replica", async () => {
+    const client = await pool.connect();
+    try {
+      // Acquire lock on separate client
+      await client.query("SELECT pg_advisory_lock(hashtextextended('governance_tuning_analyzer_cycle', 0))");
+
+      const runSpy = jest.spyOn(service, "runCycle");
+
+      // runCycleWithLock should attempt and skip because lock is already held
+      await service.runCycleWithLock();
+
+      expect(runSpy).not.toHaveBeenCalled();
+    } finally {
+      await client.query("SELECT pg_advisory_unlock(hashtextextended('governance_tuning_analyzer_cycle', 0))");
+      client.release();
+    }
+  });
+});

--- a/backend/src/__tests__/signaling-routes.test.ts
+++ b/backend/src/__tests__/signaling-routes.test.ts
@@ -11,16 +11,18 @@ jest.mock("../signaling/tally", () => ({
   getCurrentVotingPower: jest.fn(),
   getProposalThreshold: jest.fn(),
   computeWeightedTally: jest.fn(),
+  getLatestLedgerSequence: jest.fn(),
 }));
 
 import app from "../index";
 import pool from "../db/pool";
 import { canonicalSignalPayload, sep53Digest } from "../signaling/signature";
-import { getCurrentVotingPower, getProposalThreshold, computeWeightedTally } from "../signaling/tally";
+import { getCurrentVotingPower, getProposalThreshold, computeWeightedTally, getLatestLedgerSequence } from "../signaling/tally";
 
 const mockGetCurrentVotingPower = getCurrentVotingPower as jest.Mock;
 const mockGetProposalThreshold = getProposalThreshold as jest.Mock;
 const mockComputeWeightedTally = computeWeightedTally as jest.Mock;
+const mockGetLatestLedgerSequence = getLatestLedgerSequence as jest.Mock;
 
 // SEP-53-signs the canonical payload, matching what a real wallet's
 // signMessage does internally — see signaling/signature.ts's sep53Digest.
@@ -56,6 +58,7 @@ describe("Signaling Endpoints", () => {
   }> = {}) {
     mockGetCurrentVotingPower.mockResolvedValue(1000n);
     mockGetProposalThreshold.mockResolvedValue(500n);
+    mockGetLatestLedgerSequence.mockResolvedValue(1000);
 
     const creator = Keypair.random();
     const res = await request(app)
@@ -78,6 +81,7 @@ describe("Signaling Endpoints", () => {
   it("POST /signaling/polls rejects a creator below the proposal threshold", async () => {
     mockGetCurrentVotingPower.mockResolvedValue(100n);
     mockGetProposalThreshold.mockResolvedValue(500n);
+    mockGetLatestLedgerSequence.mockResolvedValue(1000);
     const creator = Keypair.random();
 
     await request(app)
@@ -92,6 +96,28 @@ describe("Signaling Endpoints", () => {
         endTime: new Date(Date.now() + 3_600_000).toISOString(),
       })
       .expect(403);
+  });
+
+  it("POST /signaling/polls rejects a snapshotLedger in the future", async () => {
+    mockGetCurrentVotingPower.mockResolvedValue(1000n);
+    mockGetProposalThreshold.mockResolvedValue(500n);
+    mockGetLatestLedgerSequence.mockResolvedValue(500);
+    const creator = Keypair.random();
+
+    const res = await request(app)
+      .post("/signaling/polls")
+      .send({
+        creatorAddress: creator.publicKey(),
+        title: "Future snapshot poll",
+        description: "Should fail with 400",
+        choices: ["Yes", "No"],
+        snapshotLedger: 999999,
+        startTime: new Date().toISOString(),
+        endTime: new Date(Date.now() + 3_600_000).toISOString(),
+      })
+      .expect(400);
+
+    expect(res.body.error).toMatch(/cannot be in the future/);
   });
 
   it("POST /signaling/polls creates a poll when the creator meets the threshold", async () => {

--- a/backend/src/governance-tuning/recommendation-store.ts
+++ b/backend/src/governance-tuning/recommendation-store.ts
@@ -83,6 +83,31 @@ export async function getLatestRecommendation(): Promise<TuningRecommendation | 
   return result.rows.length === 0 ? null : rowToRecommendation(result.rows[0]);
 }
 
+export async function touchLatestRecommendation(id: number): Promise<void> {
+  await pool.query(
+    `UPDATE governance_tuning_recommendations SET computed_at = NOW() WHERE id = $1`,
+    [id],
+  );
+}
+
+/**
+ * Retention policy for unchanged recommendation entries: deletes unchanged
+ * records older than `retentionDays` to avoid unbounded table growth on fast
+ * interval configurations.
+ */
+export async function pruneUnchangedRecommendations(retentionDays = 30): Promise<number> {
+  const result = await pool.query(
+    `DELETE FROM governance_tuning_recommendations
+     WHERE auto_proposed = FALSE
+       AND proposal_id IS NULL
+       AND current_quorum_numerator = recommended_quorum_numerator
+       AND current_proposal_threshold = recommended_proposal_threshold
+       AND computed_at < NOW() - ($1 || ' days')::INTERVAL`,
+    [retentionDays],
+  );
+  return result.rowCount ?? 0;
+}
+
 export async function listRecommendations(
   limit: number,
   offset: number,

--- a/backend/src/jobs/governance-tuning-analyzer.ts
+++ b/backend/src/jobs/governance-tuning-analyzer.ts
@@ -1,13 +1,28 @@
+import pool from "../db/pool";
 import { logger } from "../logger";
 import { computeRecommendation, gatherAnalyzerInputs } from "../governance-tuning/analyzer";
 import { getGovernanceTuningConfig } from "../governance-tuning/config-store";
-import { insertRecommendation } from "../governance-tuning/recommendation-store";
+import {
+  insertRecommendation,
+  getLatestRecommendation,
+  touchLatestRecommendation,
+  pruneUnchangedRecommendations,
+} from "../governance-tuning/recommendation-store";
 import { findUnresolvedAutoProposal, maybeAutoPropose } from "../governance-tuning/auto-propose";
 
+const GOVERNANCE_TUNING_LOCK_KEY = "governance_tuning_analyzer_cycle";
+
 /**
- * Governance tuning recommender (issue #998). Same footing as
- * `NotificationProcessorService`: a standalone background job started from
- * `bootstrap()`, not a one-off script.
+ * Governance tuning recommender (issue #998, #1125, #1126).
+ *
+ * Runs as a scheduled background service. Protected against race conditions
+ * across horizontally-scaled backend replicas via a distributed Postgres
+ * advisory lock (`pg_try_advisory_lock`).
+ *
+ * Implements a deduplication and retention policy: when recommendations are
+ * unchanged across consecutive cycles, it updates the timestamp on the existing
+ * latest record rather than inserting redundant rows, and prunes stale unchanged
+ * records.
  */
 export class GovernanceTuningAnalyzerService {
   private timer: NodeJS.Timeout | null = null;
@@ -49,11 +64,41 @@ export class GovernanceTuningAnalyzerService {
     if (this.running) return;
     this.running = true;
     try {
-      await this.runCycle();
+      await this.runCycleWithLock();
     } catch (err) {
       logger.error({ err }, "Governance tuning analyzer cycle failed");
     } finally {
       this.running = false;
+    }
+  }
+
+  /**
+   * Acquires a Postgres advisory lock before running the cycle to guard
+   * against concurrent executions from horizontally-scaled backend replicas.
+   */
+  async runCycleWithLock(): Promise<void> {
+    const client = await pool.connect();
+    try {
+      const { rows } = await client.query(
+        `SELECT pg_try_advisory_lock(hashtextextended($1, 0)) AS acquired`,
+        [GOVERNANCE_TUNING_LOCK_KEY],
+      );
+      if (!rows[0]?.acquired) {
+        logger.info(
+          "Governance tuning: another replica is currently executing the tuning cycle — skipping",
+        );
+        return;
+      }
+
+      try {
+        await this.runCycle();
+      } finally {
+        await client.query(`SELECT pg_advisory_unlock(hashtextextended($1, 0))`, [
+          GOVERNANCE_TUNING_LOCK_KEY,
+        ]);
+      }
+    } finally {
+      client.release();
     }
   }
 
@@ -86,6 +131,29 @@ export class GovernanceTuningAnalyzerService {
       }
     }
 
+    // De-duplication: when consecutive cycles produce unchanged recommendations,
+    // update the timestamp on the existing latest record to avoid unbounded table bloat.
+    const latest = await getLatestRecommendation();
+    const isConsecutiveUnchanged =
+      unchanged &&
+      latest !== null &&
+      latest.recommendedQuorumNumerator === result.recommendedQuorumNumerator &&
+      latest.recommendedProposalThreshold === result.recommendedProposalThreshold &&
+      !latest.autoProposed;
+
+    if (isConsecutiveUnchanged) {
+      await touchLatestRecommendation(latest.id);
+      logger.info(
+        { id: latest.id, unchanged: true, autoProposed: false },
+        "Governance tuning: recommendation unchanged — updated last checked timestamp on latest row",
+      );
+      // Prune old unchanged rows periodically
+      await pruneUnchangedRecommendations().catch((err) => {
+        logger.warn({ err }, "Failed to prune old unchanged recommendations");
+      });
+      return;
+    }
+
     const stored = await insertRecommendation({
       currentQuorumNumerator: inputs.currentQuorumNumerator,
       recommendedQuorumNumerator: result.recommendedQuorumNumerator,
@@ -94,6 +162,11 @@ export class GovernanceTuningAnalyzerService {
       rationale: result.rationale,
       autoProposed,
       proposalId,
+    });
+
+    // Prune old unchanged rows on new insertion
+    await pruneUnchangedRecommendations().catch((err) => {
+      logger.warn({ err }, "Failed to prune old unchanged recommendations");
     });
 
     logger.info(

--- a/backend/src/routes/signaling.ts
+++ b/backend/src/routes/signaling.ts
@@ -6,7 +6,7 @@ import { validate } from "../middleware/validate";
 import { logger } from "../logger";
 import { cached, invalidate } from "../cache";
 import { verifySignalVote } from "../signaling/signature";
-import { computeWeightedTally, getCurrentVotingPower, getProposalThreshold } from "../signaling/tally";
+import { computeWeightedTally, getCurrentVotingPower, getProposalThreshold, getLatestLedgerSequence } from "../signaling/tally";
 
 const router = Router();
 
@@ -96,13 +96,20 @@ router.post("/polls", signalingWriteLimiter, validate({ body: createPollSchema }
   const body = req.body as z.infer<typeof createPollSchema>;
 
   try {
-    const [power, threshold] = await Promise.all([
+    const [power, threshold, currentLedger] = await Promise.all([
       getCurrentVotingPower(body.creatorAddress),
       getProposalThreshold(),
+      getLatestLedgerSequence(),
     ]);
     if (power < threshold) {
       return res.status(403).json({
         error: `Creator voting power (${power}) is below the proposal threshold (${threshold})`,
+      });
+    }
+
+    if (body.snapshotLedger > currentLedger) {
+      return res.status(400).json({
+        error: `snapshotLedger (${body.snapshotLedger}) cannot be in the future (current ledger: ${currentLedger})`,
       });
     }
 

--- a/backend/src/signaling/tally.ts
+++ b/backend/src/signaling/tally.ts
@@ -26,9 +26,15 @@ function networkPassphrase(): string {
   return NETWORK_PASSPHRASES[key] ?? Networks.TESTNET;
 }
 
-function rpcServer(): rpc.Server {
+export function rpcServer(): rpc.Server {
   const url = process.env.STELLAR_RPC_URL ?? "https://soroban-testnet.stellar.org";
   return new rpc.Server(url, { allowHttp: false });
+}
+
+/** Fetches the latest committed ledger sequence height from Stellar RPC. */
+export async function getLatestLedgerSequence(): Promise<number> {
+  const latest = await rpcServer().getLatestLedger();
+  return latest.sequence;
 }
 
 function votesContract(): Contract {

--- a/contracts/treasury-strategies/src/tests.rs
+++ b/contracts/treasury-strategies/src/tests.rs
@@ -43,6 +43,16 @@ fn register_adapter(env: &Env, client: &TreasuryStrategiesContractClient, admin:
 }
 
 #[test]
+fn test_register_strategy_rejected_from_non_admin() {
+    let (env, client, _admin, _treasury, token, _sac_admin) = setup();
+    let intruder = Address::generate(&env);
+    let adapter_id = env.register(MockAdapter, ());
+
+    let result = client.try_register_strategy(&intruder, &adapter_id, &token, &10_000, &COOLDOWN);
+    assert!(result.is_err());
+}
+
+#[test]
 fn test_deposit_rejected_from_non_treasury() {
     let (env, client, admin, _treasury, token, sac_admin) = setup();
     register_adapter(&env, &client, &admin, &token, 10_000);


### PR DESCRIPTION
### Summary of Changes

This PR resolves four related issues across signaling poll validation, governance tuning background processing, and treasury strategy contract testing:

1. **Signaling Snapshot Ledger Validation (Closes #1124)**:
   - Added `getLatestLedgerSequence()` in `backend/src/signaling/tally.ts` to query the current ledger sequence from Soroban RPC.
   - Updated `POST /signaling/polls` in `backend/src/routes/signaling.ts` to reject any poll where `snapshotLedger > currentLedger` with HTTP 400.
   - Added unit test in `backend/src/__tests__/signaling-routes.test.ts` verifying future ledger sequence rejection.

2. **Governance Tuning Horizontally-Scaled Replica Protection (Closes #1125)**:
   - Added a distributed Postgres advisory lock (`pg_try_advisory_lock`) in `GovernanceTuningAnalyzerService.runCycleWithLock` (`backend/src/jobs/governance-tuning-analyzer.ts`) to ensure only one replica executes the tuning cycle and auto-propose checks at a time.
   - Added unit test in `backend/src/__tests__/governance-tuning-service.test.ts` verifying lock acquisition and graceful skip behavior.

3. **Governance Tuning Unchanged Row Deduplication and Retention Policy (Closes #1126)**:
   - Added `touchLatestRecommendation` and `pruneUnchangedRecommendations` in `backend/src/governance-tuning/recommendation-store.ts`.
   - Updated `GovernanceTuningAnalyzerService.runCycle` to avoid inserting redundant rows on consecutive unchanged cycles, updating the latest entry's `computed_at` timestamp instead.
   - Added retention pruning for unchanged entries older than 30 days.
   - Added unit test in `backend/src/__tests__/governance-tuning-service.test.ts` verifying deduplication behavior across consecutive unchanged cycles.

4. **Treasury Strategies Non-Admin Strategy Registration Test (Closes #1127)**:
   - Added `test_register_strategy_rejected_from_non_admin` in `contracts/treasury-strategies/src/tests.rs` asserting that non-admin callers attempting `register_strategy` fail access control.

---
Closes #1124
Closes #1125
Closes #1126
Closes #1127