### PR TITLE
fix(frontend): use shared env helpers and guard against stale tuning recommendations

### DIFF
--- a/app/src/components/TuningRecommendationCard.tsx
+++ b/app/src/components/TuningRecommendationCard.tsx
@@ -49,6 +49,21 @@ export function TuningRecommendationCard({
       const governor = new GovernorClient(config);
       const source = publicKey ?? config.governorAddress;
       const currentSettings = await governor.getSettings(source);
+
+      // The recommendation's delta was computed against a prior on-chain
+      // snapshot (via the indexer's /config-history). If settings drifted
+      // since then, blending the recommended delta onto today's baseline
+      // would misrepresent what the recommendation's rationale was based on.
+      if (
+        currentSettings.quorumNumerator !== recommendation.currentQuorumNumerator ||
+        currentSettings.proposalThreshold !== recommendation.currentProposalThreshold
+      ) {
+        throw new Error(
+          `Governor settings have changed on-chain since this recommendation was computed ` +
+            `(${new Date(recommendation.computedAt).toLocaleString()}). Refresh recommendations before proposing.`,
+        );
+      }
+
       const nextSettings = {
         ...currentSettings,
         quorumNumerator: recommendation.recommendedQuorumNumerator,

--- a/app/src/hooks/useConvictionProposals.ts
+++ b/app/src/hooks/useConvictionProposals.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { readIndexerUrl } from "../lib/nebgov-env";
 
 export interface ConvictionProposalView {
   proposalId: string;
@@ -30,7 +31,7 @@ export function useConvictionProposals(status = "active") {
   const [proposals, setProposals] = useState<ConvictionProposalView[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const indexerUrl = process.env.NEXT_PUBLIC_INDEXER_URL;
+  const indexerUrl = readIndexerUrl();
 
   const refresh = useCallback(async () => {
     if (!indexerUrl) {

--- a/app/src/hooks/useSplitDelegation.ts
+++ b/app/src/hooks/useSplitDelegation.ts
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { VotesClient, type SplitDelegation, type Network } from "@nebgov/sdk";
+import { VotesClient, type SplitDelegation } from "@nebgov/sdk";
+import { readGovernorConfig } from "../lib/nebgov-env";
 import { useWallet } from "../lib/wallet-context";
 
 interface UseSplitDelegationResult {
@@ -21,23 +22,11 @@ interface UseSplitDelegationResult {
 }
 
 function getVotesClientFromEnv(): VotesClient {
-  const governorAddress = process.env.NEXT_PUBLIC_GOVERNOR_ADDRESS;
-  const timelockAddress = process.env.NEXT_PUBLIC_TIMELOCK_ADDRESS;
-  const votesAddress = process.env.NEXT_PUBLIC_VOTES_ADDRESS;
-  const network = (process.env.NEXT_PUBLIC_NETWORK || "testnet") as Network;
-  const rpcUrl = process.env.NEXT_PUBLIC_RPC_URL;
-
-  if (!governorAddress || !timelockAddress || !votesAddress) {
+  const config = readGovernorConfig();
+  if (!config) {
     throw new Error("Missing NEXT_PUBLIC_* contract addresses in .env.local");
   }
-
-  return new VotesClient({
-    governorAddress,
-    timelockAddress,
-    votesAddress,
-    network,
-    ...(rpcUrl && { rpcUrl }),
-  });
+  return new VotesClient(config);
 }
 
 /**

--- a/app/src/hooks/useTreasuryStrategies.ts
+++ b/app/src/hooks/useTreasuryStrategies.ts
@@ -22,6 +22,14 @@ export function buildTreasuryStrategiesClient(): TreasuryStrategiesClient | null
   });
 }
 
+/** Cache of `maxAllocationBps`/`withdrawalCooldownLedgers` by strategyId. These
+ * are set once at `register_strategy` and never change, so a single on-chain
+ * simulate call per strategy for the lifetime of the page is sufficient. */
+const staticFieldsCache = new Map<
+  string,
+  Pick<StrategyRow, "maxAllocationBps" | "withdrawalCooldownLedgers">
+>();
+
 interface UseTreasuryStrategiesResult {
   strategies: StrategyRow[];
   loading: boolean;
@@ -56,12 +64,15 @@ export function useTreasuryStrategies(token?: string): UseTreasuryStrategiesResu
         const indexed = await client.listStrategies({ token, limit: 100 });
         const merged = await Promise.all(
           indexed.map(async (row) => {
+            const cached = staticFieldsCache.get(row.strategyId);
+            if (cached) return { ...row, ...cached };
             const onChain = await client.getStrategy(row.strategyId);
-            return {
-              ...row,
+            const staticFields = {
               maxAllocationBps: onChain.maxAllocationBps,
               withdrawalCooldownLedgers: onChain.withdrawalCooldownLedgers,
             };
+            staticFieldsCache.set(row.strategyId, staticFields);
+            return { ...row, ...staticFields };
           }),
         );
         if (!cancelled) setStrategies(merged);


### PR DESCRIPTION
## Summary

Fixes four frontend inconsistencies/issues around env-var access and stale data handling, per the assigned issues below.

### #1121 — `useSplitDelegation` reads `NEXT_PUBLIC_*` env vars directly
`getVotesClientFromEnv()` in [app/src/hooks/useSplitDelegation.ts](app/src/hooks/useSplitDelegation.ts) now builds its `VotesClient` from the shared `readGovernorConfig()` helper (in `app/src/lib/nebgov-env.ts`) instead of reading `NEXT_PUBLIC_GOVERNOR_ADDRESS` / `NEXT_PUBLIC_TIMELOCK_ADDRESS` / `NEXT_PUBLIC_VOTES_ADDRESS` / `NEXT_PUBLIC_NETWORK` / `NEXT_PUBLIC_RPC_URL` directly, matching the pattern already used by `useProposalBonds`, `useTreasuryStrategies`, `useGovernanceTuning`, etc.

### #1119 — `useConvictionProposals` reads `NEXT_PUBLIC_INDEXER_URL` directly
[app/src/hooks/useConvictionProposals.ts](app/src/hooks/useConvictionProposals.ts) now resolves the indexer URL via the shared `readIndexerUrl()` helper, consistent with `useOptimisticProposals`, `useTreasuryStrategies`, and `useProposalBonds`.

### #1122 — `useTreasuryStrategies` makes an on-chain simulate call per strategy on every load
`load()` in [app/src/hooks/useTreasuryStrategies.ts](app/src/hooks/useTreasuryStrategies.ts) previously called `client.getStrategy(row.strategyId)` for every indexer-returned strategy on every load/refetch, just to read `maxAllocationBps`/`withdrawalCooldownLedgers` — fields set once at `register_strategy` and effectively immutable. This now caches those two fields client-side per `strategyId` after the first on-chain read, so subsequent loads/refetches only hit the chain for strategies not seen before, eliminating the repeated N Soroban round-trips per page view.

### #1123 — `TuningRecommendationCard` merges a possibly-stale recommended delta onto freshly-fetched settings
`handlePropose` in [app/src/components/TuningRecommendationCard.tsx](app/src/components/TuningRecommendationCard.tsx) fetched `currentSettings` fresh on-chain and then blindly spread the recommended delta from `recommendation` (computed by a prior analyzer cycle) on top of it. If governor settings changed on-chain between when the recommendation was computed and when the user clicks "Propose This Change," the resulting `update_config` calldata could combine a stale delta with a baseline it wasn't computed against. This now compares the freshly-read on-chain `quorumNumerator`/`proposalThreshold` against `recommendation.currentQuorumNumerator`/`currentProposalThreshold` before building the proposal, and surfaces a clear error (including `recommendation.computedAt`) telling the user to refresh recommendations if settings have drifted, instead of silently proposing against outdated rationale.

## Why

All four items were flagged as inconsistencies/inefficiencies against the rest of the codebase's established patterns (shared env helpers in `app/src/lib/nebgov-env.ts`, and defensive freshness checks around on-chain state used in proposal building).

## Testing

- Reviewed sibling hooks (`useOptimisticProposals`, `useProposalBonds`, `useGovernanceTuning`) to confirm the shared helpers are used identically.
- Verified no other call sites depend on the removed direct `process.env` reads in the touched files.
- `getSettings()` return shape (`quorumNumerator`/`proposalThreshold`) matches `TuningRecommendation.currentQuorumNumerator`/`currentProposalThreshold` types used for the drift comparison.

Closes #1121
Closes #1119
Closes #1122
Closes #1123
