### PR TITLE
fix(treasury,deployment,optimistic-governor): add deactivate UI, verify-deployment coverage, drop unused execute() param

### DIFF
--- a/app/src/app/treasury/strategies/page.tsx
+++ b/app/src/app/treasury/strategies/page.tsx
@@ -7,7 +7,10 @@ import type { StrategyPerformancePoint, TreasuryStrategiesClient } from "@nebgov
 import { useWallet } from "../../../lib/wallet-context";
 import { readGovernorConfig } from "../../../lib/nebgov-env";
 import { TreasuryClient } from "../../../lib/treasury-client";
-import { encodeRegisterStrategyCalldata } from "../../../lib/treasury-calldata";
+import {
+  encodeDeactivateStrategyCalldata,
+  encodeRegisterStrategyCalldata,
+} from "../../../lib/treasury-calldata";
 import {
   useTreasuryStrategies,
   buildTreasuryStrategiesClient,
@@ -31,7 +34,6 @@ export default function TreasuryStrategiesPage() {
 
   const config = useMemo(() => readGovernorConfig(), []);
   const network = (process.env.NEXT_PUBLIC_NETWORK || "testnet") as StellarNetwork;
-  const treasuryAddress = process.env.NEXT_PUBLIC_TREASURY_ADDRESS || "";
   const treasuryStrategiesAddress = config?.treasuryStrategiesAddress ?? "";
 
   const treasuryClient = useMemo(() => {
@@ -45,6 +47,8 @@ export default function TreasuryStrategiesPage() {
   const [regCooldownLedgers, setRegCooldownLedgers] = useState("");
   const [registering, setRegistering] = useState(false);
   const [registerError, setRegisterError] = useState<string | null>(null);
+  const [deactivatingId, setDeactivatingId] = useState<number | null>(null);
+  const [deactivateError, setDeactivateError] = useState<string | null>(null);
 
   const canRegister = Boolean(
     isConnected && publicKey && treasuryClient && treasuryAddress && treasuryStrategiesAddress,
@@ -98,6 +102,41 @@ export default function TreasuryStrategiesPage() {
       toast.error(msg);
     } finally {
       setRegistering(false);
+    }
+  }
+
+  async function handleDeactivateStrategy(strategyId: number) {
+    if (!treasuryClient || !publicKey || !treasuryAddress || !treasuryStrategiesAddress) return;
+    if (
+      !window.confirm(
+        `Deactivate strategy #${strategyId}? It will stop receiving new deposits.`,
+      )
+    ) {
+      return;
+    }
+    setDeactivatingId(strategyId);
+    setDeactivateError(null);
+    try {
+      const data = encodeDeactivateStrategyCalldata(treasuryAddress, strategyId);
+      const txId = await treasuryClient.submit(
+        publicKey,
+        treasuryStrategiesAddress,
+        "deactivate_strategy",
+        data,
+        signTransaction,
+      );
+      toast.success(
+        txId > 0n
+          ? `Submitted treasury transaction #${txId} — pending owner approvals.`
+          : "Deactivation submitted to the treasury — pending owner approvals.",
+      );
+      refetch();
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Could not submit deactivation";
+      setDeactivateError(msg);
+      toast.error(msg);
+    } finally {
+      setDeactivatingId(null);
     }
   }
 
@@ -258,6 +297,12 @@ export default function TreasuryStrategiesPage() {
         </div>
       )}
 
+      {deactivateError && (
+        <div className="mb-6 bg-red-50 border border-red-200 rounded-xl p-4 text-sm text-red-700">
+          {deactivateError}
+        </div>
+      )}
+
       {loading ? (
         <div className="text-center py-8 text-gray-400">Loading strategies…</div>
       ) : strategies.length === 0 ? (
@@ -293,16 +338,28 @@ export default function TreasuryStrategiesPage() {
                       Token: {s.token}
                     </p>
                   </div>
-                  {canRequestWithdrawal && (
-                    <button
-                      type="button"
-                      onClick={() => setWithdrawTarget(s)}
-                      disabled={s.currentAllocation <= 0n}
-                      className="shrink-0 text-sm rounded-lg px-4 py-2 font-medium border border-indigo-200 text-indigo-600 hover:bg-indigo-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      Request Withdrawal
-                    </button>
-                  )}
+                  <div className="flex shrink-0 gap-2">
+                    {canRequestWithdrawal && (
+                      <button
+                        type="button"
+                        onClick={() => setWithdrawTarget(s)}
+                        disabled={s.currentAllocation <= 0n}
+                        className="shrink-0 text-sm rounded-lg px-4 py-2 font-medium border border-indigo-200 text-indigo-600 hover:bg-indigo-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        Request Withdrawal
+                      </button>
+                    )}
+                    {canRegister && s.active && (
+                      <button
+                        type="button"
+                        onClick={() => handleDeactivateStrategy(s.strategyId)}
+                        disabled={deactivatingId === s.strategyId}
+                        className="shrink-0 text-sm rounded-lg px-4 py-2 font-medium border border-rose-200 text-rose-600 hover:bg-rose-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        {deactivatingId === s.strategyId ? "Deactivating…" : "Deactivate"}
+                      </button>
+                    )}
+                  </div>
                 </div>
 
                 <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mt-4">

--- a/app/src/app/vote-escrow/page.tsx
+++ b/app/src/app/vote-escrow/page.tsx
@@ -119,7 +119,7 @@ export default function VoteEscrowPage() {
                   </>
                 ) : (
                   <p className="text-sm text-gray-600 dark:text-gray-400">
-                    You don't have an active lock. Create one to get started.
+                    You don&apos;t have an active lock. Create one to get started.
                   </p>
                 )}
               </div>

--- a/app/src/lib/treasury-calldata.ts
+++ b/app/src/lib/treasury-calldata.ts
@@ -83,6 +83,22 @@ export function encodeRegisterStrategyCalldata(
   return Uint8Array.from(xdr.ScVal.scvVec(vals).toXDR());
 }
 
+/**
+ * Calldata for `treasury-strategies::deactivate_strategy(admin, strategy_id)`,
+ * for submission through the treasury multisig's `submit`/`approve` flow —
+ * same access-control shape as `register_strategy` above.
+ */
+export function encodeDeactivateStrategyCalldata(
+  admin: string,
+  strategyId: number
+): Uint8Array {
+  const vals = [
+    nativeToScVal(admin, { type: "address" }),
+    nativeToScVal(strategyId, { type: "u64" }),
+  ];
+  return Uint8Array.from(xdr.ScVal.scvVec(vals).toXDR());
+}
+
 export function previewCalldata(
   target: string,
   functionName: string,

--- a/contracts/optimistic-governor/src/lib.rs
+++ b/contracts/optimistic-governor/src/lib.rs
@@ -278,10 +278,12 @@ impl OptimisticGovernorContract {
         events::emit_proposal_passed(&env, proposal_id);
     }
 
-    /// Invoke the proposal's target once it has cleared its challenge
-    /// window unobjected.
-    pub fn execute(env: Env, caller: Address, proposal_id: u64) {
-        caller.require_auth();
+    /// Permissionless, like `finalize`: invoke the proposal's target once it
+    /// has cleared its challenge window unobjected. Anyone may trigger this
+    /// once a proposal is `Passed`; there is no meaningful caller identity to
+    /// gate on since the target invocation runs with the contract's own
+    /// authority, not the caller's.
+    pub fn execute(env: Env, proposal_id: u64) {
         let mut proposal = Self::must_get_proposal(&env, proposal_id);
         if proposal.state != OptimisticProposalState::Passed {
             env.panic_with_error(OptimisticGovernorError::ProposalNotPassed);

--- a/contracts/optimistic-governor/src/tests.rs
+++ b/contracts/optimistic-governor/src/tests.rs
@@ -205,7 +205,7 @@ fn execute_rejected_before_finalize_has_run() {
         .ledger()
         .with_mut(|l| l.sequence_number += CHALLENGE_WINDOW + 1);
     // finalize() was never called, so state is still ChallengeWindow.
-    c.execute(&f.proposer, &id);
+    c.execute(&id);
 }
 
 #[test]
@@ -222,7 +222,7 @@ fn execute_rejected_on_objected_proposal() {
     f.env
         .ledger()
         .with_mut(|l| l.sequence_number += CHALLENGE_WINDOW + 1);
-    c.execute(&f.proposer, &id);
+    c.execute(&id);
 }
 
 #[test]
@@ -254,7 +254,7 @@ fn bond_locked_on_propose_and_refunded_on_passed_and_executed() {
     assert_eq!(tok.balance(&f.proposer), balance_before);
     assert_eq!(tok.balance(&f.client_id), 0);
 
-    c.execute(&f.proposer, &id);
+    c.execute(&id);
     let proposal = c.get_proposal(&id);
     assert_eq!(proposal.state, OptimisticProposalState::Executed);
     assert_eq!(TargetClient::new(&f.env, &f.target_id).calls(), 1);

--- a/contracts/treasury-strategies/src/lib.rs
+++ b/contracts/treasury-strategies/src/lib.rs
@@ -369,6 +369,14 @@ impl TreasuryStrategiesContract {
             })
     }
 
+    /// Read-only lookup of the configured treasury address, mirroring
+    /// `TokenVotes::admin`/`Liquidity::governor` — lets deploy tooling
+    /// confirm the contract is both deployed and initialized without
+    /// mutating state.
+    pub fn get_treasury(env: Env) -> Address {
+        env.storage().instance().get(&DataKey::Treasury).unwrap()
+    }
+
     pub fn get_total_value(env: Env, token: Address) -> i128 {
         let ids: Vec<u64> = env
             .storage()

--- a/contracts/treasury-strategies/src/tests.rs
+++ b/contracts/treasury-strategies/src/tests.rs
@@ -198,3 +198,9 @@ fn test_register_strategy_rejects_invalid_max_allocation_bps() {
     let adapter_id = env.register(MockAdapter, ());
     client.register_strategy(&admin, &adapter_id, &token, &10_001, &COOLDOWN);
 }
+
+#[test]
+fn test_get_treasury_returns_configured_treasury() {
+    let (_env, client, _admin, treasury, _token, _sac_admin) = setup();
+    assert_eq!(client.get_treasury(), treasury);
+}

--- a/pr.md
+++ b/pr.md
@@ -1,3 +1,5 @@
+# fix(treasury,deployment,optimistic-governor): add deactivate UI, verify-deployment coverage, drop unused execute() param
+
 ## Summary
 
 - Added an admin-only "Deactivate" action to each strategy card in
@@ -80,3 +82,8 @@ unrelated to the four issues above but blocking a green frontend build.
 - [x] `pnpm next build` in `app/` — succeeds
 - [x] `pnpm test` in `app/` — same 6 pre-existing failing suites as `main`
       (confirmed via stash comparison), nothing new broken
+
+closes #1107
+closes #1103
+closes #1104
+closes #1108

--- a/pr.md
+++ b/pr.md
@@ -1,23 +1,82 @@
 ## Summary
 
-- Makefile's `test-contracts` and `build-wasm` targets ran cargo with no package list at all, so they silently diverged from `.github/workflows/rust.yml`. Governor-factory's tests need prebuilt contract WASM (via `contractimport!`), which the old targets never produced, so `make test-contracts` failed outright. Both targets now use the same explicit `-p sorogov-*` package list as CI — including `proposal-bonds`, `conviction-voting`, and `signal-anchor` — and `test-contracts` depends on `build-wasm` so the WASM artifacts exist before tests run, matching CI's step ordering. Fixes #1096, #1098, #1100.
-- Added an admin-only "Register new strategy" form to `app/src/app/treasury/strategies/page.tsx` for the `register_strategy` contract function, which previously had no UI anywhere. Fixes #1106.
+- Added an admin-only "Deactivate" action to each strategy card in
+  `app/src/app/treasury/strategies/page.tsx`, submitting a treasury
+  multisig transaction that calls `treasury-strategies::deactivate_strategy`
+  — the same submit/approve flow the existing "Register new strategy" form
+  uses. Fixes #1107.
+- Added post-deploy validation for `contracts/conviction-voting` and
+  `contracts/treasury-strategies` to `scripts/verify-deployment.sh`, so a
+  broken or missing deployment of either contract now fails verification
+  instead of passing silently. Fixes #1103, #1104.
+- Dropped the unused `caller` parameter from
+  `optimistic-governor::execute()` so its signature is permissionless like
+  `finalize()`, one step earlier in the same lifecycle. Fixes #1108.
 
 ## Details
 
-### Makefile (#1096, #1098, #1100)
+### #1107 — Deactivate strategy UI
 
-`register_strategy`'s admin argument must equal the treasury contract's own address in production (per `TreasuryStrategiesClient`'s docstring), not a signable wallet — so it can't be called directly. The new form instead builds the `register_strategy` calldata (adapter, token, max allocation bps, withdrawal cooldown) and submits it through the treasury multisig's existing `submit`/`approve` flow (`TreasuryClient.submit`), the same mechanism `app/src/app/treasury/page.tsx` already uses for admin actions. The form is gated on wallet connection the same way `app/src/app/settings` gates its admin controls; on-chain authorization is still enforced by the treasury contract's own `require_owner` check in `submit()`.
+`treasury-strategies::deactivate_strategy(admin, strategy_id)` is
+admin-gated the same way `register_strategy` is — the contract's `admin` is
+the treasury multisig, not a signable wallet — so the new "Deactivate"
+button reuses `TreasuryClient.submit(...)` with a new
+`encodeDeactivateStrategyCalldata` helper (`app/src/lib/treasury-calldata.ts`)
+instead of calling the contract directly. The button only renders for
+active strategies, is gated behind the same `canRegister` admin-availability
+check as the registration form, and confirms before submitting since it's a
+state-changing multisig action.
+
+While in this file, also fixed a duplicate `const treasuryAddress`
+declaration (two conflicting definitions had landed from parallel PRs) that
+would fail to compile.
+
+### #1103 / #1104 — verify-deployment.sh coverage gaps
+
+- `conviction-voting` has no dedicated `get_config`/`get_settings` getter;
+  `get_required_threshold` is the only read-only entrypoint that panics
+  with `NotInitialized` until `initialize()` succeeds, so it's called with
+  `requested_amount=0` to double as the deployed+initialized check.
+- `treasury-strategies` had no read-only entrypoint at all that depended on
+  initialization state. Added a minimal `get_treasury()` getter (mirroring
+  `TokenVotes::admin()` / `Liquidity::governor()`) and wired the script to
+  both confirm it's deployed+initialized and that it's wired to the same
+  `TREASURY_ADDRESS` used elsewhere in the env file.
+- `query()` now accepts extra CLI args after the function name, needed for
+  `get_required_threshold`'s `requested_amount` argument.
+
+### #1108 — optimistic-governor `execute()` signature
+
+`execute(caller, proposal_id)` called `caller.require_auth()` but never
+read `caller` again, so any address could still call it by authenticating
+as itself — no real access control, just an extra required signer/param
+versus `finalize(proposal_id)` one step earlier in the same lifecycle.
+Removed the parameter; `execute` is now permissionless like `finalize`.
+Updated the SDK's `OptimisticGovernorClient.execute`/`executeWithSign` and
+the contract's test suite to match the new signature.
+
+### Also fixed
+
+`app/src/app/vote-escrow/page.tsx` had a pre-existing unescaped apostrophe
+that fails `next build`'s lint step (`react/no-unescaped-entities`),
+unrelated to the four issues above but blocking a green frontend build.
 
 ## Test plan
 
-- [x] `make build-wasm` — builds all 14 contract crates
-- [x] `make test-contracts` — all contract test suites pass (28 `test result: ok` blocks, 0 failures)
-- [x] `pnpm --filter @nebgov/sdk build` — SDK compiles
-- [x] `tsc --noEmit` in `app/` — no type errors
-- [x] `pnpm build` in `app/` — Next.js production build succeeds, `/treasury/strategies` compiles
-- [ ] Manual click-through of the new registration form against a deployed treasury (needs a live testnet treasury + owner wallet)
-
-## Notes for reviewers
-
-- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings` both currently fail on pre-existing drift unrelated to this change (formatting in `co-sponsorship`/`governor`/`timelock`/etc., and `assert_eq!(x, bool)` clippy lints in `treasury/src/stream_tests.rs`). Neither of those touches the files in this PR; `fmt` isn't part of `rust.yml` at all, and the clippy failures predate this branch. Flagging separately rather than folding an unrelated cleanup into this PR.
+- [x] `cargo test -p sorogov-optimistic-governor` — 17 passed
+- [x] `cargo test -p sorogov-treasury-strategies` — 13 passed (incl. new
+      `test_get_treasury_returns_configured_treasury`)
+- [x] `cargo test` across the full CI package list — all green except one
+      pre-existing, unrelated failure in `sorogov-token-votes`
+      (`split_delegation_tests::test_single_100_weight_delegate_split_collapses_to_legacy_delegate_key`),
+      confirmed present on `main` before this branch's changes
+- [x] `cargo build --target wasm32v1-none --release` across all contract
+      packages
+- [x] `bash -n scripts/verify-deployment.sh`
+- [x] `pnpm --filter @nebgov/sdk build` and `test` — 395 passed
+- [x] `pnpm tsc --noEmit` in `app/`
+- [x] `pnpm eslint .` in `app/` — no errors (pre-existing warnings only, in
+      untouched files)
+- [x] `pnpm next build` in `app/` — succeeds
+- [x] `pnpm test` in `app/` — same 6 pre-existing failing suites as `main`
+      (confirmed via stash comparison), nothing new broken

--- a/scripts/verify-deployment.sh
+++ b/scripts/verify-deployment.sh
@@ -39,13 +39,17 @@ command -v stellar >/dev/null 2>&1 || { printf "${RED}[error]${NC} stellar-cli n
 NETWORK="${STELLAR_NETWORK:-testnet}"
 IDENTITY="${STELLAR_IDENTITY:-deployer}"
 
-# Call a contract getter; returns "ERROR" if the invocation fails.
+# Call a contract getter, optionally with extra `-- <fn>` args after the
+# function name (e.g. `query "$ID" get_required_threshold --requested_amount 0`).
+# Returns "ERROR" if the invocation fails.
 query() {
+  local id="$1" fn="$2"
+  shift 2
   stellar contract invoke \
-    --id "$1" \
+    --id "$id" \
     --source "$IDENTITY" \
     --network "$NETWORK" \
-    -- "$2" 2>/dev/null || echo "ERROR"
+    -- "$fn" "$@" 2>/dev/null || echo "ERROR"
 }
 
 # Assert got == expected and print a labelled result.
@@ -120,6 +124,24 @@ info "Treasury (${TREASURY_ADDRESS:-<not set>})"
 check "  treasury.threshold" \
   "$(query "${TREASURY_ADDRESS:-}" threshold)" \
   "${TREASURY_THRESHOLD:-1}"
+
+# ---- ConvictionVoting ----------------------------------------------------
+# No config/settings getter exists on this contract; get_required_threshold
+# is the only read-only entrypoint that panics with NotInitialized until
+# initialize() succeeds, so it doubles as the deployed+initialized check.
+info "ConvictionVoting (${CONVICTION_VOTING_ADDRESS:-<not set>})"
+check_initialized "  conviction_voting.get_required_threshold" \
+  "$(query "${CONVICTION_VOTING_ADDRESS:-}" get_required_threshold --requested_amount 0)"
+
+# ---- TreasuryStrategies ---------------------------------------------------
+info "TreasuryStrategies (${TREASURY_STRATEGIES_ADDRESS:-<not set>})"
+TREASURY_STRATEGIES_TREASURY="$(query "${TREASURY_STRATEGIES_ADDRESS:-}" get_treasury)"
+check_initialized "  treasury_strategies.get_treasury" "$TREASURY_STRATEGIES_TREASURY"
+if [[ "$TREASURY_STRATEGIES_TREASURY" != "ERROR" ]]; then
+  check_contains "  treasury_strategies.treasury" \
+    "$TREASURY_STRATEGIES_TREASURY" \
+    "${TREASURY_ADDRESS:-}"
+fi
 
 # ---- Liquidity ---------------------------------------------------------
 info "Liquidity (${LIQUIDITY_ADDRESS:-<not set>})"

--- a/sdk/src/optimisticGovernor.ts
+++ b/sdk/src/optimisticGovernor.ts
@@ -86,11 +86,11 @@ export class OptimisticGovernorClient {
     return { state: proposal.state };
   }
 
+  /** Permissionless, like {@link finalize}: any connected account may call it. */
   async execute(caller: Keypair, proposalId: number): Promise<string> {
     return (await this.submit(
       caller,
       "execute",
-      nativeToScVal(caller.publicKey(), { type: "address" }),
       nativeToScVal(proposalId, { type: "u64" }),
     )).hash;
   }
@@ -277,7 +277,7 @@ export class OptimisticGovernorClient {
     return { state: proposal.state };
   }
 
-  /** Wallet-signing variant of {@link execute}. */
+  /** Wallet-signing variant of {@link execute}. Permissionless — any connected account may call it. */
   async executeWithSign(
     callerPublicKey: string,
     proposalId: number,
@@ -287,7 +287,6 @@ export class OptimisticGovernorClient {
       callerPublicKey,
       signUnsignedXdr,
       "execute",
-      nativeToScVal(callerPublicKey, { type: "address" }),
       nativeToScVal(proposalId, { type: "u64" }),
     );
     return hash;


### PR DESCRIPTION
# fix(treasury,deployment,optimistic-governor): add deactivate UI, verify-deployment coverage, drop unused execute() param

## Summary

- Added an admin-only "Deactivate" action to each strategy card in
  `app/src/app/treasury/strategies/page.tsx`, submitting a treasury
  multisig transaction that calls `treasury-strategies::deactivate_strategy`
  — the same submit/approve flow the existing "Register new strategy" form
  uses. Fixes #1107.
- Added post-deploy validation for `contracts/conviction-voting` and
  `contracts/treasury-strategies` to `scripts/verify-deployment.sh`, so a
  broken or missing deployment of either contract now fails verification
  instead of passing silently. Fixes #1103, #1104.
- Dropped the unused `caller` parameter from
  `optimistic-governor::execute()` so its signature is permissionless like
  `finalize()`, one step earlier in the same lifecycle. Fixes #1108.

## Details

### #1107 — Deactivate strategy UI

`treasury-strategies::deactivate_strategy(admin, strategy_id)` is
admin-gated the same way `register_strategy` is — the contract's `admin` is
the treasury multisig, not a signable wallet — so the new "Deactivate"
button reuses `TreasuryClient.submit(...)` with a new
`encodeDeactivateStrategyCalldata` helper (`app/src/lib/treasury-calldata.ts`)
instead of calling the contract directly. The button only renders for
active strategies, is gated behind the same `canRegister` admin-availability
check as the registration form, and confirms before submitting since it's a
state-changing multisig action.

While in this file, also fixed a duplicate `const treasuryAddress`
declaration (two conflicting definitions had landed from parallel PRs) that
would fail to compile.

### #1103 / #1104 — verify-deployment.sh coverage gaps

- `conviction-voting` has no dedicated `get_config`/`get_settings` getter;
  `get_required_threshold` is the only read-only entrypoint that panics
  with `NotInitialized` until `initialize()` succeeds, so it's called with
  `requested_amount=0` to double as the deployed+initialized check.
- `treasury-strategies` had no read-only entrypoint at all that depended on
  initialization state. Added a minimal `get_treasury()` getter (mirroring
  `TokenVotes::admin()` / `Liquidity::governor()`) and wired the script to
  both confirm it's deployed+initialized and that it's wired to the same
  `TREASURY_ADDRESS` used elsewhere in the env file.
- `query()` now accepts extra CLI args after the function name, needed for
  `get_required_threshold`'s `requested_amount` argument.

### #1108 — optimistic-governor `execute()` signature

`execute(caller, proposal_id)` called `caller.require_auth()` but never
read `caller` again, so any address could still call it by authenticating
as itself — no real access control, just an extra required signer/param
versus `finalize(proposal_id)` one step earlier in the same lifecycle.
Removed the parameter; `execute` is now permissionless like `finalize`.
Updated the SDK's `OptimisticGovernorClient.execute`/`executeWithSign` and
the contract's test suite to match the new signature.

### Also fixed

`app/src/app/vote-escrow/page.tsx` had a pre-existing unescaped apostrophe
that fails `next build`'s lint step (`react/no-unescaped-entities`),
unrelated to the four issues above but blocking a green frontend build.

## Test plan

- [x] `cargo test -p sorogov-optimistic-governor` — 17 passed
- [x] `cargo test -p sorogov-treasury-strategies` — 13 passed (incl. new
      `test_get_treasury_returns_configured_treasury`)
- [x] `cargo test` across the full CI package list — all green except one
      pre-existing, unrelated failure in `sorogov-token-votes`
      (`split_delegation_tests::test_single_100_weight_delegate_split_collapses_to_legacy_delegate_key`),
      confirmed present on `main` before this branch's changes
- [x] `cargo build --target wasm32v1-none --release` across all contract
      packages
- [x] `bash -n scripts/verify-deployment.sh`
- [x] `pnpm --filter @nebgov/sdk build` and `test` — 395 passed
- [x] `pnpm tsc --noEmit` in `app/`
- [x] `pnpm eslint .` in `app/` — no errors (pre-existing warnings only, in
      untouched files)
- [x] `pnpm next build` in `app/` — succeeds
- [x] `pnpm test` in `app/` — same 6 pre-existing failing suites as `main`
      (confirmed via stash comparison), nothing new broken

closes #1107
closes #1103
closes #1104
closes #1108
