### PR TITLE
test: add StakeNotFound rejection tests for withdraw_stake

### DIFF
--- a/contracts/conviction-voting/src/tests.rs
+++ b/contracts/conviction-voting/src/tests.rs
@@ -174,6 +174,26 @@ fn cancelled_proposal_rejects_stakes() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn withdraw_stake_rejects_never_staked() {
+    let f = setup(100);
+    let client = ConvictionVotingContractClient::new(&f.env, &f.contract_id);
+    let never_staked = Address::generate(&f.env);
+    client.withdraw_stake(&never_staked);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn withdraw_stake_rejects_after_withdrawal() {
+    let f = setup(100);
+    let client = ConvictionVotingContractClient::new(&f.env, &f.contract_id);
+    let id = proposal(&f, 0);
+    client.stake(&f.staker, &id, &1_000);
+    client.withdraw_stake(&f.staker);
+    client.withdraw_stake(&f.staker);
+}
+
+#[test]
 fn zero_amount_uses_minimum_threshold() {
     let f = setup(777);
     assert_eq!(


### PR DESCRIPTION
Cover two rejection paths for withdraw_stake when no active stake exists:
- calling on an address that never staked
- calling a second time after an initial withdrawal

Both should panic with ConvictionVotingError::StakeNotFound (#8).

Here's the PR message:

---

Closes #1075
Closes #1074
Closes #1073
Closes #1069


**Body:**

## Summary

- Add two tests for the `withdraw_stake` error path where no active stake exists
- Both assert the contract panics with `ConvictionVotingError::StakeNotFound` (#8)

## Tests added

- **`withdraw_stake_rejects_never_staked`** — calls `withdraw_stake` on an address that has never staked. Validates the contract rejects the call rather than silently succeeding or panicking with an unrelated error.
- **`withdraw_stake_rejects_after_withdrawal`** — stakes, withdraws, then attempts a second withdrawal. Validates the stake record is fully cleaned up and the second call is rejected.

## Motivation

The `withdraw_stake` rejection path (`StakeNotFound`) had no dedicated test coverage. The existing test suite exercised the happy-path withdrawal and conviction decay, but did not verify that calling withdraw with no active stake produces the expected error.

