### PR TITLE
fix(frontend): align hook errors, config, and dark-mode badges

### DIFF
--- a/app/src/components/BondStatusBadge.tsx
+++ b/app/src/components/BondStatusBadge.tsx
@@ -1,9 +1,24 @@
 import { BondState } from "@nebgov/sdk";
 
 const STATE_CONFIG: Record<BondState, { color: string; icon: string; label: string }> = {
-  Locked: { color: "bg-blue-100 text-blue-800 border border-blue-200", icon: '🔒', label: 'Locked' },
-  Refunded: { color: "bg-green-100 text-green-800 border border-green-200", icon: '✓', label: 'Refunded' },
-  Slashed: { color: "bg-red-100 text-red-800 border border-red-200", icon: '✕', label: 'Slashed' },
+  Locked: {
+    color:
+      "bg-blue-100 text-blue-800 border border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800",
+    icon: "🔒",
+    label: "Locked",
+  },
+  Refunded: {
+    color:
+      "bg-green-100 text-green-800 border border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-800",
+    icon: "✓",
+    label: "Refunded",
+  },
+  Slashed: {
+    color:
+      "bg-red-100 text-red-800 border border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-800",
+    icon: "✕",
+    label: "Slashed",
+  },
 };
 
 interface Props {
@@ -15,7 +30,7 @@ export function BondStatusBadge({ state }: Props) {
 
   if (!meta) {
     return (
-      <span className="px-3 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-700 border border-gray-200">
+      <span className="px-3 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-700 border border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700">
         Unknown
       </span>
     );

--- a/app/src/components/__tests__/BondStatusBadge.test.tsx
+++ b/app/src/components/__tests__/BondStatusBadge.test.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import type { BondState } from "@nebgov/sdk";
+import { BondStatusBadge } from "../BondStatusBadge";
+
+const STATES: BondState[] = ["Locked", "Refunded", "Slashed"];
+
+describe("BondStatusBadge", () => {
+  it.each(STATES)("includes dark-mode colors for %s bonds", (state) => {
+    const badge = renderer.create(<BondStatusBadge state={state} />).root.findByType("span");
+
+    expect(badge.props.className).toMatch(/dark:bg-/);
+    expect(badge.props.className).toMatch(/dark:text-/);
+    expect(badge.props.className).toMatch(/dark:border-/);
+  });
+});

--- a/app/src/hooks/useGovernanceTuning.ts
+++ b/app/src/hooks/useGovernanceTuning.ts
@@ -1,8 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { GovernanceTuningClient, type Network, type TuningRecommendation } from "@nebgov/sdk";
-import { backendBaseUrl } from "../lib/backend";
+import { GovernanceTuningClient, type TuningRecommendation } from "@nebgov/sdk";
+import { readGovernorConfig } from "../lib/nebgov-env";
 
 interface UseGovernanceTuningResult {
   latest: TuningRecommendation | null;
@@ -33,22 +33,12 @@ export function useGovernanceTuning(): UseGovernanceTuningResult {
       setLoading(true);
       setError(null);
       try {
-        const governorAddress = process.env.NEXT_PUBLIC_GOVERNOR_ADDRESS;
-        const timelockAddress = process.env.NEXT_PUBLIC_TIMELOCK_ADDRESS;
-        const votesAddress = process.env.NEXT_PUBLIC_VOTES_ADDRESS;
-        const network = (process.env.NEXT_PUBLIC_NETWORK || "testnet") as Network;
-
-        if (!governorAddress || !timelockAddress || !votesAddress) {
+        const config = readGovernorConfig();
+        if (!config) {
           throw new Error("Missing required environment variables for GovernanceTuningClient");
         }
 
-        const client = new GovernanceTuningClient({
-          governorAddress,
-          timelockAddress,
-          votesAddress,
-          network,
-          backendUrl: backendBaseUrl(),
-        });
+        const client = new GovernanceTuningClient(config);
 
         const [latestRec, historyRecs] = await Promise.all([
           client.getLatestRecommendation(),

--- a/app/src/hooks/useOptimisticProposals.ts
+++ b/app/src/hooks/useOptimisticProposals.ts
@@ -103,17 +103,18 @@ export function useOptimisticProposal(id: string | undefined) {
       const proposalRow = (await proposalRes.json()) as Record<string, unknown>;
       setProposal(parseProposal(proposalRow));
 
-      if (objectionsRes.ok) {
-        const body = (await objectionsRes.json()) as { data: Record<string, unknown>[] };
-        setObjections(
-          body.data.map((row) => ({
-            objector: String(row.objector),
-            weight: BigInt(String(row.weight)),
-            runningTotal: BigInt(String(row.running_total)),
-            ledger: Number(row.ledger),
-          })),
-        );
+      if (!objectionsRes.ok) {
+        throw new Error(`Indexer objections endpoint returned ${objectionsRes.status}`);
       }
+      const body = (await objectionsRes.json()) as { data: Record<string, unknown>[] };
+      setObjections(
+        body.data.map((row) => ({
+          objector: String(row.objector),
+          weight: BigInt(String(row.weight)),
+          runningTotal: BigInt(String(row.running_total)),
+          ledger: Number(row.ledger),
+        })),
+      );
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : "Failed to load proposal");
     } finally {

--- a/app/src/hooks/useSignalingPolls.ts
+++ b/app/src/hooks/useSignalingPolls.ts
@@ -23,14 +23,16 @@ export function useSignalingPolls(status?: "active" | "closed") {
   const client = useSignalingClient();
   const [polls, setPolls] = useState<SignalingPoll[]>([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     if (!client) return;
     setLoading(true);
+    setError(null);
     try {
       setPolls(await client.listPolls(status));
-    } catch {
-      // Backend unreachable — leave prior state in place.
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Failed to load signaling polls");
     } finally {
       setLoading(false);
     }
@@ -42,7 +44,7 @@ export function useSignalingPolls(status?: "active" | "closed") {
     return () => clearInterval(interval);
   }, [refresh]);
 
-  return { polls, loading, refresh };
+  return { polls, loading, error, refresh };
 }
 
 /** A single poll plus its live/final results, auto-refreshing while open. */
@@ -51,10 +53,12 @@ export function useSignalingPoll(pollId: number | null) {
   const [poll, setPoll] = useState<SignalingPoll | null>(null);
   const [results, setResults] = useState<SignalingPollResults | null>(null);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     if (!client || pollId === null) return;
     setLoading(true);
+    setError(null);
     try {
       const [nextPoll, nextResults] = await Promise.all([
         client.getPoll(pollId),
@@ -62,8 +66,8 @@ export function useSignalingPoll(pollId: number | null) {
       ]);
       setPoll(nextPoll);
       setResults(nextResults);
-    } catch {
-      // Backend unreachable — leave prior state in place.
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Failed to load signaling poll");
     } finally {
       setLoading(false);
     }
@@ -77,7 +81,7 @@ export function useSignalingPoll(pollId: number | null) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [refresh, poll?.finalized]);
 
-  return { poll, results, loading, refresh };
+  return { poll, results, loading, error, refresh };
 }
 
 /** Create-poll and cast-vote mutations — both require a connected wallet. */


### PR DESCRIPTION
## Summary

- build `GovernanceTuningClient` from the shared `readGovernorConfig()` helper
- add dark-mode background, text, and border colors to every bond status badge
- expose and clear fetch errors from both signaling poll hooks while preserving prior data
- report non-successful optimistic-proposal objection responses instead of treating them as an empty list
- add regression coverage for bond badge dark-mode variants

## Validation

- `pnpm --filter @nebgov/sdk run build`
- `pnpm eslint .`
- `pnpm tsc --noEmit`
- `pnpm test -- --runInBand src/components/__tests__/BondStatusBadge.test.tsx`
- `pnpm next build`

Closes #1116
Closes #1117
Closes #1118
Closes #1120
