### PR TITLE
Fixes four deployment-tooling gaps where contracts added in recent feature work weren't wired into the local deploy-verification script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,29 @@
 .PHONY: test-contracts build-wasm deploy-testnet verify-testnet fmt lint
 
-test-contracts:
-	cargo test --workspace -- --nocapture
+# Keep in sync with the package list in .github/workflows/rust.yml.
+CONTRACTS := \
+	sorogov-governor \
+	sorogov-timelock \
+	sorogov-token-votes \
+	sorogov-governor-factory \
+	sorogov-treasury \
+	sorogov-liquidity \
+	sorogov-token-votes-wrapper \
+	sorogov-co-sponsorship \
+	sorogov-conviction-voting \
+	sorogov-signal-anchor \
+	sorogov-proposal-bonds \
+	sorogov-treasury-strategies \
+	sorogov-optimistic-governor \
+	sorogov-voting-rewards
+
+CONTRACT_PACKAGES := $(foreach c,$(CONTRACTS),-p $(c))
+
+test-contracts: build-wasm
+	cargo test $(CONTRACT_PACKAGES) -- --nocapture
 
 build-wasm:
-	cargo build --release --target wasm32v1-none
+	cargo build --release --target wasm32v1-none $(CONTRACT_PACKAGES)
 
 deploy-testnet:
 	./scripts/deploy-testnet.sh
@@ -16,4 +35,4 @@ fmt:
 	cargo fmt --all
 
 lint:
-	cargo clippy --workspace -- -D warnings
+	cargo clippy $(CONTRACT_PACKAGES) -- -D warnings

--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,37 @@
+## Summary
+
+Fixes four deployment-tooling gaps where contracts added in recent feature work weren't wired into the local deploy-verification script or Makefile, so a broken deployment or a `make` run could silently skip them:
+
+- **#1102** — `scripts/verify-deployment.sh` had no check for `contracts/optimistic-governor`.
+- **#1101** — `scripts/verify-deployment.sh` had no check for `contracts/proposal-bonds`.
+- **#1099** — `Makefile` build/test targets didn't cover `contracts/treasury-strategies`, even though CI already builds/tests it via `-p sorogov-treasury-strategies`.
+- **#1097** — `Makefile` build/test targets didn't cover `contracts/optimistic-governor`, even though CI already builds/tests it via `-p sorogov-optimistic-governor`.
+
+## Changes
+
+**`scripts/verify-deployment.sh`**
+- Added a validation section for `OptimisticGovernor`: calls `get_config()`, which panics with `NotInitialized` until `initialize()` has succeeded, so a non-error response proves the contract is deployed *and* initialized. Also checks the returned `votes_token` matches the deployed `TOKEN_VOTES_ADDRESS`.
+- Added the same pattern for `ProposalBonds` using `get_settings()`, checking `governor` matches `GOVERNOR_ADDRESS`.
+- Added two small helpers, `check_initialized` and `check_contains`, since neither contract exposes a scalar `admin()`-style getter like the existing checks use — both only expose struct-returning getters.
+
+**`Makefile`**
+- Replaced the implicit `--workspace`/default-member build and test selection with an explicit `CONTRACT_PACKAGES` list (kept in sync with `.github/workflows/rust.yml`), so `test-contracts`, `build-wasm`, and `lint` always cover every contract by name — including `treasury-strategies` and `optimistic-governor` — instead of relying on undocumented workspace-default behavior.
+- Made `test-contracts` depend on `build-wasm`: `governor-factory`'s tests load prebuilt `.wasm` artifacts via `contractimport!`, which fails with "No such file or directory" on a clean checkout unless the WASM is built first — mirroring CI's separate "Build WASMs for test dependencies" step.
+
+## Verification
+
+Ran the equivalent of the CI workflow locally against these changes:
+
+- `make build-wasm` — passes, produces all 14 contract `.wasm` artifacts.
+- `make test-contracts` — passes (28/28 test suites green) after adding the `build-wasm` prerequisite.
+- `bash -n scripts/verify-deployment.sh` — syntax OK.
+- `make -n test-contracts|build-wasm|lint` — confirmed `sorogov-treasury-strategies` and `sorogov-optimistic-governor` now appear explicitly in every target's expanded command.
+
+**Known pre-existing failure, out of scope:** `make lint` fails on `contracts/treasury/src/streams.rs` (clippy `too_many_arguments`, `unnecessary_cast`, `manual_checked_ops`). Confirmed via `git stash` that this fails identically on unmodified `main` with the original `cargo clippy --workspace -- -D warnings` command — it's unrelated business logic in `treasury`, not something introduced or touched by this PR. Flagging separately rather than fixing here since it would mean changing contract logic outside the scope of these four issues.
+
+## Test plan
+
+- [x] `make build-wasm`
+- [x] `make test-contracts`
+- [x] `bash -n scripts/verify-deployment.sh`
+- [ ] Run `make verify-testnet` against a real testnet deployment with `OPTIMISTIC_GOVERNOR_ADDRESS` / `PROPOSAL_BONDS_ADDRESS` set, to confirm the new checks pass against live contracts (note: `scripts/deploy-testnet.sh` doesn't currently deploy either contract, so these addresses must be set manually for now — separate follow-up if desired)

--- a/scripts/verify-deployment.sh
+++ b/scripts/verify-deployment.sh
@@ -58,6 +58,28 @@ check() {
   fi
 }
 
+# Assert that a getter response is neither "ERROR" (deploy/invoke failure)
+# nor empty, proving the contract is both deployed and initialized (the
+# getters used here panic with NotInitialized until initialize() succeeds).
+check_initialized() {
+  local label="$1" got="$2"
+  if [[ -n "$got" && "$got" != "ERROR" ]]; then
+    pass "$label: deployed and initialized"
+  else
+    fail "$label: contract not deployed or not initialized"
+  fi
+}
+
+# Assert that `haystack` contains `needle` and print a labelled result.
+check_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ -n "$needle" && "$haystack" == *"$needle"* ]]; then
+    pass "$label: contains $needle"
+  else
+    fail "$label: expected '$haystack' to contain '$needle'"
+  fi
+}
+
 DEPLOYER_ADDR="${DEPLOYER_ADDR:-$(stellar keys address "${IDENTITY}" 2>/dev/null || echo '')}"
 
 info "Verifying NebGov deployment against $ENV_FILE"
@@ -104,6 +126,26 @@ info "Liquidity (${LIQUIDITY_ADDRESS:-<not set>})"
 check "  liquidity.governor" \
   "$(query "${LIQUIDITY_ADDRESS:-}" governor)" \
   "\"${DEPLOYER_ADDR}\""
+
+# ---- OptimisticGovernor -------------------------------------------------
+info "OptimisticGovernor (${OPTIMISTIC_GOVERNOR_ADDRESS:-<not set>})"
+OPTIMISTIC_GOVERNOR_CONFIG="$(query "${OPTIMISTIC_GOVERNOR_ADDRESS:-}" get_config)"
+check_initialized "  optimistic_governor.get_config" "$OPTIMISTIC_GOVERNOR_CONFIG"
+if [[ "$OPTIMISTIC_GOVERNOR_CONFIG" != "ERROR" ]]; then
+  check_contains "  optimistic_governor.votes_token" \
+    "$OPTIMISTIC_GOVERNOR_CONFIG" \
+    "${TOKEN_VOTES_ADDRESS:-}"
+fi
+
+# ---- ProposalBonds -------------------------------------------------------
+info "ProposalBonds (${PROPOSAL_BONDS_ADDRESS:-<not set>})"
+PROPOSAL_BONDS_SETTINGS="$(query "${PROPOSAL_BONDS_ADDRESS:-}" get_settings)"
+check_initialized "  proposal_bonds.get_settings" "$PROPOSAL_BONDS_SETTINGS"
+if [[ "$PROPOSAL_BONDS_SETTINGS" != "ERROR" ]]; then
+  check_contains "  proposal_bonds.governor" \
+    "$PROPOSAL_BONDS_SETTINGS" \
+    "${GOVERNOR_ADDRESS:-}"
+fi
 
 printf '\n'
 if [[ "$FAILURES" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Fixes four deployment-tooling gaps where contracts added in recent feature work weren't wired into the local deploy-verification script or Makefile, so a broken deployment or a `make` run could silently skip them:

- **#1102** — `scripts/verify-deployment.sh` had no check for `contracts/optimistic-governor`.
- **#1101** — `scripts/verify-deployment.sh` had no check for `contracts/proposal-bonds`.
- **#1099** — `Makefile` build/test targets didn't cover `contracts/treasury-strategies`, even though CI already builds/tests it via `-p sorogov-treasury-strategies`.
- **#1097** — `Makefile` build/test targets didn't cover `contracts/optimistic-governor`, even though CI already builds/tests it via `-p sorogov-optimistic-governor`.

closes #1102 
closes #1101 
closes #1099 
closes #1097
## Changes

**`scripts/verify-deployment.sh`**
- Added a validation section for `OptimisticGovernor`: calls `get_config()`, which panics with `NotInitialized` until `initialize()` has succeeded, so a non-error response proves the contract is deployed *and* initialized. Also checks the returned `votes_token` matches the deployed `TOKEN_VOTES_ADDRESS`.
- Added the same pattern for `ProposalBonds` using `get_settings()`, checking `governor` matches `GOVERNOR_ADDRESS`.
- Added two small helpers, `check_initialized` and `check_contains`, since neither contract exposes a scalar `admin()`-style getter like the existing checks use — both only expose struct-returning getters.

**`Makefile`**
- Replaced the implicit `--workspace`/default-member build and test selection with an explicit `CONTRACT_PACKAGES` list (kept in sync with `.github/workflows/rust.yml`), so `test-contracts`, `build-wasm`, and `lint` always cover every contract by name — including `treasury-strategies` and `optimistic-governor` — instead of relying on undocumented workspace-default behavior.
- Made `test-contracts` depend on `build-wasm`: `governor-factory`'s tests load prebuilt `.wasm` artifacts via `contractimport!`, which fails with "No such file or directory" on a clean checkout unless the WASM is built first — mirroring CI's separate "Build WASMs for test dependencies" step.

## Verification

Ran the equivalent of the CI workflow locally against these changes:

- `make build-wasm` — passes, produces all 14 contract `.wasm` artifacts.
- `make test-contracts` — passes (28/28 test suites green) after adding the `build-wasm` prerequisite.
- `bash -n scripts/verify-deployment.sh` — syntax OK.
- `make -n test-contracts|build-wasm|lint` — confirmed `sorogov-treasury-strategies` and `sorogov-optimistic-governor` now appear explicitly in every target's expanded command.

**Known pre-existing failure, out of scope:** `make lint` fails on `contracts/treasury/src/streams.rs` (clippy `too_many_arguments`, `unnecessary_cast`, `manual_checked_ops`). Confirmed via `git stash` that this fails identically on unmodified `main` with the original `cargo clippy --workspace -- -D warnings` command — it's unrelated business logic in `treasury`, not something introduced or touched by this PR. Flagging separately rather than fixing here since it would mean changing contract logic outside the scope of these four issues.

## Test plan

- [x] `make build-wasm`
- [x] `make test-contracts`
- [x] `bash -n scripts/verify-deployment.sh`
- [ ] Run `make verify-testnet` against a real testnet deployment with `OPTIMISTIC_GOVERNOR_ADDRESS` / `PROPOSAL_BONDS_ADDRESS` set, to confirm the new checks pass against live contracts (note: `scripts/deploy-testnet.sh` doesn't currently deploy either contract, so these addresses must be set manually for now — separate follow-up if desired)
