### PR TITLE
test(sdk,sim): add test files and conviction voting scenario

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,9 +217,11 @@ Issues tagged `good first issue` are recommended for first-time contributors.
 
 ## Branch Naming
 
-- `feat/issue-<number>-<description>` for features
-- `fix/issue-<number>-<description>` for bug fixes
-- `docs/issue-<number>-<description>` for documentation
+- `feat/<description>` for features
+- `fix/<description>` for bug fixes
+- `docs/<description>` for documentation
+
+Example: `feat/governor-parameter-tuning`, `fix/quorum-calculation-edge-case`, `docs/contract-architecture`
 
 ## Commit Messages
 

--- a/sdk/src/__tests__/streamEvents.test.ts
+++ b/sdk/src/__tests__/streamEvents.test.ts
@@ -1,0 +1,387 @@
+import {
+  streamEvents,
+  UnsubscribeFn,
+  IndexerEvent,
+  WsEventType,
+  StreamEventsOptions,
+} from "../streamEvents";
+
+describe("streamEvents", () => {
+  const indexerUrl = "https://indexer.example.com";
+  let mockWs: any;
+  let mockFetch: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Mock WebSocket
+    mockWs = {
+      send: jest.fn(),
+      close: jest.fn(),
+      onopen: null as any,
+      onmessage: null as any,
+      onerror: null as any,
+      onclose: null as any,
+    };
+
+    global.WebSocket = jest.fn().mockImplementation((url) => {
+      // Simulate successful connection after a tick
+      setTimeout(() => {
+        if (mockWs.onopen) mockWs.onopen();
+      }, 0);
+      return mockWs;
+    }) as any;
+
+    mockFetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("basic functionality", () => {
+    it("returns an unsubscribe function", () => {
+      const handler = jest.fn();
+      const unsubscribe = streamEvents(indexerUrl, handler);
+      expect(typeof unsubscribe).toBe("function");
+      unsubscribe();
+    });
+
+    it("closes WebSocket on unsubscribe", (done) => {
+      const handler = jest.fn();
+      const unsubscribe = streamEvents(indexerUrl, handler);
+
+      setTimeout(() => {
+        unsubscribe();
+        expect(mockWs.close).toHaveBeenCalled();
+        done();
+      }, 10);
+    });
+
+    it("calls handler when event is received", (done) => {
+      const handler = jest.fn();
+      streamEvents(indexerUrl, handler);
+
+      setTimeout(() => {
+        const event: IndexerEvent = {
+          type: "proposal_created",
+          data: { id: "1", title: "Test" },
+        };
+        mockWs.onmessage({ data: JSON.stringify(event) });
+
+        expect(handler).toHaveBeenCalledWith(event);
+        done();
+      }, 10);
+    });
+
+    it("handles binary message data", (done) => {
+      const handler = jest.fn();
+      streamEvents(indexerUrl, handler);
+
+      setTimeout(() => {
+        const event: IndexerEvent = {
+          type: "vote_cast",
+          data: { voter: "test" },
+        };
+        const data = JSON.stringify(event);
+        const buffer = Buffer.from(data);
+        mockWs.onmessage({ data: buffer });
+
+        expect(handler).toHaveBeenCalledWith(event);
+        done();
+      }, 10);
+    });
+
+    it("ignores malformed messages", (done) => {
+      const handler = jest.fn();
+      streamEvents(indexerUrl, handler);
+
+      setTimeout(() => {
+        mockWs.onmessage({ data: "not json" });
+        expect(handler).not.toHaveBeenCalled();
+        done();
+      }, 10);
+    });
+  });
+
+  describe("event filtering", () => {
+    it("filters by event type", (done) => {
+      const handler = jest.fn();
+      const opts: StreamEventsOptions = { types: ["proposal_created"] };
+      streamEvents(indexerUrl, handler, opts);
+
+      setTimeout(() => {
+        const event1: IndexerEvent = {
+          type: "proposal_created",
+          data: { id: "1" },
+        };
+        const event2: IndexerEvent = {
+          type: "vote_cast",
+          data: { voter: "test" },
+        };
+
+        mockWs.onmessage({ data: JSON.stringify(event1) });
+        mockWs.onmessage({ data: JSON.stringify(event2) });
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(handler).toHaveBeenCalledWith(event1);
+        done();
+      }, 10);
+    });
+
+    it("filters by proposal ID", (done) => {
+      const handler = jest.fn();
+      const opts: StreamEventsOptions = { proposalId: "42" };
+      streamEvents(indexerUrl, handler, opts);
+
+      setTimeout(() => {
+        mockWs.onmessage({
+          data: JSON.stringify({
+            type: "vote_cast",
+            data: { proposal_id: "42", voter: "test" },
+          }),
+        });
+        mockWs.onmessage({
+          data: JSON.stringify({
+            type: "vote_cast",
+            data: { proposal_id: "99", voter: "other" },
+          }),
+        });
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        done();
+      }, 10);
+    });
+
+    it("filters by stream ID", (done) => {
+      const handler = jest.fn();
+      const opts: StreamEventsOptions = { streamId: "stream-1" };
+      streamEvents(indexerUrl, handler, opts);
+
+      setTimeout(() => {
+        mockWs.onmessage({
+          data: JSON.stringify({
+            type: "stream_spend",
+            data: { stream_id: "stream-1", amount: "100" },
+          }),
+        });
+        mockWs.onmessage({
+          data: JSON.stringify({
+            type: "stream_spend",
+            data: { stream_id: "stream-2", amount: "200" },
+          }),
+        });
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        done();
+      }, 10);
+    });
+
+    it("filters by proposal state", (done) => {
+      const handler = jest.fn();
+      const opts: StreamEventsOptions = { state: "Active" };
+      streamEvents(indexerUrl, handler, opts);
+
+      setTimeout(() => {
+        mockWs.onmessage({
+          data: JSON.stringify({
+            type: "vote_cast",
+            data: { proposal_id: "1" },
+          }),
+        });
+        mockWs.onmessage({
+          data: JSON.stringify({
+            type: "proposal_created",
+            data: { proposal_id: "2" },
+          }),
+        });
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        done();
+      }, 10);
+    });
+
+    it("combines multiple filters", (done) => {
+      const handler = jest.fn();
+      const opts: StreamEventsOptions = {
+        types: ["vote_cast"],
+        proposalId: "42",
+      };
+      streamEvents(indexerUrl, handler, opts);
+
+      setTimeout(() => {
+        // Matches type and proposal ID
+        mockWs.onmessage({
+          data: JSON.stringify({
+            type: "vote_cast",
+            data: { proposal_id: "42", voter: "test" },
+          }),
+        });
+        // Wrong type
+        mockWs.onmessage({
+          data: JSON.stringify({
+            type: "proposal_queued",
+            data: { proposal_id: "42" },
+          }),
+        });
+        // Right type but wrong proposal ID
+        mockWs.onmessage({
+          data: JSON.stringify({
+            type: "vote_cast",
+            data: { proposal_id: "99", voter: "other" },
+          }),
+        });
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        done();
+      }, 10);
+    });
+  });
+
+  describe("WebSocket connection", () => {
+    it("sends filter options on open", (done) => {
+      const handler = jest.fn();
+      const opts: StreamEventsOptions = {
+        types: ["proposal_created", "vote_cast"],
+        proposalId: "123",
+      };
+      streamEvents(indexerUrl, handler, opts);
+
+      setTimeout(() => {
+        expect(mockWs.send).toHaveBeenCalledWith(
+          JSON.stringify({
+            types: opts.types,
+            proposalId: opts.proposalId,
+            streamId: undefined,
+          })
+        );
+        done();
+      }, 10);
+    });
+
+    it("sends state filter separately if specified", (done) => {
+      const handler = jest.fn();
+      const opts: StreamEventsOptions = { state: "Queued" };
+      streamEvents(indexerUrl, handler, opts);
+
+      setTimeout(() => {
+        expect(mockWs.send).toHaveBeenCalledWith(
+          JSON.stringify({ subscribe: "state", state: "Queued" })
+        );
+        done();
+      }, 10);
+    });
+
+    it("handles WebSocket errors gracefully", (done) => {
+      const handler = jest.fn();
+      streamEvents(indexerUrl, handler, { pollIntervalMs: 1 });
+
+      setTimeout(() => {
+        mockWs.onerror();
+        // Should fall back to polling or reconnect
+        expect(mockWs.close).not.toHaveBeenCalled();
+        done();
+      }, 10);
+    });
+  });
+
+  describe("polling fallback", () => {
+    it("falls back to polling when WebSocket is unavailable", (done) => {
+      const handler = jest.fn();
+      global.WebSocket = undefined as any;
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          proposals: [
+            { id: 1, title: "Proposal 1" },
+            { id: 2, title: "Proposal 2" },
+          ],
+        }),
+      });
+
+      streamEvents(indexerUrl, handler, { fetchFn: mockFetch });
+
+      setTimeout(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "https://indexer.example.com/proposals?limit=20"
+        );
+        done();
+      }, 100);
+    });
+
+    it("respects custom reconnect delay", (done) => {
+      jest.useFakeTimers();
+      const handler = jest.fn();
+      const reconnectDelayMs = 5000;
+
+      streamEvents(indexerUrl, handler, { reconnectDelayMs });
+
+      // Trigger WebSocket close
+      setTimeout(() => {
+        mockWs.onclose();
+      }, 10);
+
+      jest.advanceTimersByTime(reconnectDelayMs - 100);
+      // Should not have reconnected yet
+
+      jest.advanceTimersByTime(100);
+      // Now it should have attempted to reconnect
+      expect(global.WebSocket).toHaveBeenCalled();
+
+      jest.useRealTimers();
+      done();
+    });
+  });
+
+  describe("event type coverage", () => {
+    const eventTypes: WsEventType[] = [
+      "proposal_created",
+      "vote_cast",
+      "proposal_queued",
+      "proposal_executed",
+      "proposal_cancelled",
+      "delegate_changed",
+      "config_updated",
+      "governor_upgraded",
+      "wrapper_deposit",
+      "wrapper_withdrawal",
+      "reputation_updated",
+      "effective_threshold_changed",
+      "delegation_registered",
+      "delegation_revoked",
+      "delegation_depth_limit_updated",
+      "draft_created",
+      "co_sponsored",
+      "co_sponsorship_withdrawn",
+      "draft_finalized",
+      "draft_cancelled",
+      "draft_expired",
+      "stream_created",
+      "stream_spend",
+      "stream_batch",
+      "stream_revoked",
+      "stream_extended",
+      "stream_topped_up",
+      "stream_exhausted",
+      "stream_expired",
+      "optimistic_proposal_created",
+      "optimistic_objection_cast",
+      "optimistic_proposal_objected",
+      "optimistic_proposal_passed",
+      "optimistic_proposal_executed",
+      "optimistic_proposal_cancelled",
+    ];
+
+    it("accepts all documented event types", (done) => {
+      const handler = jest.fn();
+      streamEvents(indexerUrl, handler, { types: eventTypes });
+
+      setTimeout(() => {
+        // Should send without error
+        expect(mockWs.send).toHaveBeenCalled();
+        done();
+      }, 10);
+    });
+  });
+});

--- a/sdk/src/__tests__/wrapper.test.ts
+++ b/sdk/src/__tests__/wrapper.test.ts
@@ -1,0 +1,227 @@
+var mockScValToNative = jest.fn();
+var mockNativeToScVal = jest.fn();
+var mockGetAccount = jest.fn();
+var mockPrepareTransaction = jest.fn();
+var mockSendTransaction = jest.fn();
+var mockSimulationSuccess = jest.fn();
+
+import { WrapperClient } from "../wrapper";
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const actual = jest.requireActual("@stellar/stellar-sdk");
+  return {
+    ...actual,
+    scValToNative: mockScValToNative,
+    nativeToScVal: mockNativeToScVal,
+    SorobanRpc: {
+      ...actual.SorobanRpc,
+      Server: jest.fn().mockImplementation(() => ({
+        getAccount: mockGetAccount,
+        prepareTransaction: mockPrepareTransaction,
+        sendTransaction: mockSendTransaction,
+        simulateTransaction: jest.fn(),
+      })),
+      Api: {
+        isSimulationSuccess: mockSimulationSuccess,
+      },
+    },
+    Contract: jest.fn().mockImplementation((addr) => ({
+      call: jest.fn().mockReturnValue({}),
+      address: () => addr,
+    })),
+    TransactionBuilder: jest.fn().mockImplementation(() => ({
+      addOperation: jest.fn().mockReturnThis(),
+      setTimeout: jest.fn().mockReturnThis(),
+      build: jest.fn().mockReturnValue({}),
+    })),
+  };
+});
+
+import { Account, Keypair, xdr } from "@stellar/stellar-sdk";
+
+describe("WrapperClient", () => {
+  let client: WrapperClient;
+  const wrapperAddress = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+  const validGAddr = "GBFUUXATVOGXGD4KS3I423QFZSPE4ZFOQ3TCJVWFUYSIPULXIRVRE2DT";
+  const mockKeypair = Keypair.random();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAccount.mockResolvedValue(new Account(validGAddr, "1"));
+    mockNativeToScVal.mockReturnValue({} as xdr.ScVal);
+    mockSimulationSuccess.mockReturnValue(true);
+
+    client = new WrapperClient({
+      wrapperAddress,
+      network: "testnet",
+    });
+  });
+
+  describe("constructor", () => {
+    it("initializes with provided config", () => {
+      const config = {
+        wrapperAddress,
+        network: "mainnet" as const,
+      };
+      const newClient = new WrapperClient(config);
+      expect(newClient).toBeDefined();
+    });
+
+    it("uses default RPC URL for network", () => {
+      const newClient = new WrapperClient({
+        wrapperAddress,
+        network: "testnet",
+      });
+      expect(newClient).toBeDefined();
+    });
+
+    it("accepts custom RPC URL", () => {
+      const customRpc = "https://custom-soroban-rpc.example.com";
+      const newClient = new WrapperClient({
+        wrapperAddress,
+        network: "testnet",
+        rpcUrl: customRpc,
+      });
+      expect(newClient).toBeDefined();
+    });
+  });
+
+  describe("deposit()", () => {
+    beforeEach(() => {
+      const mockTx = { sign: jest.fn() };
+      mockPrepareTransaction.mockResolvedValue(mockTx);
+      mockSendTransaction.mockResolvedValue({
+        status: "PENDING",
+        hash: "deposit123",
+      });
+    });
+
+    it("builds and sends a deposit transaction", async () => {
+      const amount = 1000n;
+      const hash = await client.deposit(mockKeypair, amount);
+      expect(hash).toBe("deposit123");
+      expect(mockGetAccount).toHaveBeenCalledWith(mockKeypair.publicKey());
+      expect(mockPrepareTransaction).toHaveBeenCalled();
+      expect(mockSendTransaction).toHaveBeenCalled();
+    });
+
+    it("calls nativeToScVal with correct parameters", async () => {
+      await client.deposit(mockKeypair, 500n);
+      expect(mockNativeToScVal).toHaveBeenCalledWith(mockKeypair.publicKey(), {
+        type: "address",
+      });
+      expect(mockNativeToScVal).toHaveBeenCalledWith(500n, { type: "i128" });
+    });
+
+    it("returns transaction hash on success", async () => {
+      mockSendTransaction.mockResolvedValue({
+        status: "SUCCESS",
+        hash: "abc123def456",
+      });
+      const hash = await client.deposit(mockKeypair, 1000n);
+      expect(hash).toBe("abc123def456");
+    });
+  });
+
+  describe("withdraw()", () => {
+    beforeEach(() => {
+      const mockTx = { sign: jest.fn() };
+      mockPrepareTransaction.mockResolvedValue(mockTx);
+      mockSendTransaction.mockResolvedValue({
+        status: "PENDING",
+        hash: "withdraw123",
+      });
+    });
+
+    it("builds and sends a withdraw transaction", async () => {
+      const amount = 500n;
+      const hash = await client.withdraw(mockKeypair, amount);
+      expect(hash).toBe("withdraw123");
+      expect(mockGetAccount).toHaveBeenCalledWith(mockKeypair.publicKey());
+      expect(mockPrepareTransaction).toHaveBeenCalled();
+      expect(mockSendTransaction).toHaveBeenCalled();
+    });
+
+    it("calls nativeToScVal with withdraw amount", async () => {
+      await client.withdraw(mockKeypair, 750n);
+      expect(mockNativeToScVal).toHaveBeenCalledWith(750n, { type: "i128" });
+    });
+  });
+
+  describe("delegate()", () => {
+    const delegateeAddr = "GBTESTDELEGATEEADDRESSEXAMPLEFORUNITTESTSTESTING";
+
+    beforeEach(() => {
+      const mockTx = { sign: jest.fn() };
+      mockPrepareTransaction.mockResolvedValue(mockTx);
+      mockSendTransaction.mockResolvedValue({
+        status: "PENDING",
+        hash: "delegate123",
+      });
+    });
+
+    it("builds and sends a delegate transaction", async () => {
+      const hash = await client.delegate(mockKeypair, delegateeAddr);
+      expect(hash).toBe("delegate123");
+      expect(mockGetAccount).toHaveBeenCalledWith(mockKeypair.publicKey());
+      expect(mockPrepareTransaction).toHaveBeenCalled();
+      expect(mockSendTransaction).toHaveBeenCalled();
+    });
+
+    it("calls nativeToScVal with delegatee address", async () => {
+      await client.delegate(mockKeypair, delegateeAddr);
+      expect(mockNativeToScVal).toHaveBeenCalledWith(delegateeAddr, {
+        type: "address",
+      });
+    });
+  });
+
+  describe("getVotes()", () => {
+    it("returns voting power for address", async () => {
+      mockSimulationSuccess.mockReturnValue(true);
+      const mockServer = {
+        getAccount: mockGetAccount,
+        prepareTransaction: mockPrepareTransaction,
+        simulateTransaction: jest.fn().mockResolvedValue({
+          result: { retval: { value: "100000" } },
+        }),
+      };
+
+      client["server"] = mockServer as any;
+
+      const votes = await client.getVotes(validGAddr);
+      expect(votes).toBeDefined();
+    });
+
+    it("returns 0n when simulation has no retval", async () => {
+      mockSimulationSuccess.mockReturnValue(true);
+      const mockServer = {
+        getAccount: mockGetAccount,
+        prepareTransaction: mockPrepareTransaction,
+        simulateTransaction: jest.fn().mockResolvedValue({
+          result: { retval: null },
+        }),
+      };
+
+      client["server"] = mockServer as any;
+
+      const votes = await client.getVotes(validGAddr);
+      expect(votes).toBe(0n);
+    });
+
+    it("throws when simulation fails", async () => {
+      mockSimulationSuccess.mockReturnValue(false);
+      const mockServer = {
+        getAccount: mockGetAccount,
+        prepareTransaction: mockPrepareTransaction,
+        simulateTransaction: jest.fn().mockResolvedValue({}),
+      };
+
+      client["server"] = mockServer as any;
+
+      await expect(client.getVotes(validGAddr)).rejects.toThrow(
+        "Simulation failed"
+      );
+    });
+  });
+});

--- a/tools/sim/Cargo.toml
+++ b/tools/sim/Cargo.toml
@@ -15,6 +15,7 @@ sorogov-timelock = { path = "../../contracts/timelock" }
 sorogov-token-votes = { path = "../../contracts/token-votes" }
 sorogov-treasury = { path = "../../contracts/treasury" }
 sorogov-co-sponsorship = { path = "../../contracts/co-sponsorship" }
+sorogov-conviction-voting = { path = "../../contracts/conviction-voting" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rand = "0.8"

--- a/tools/sim/src/runner.rs
+++ b/tools/sim/src/runner.rs
@@ -21,6 +21,7 @@ use soroban_sdk::testutils::{Address as _, Ledger as _};
 use soroban_sdk::{token, Address, Bytes, Env, String as SorobanString, Symbol, Vec as SorobanVec};
 
 use sorogov_co_sponsorship::{CoSponsorshipContract, CoSponsorshipContractClient};
+use sorogov_conviction_voting::{ConvictionVotingContract, ConvictionVotingContractClient};
 use sorogov_governor::{
     GovernorContract, GovernorContractClient, GovernorSettings, ProposalState, VoteSupport,
     VoteType,
@@ -64,6 +65,8 @@ pub struct SimulationRunner {
     treasury: TreasuryContractClient<'static>,
     #[allow(dead_code)]
     co_sponsorship: CoSponsorshipContractClient<'static>,
+    #[allow(dead_code)]
+    conviction_voting: ConvictionVotingContractClient<'static>,
     token: Address,
     target: Address,
     treasury_addr: Address,
@@ -153,6 +156,17 @@ impl SimulationRunner {
         governor_settings.co_sponsorship_registry = Some(co_sponsorship_id);
         governor.update_config(&governor_settings);
 
+        let conviction_voting_id = env.register(ConvictionVotingContract, ());
+        let conviction_voting = ConvictionVotingContractClient::new(&env, &conviction_voting_id);
+        conviction_voting.initialize(
+            &admin,
+            &token_votes_id,
+            &5000u32,  // decay_bps: 50%
+            &5000u32,  // max_ratio_bps: 50%
+            &10_000_000i128, // min_threshold_conviction
+            &100u32,   // weight_bps: 1%
+        );
+
         let target = env.register(SimTargetContract, ());
 
         let sac = token::StellarAssetClient::new(&env, &token);
@@ -179,6 +193,7 @@ impl SimulationRunner {
             token_votes,
             treasury,
             co_sponsorship,
+            conviction_voting,
             token,
             target,
             treasury_addr: treasury_id,
@@ -600,6 +615,44 @@ impl SimulationRunner {
                         result.cycle_path
                     );
                 }
+            }
+            SimStep::ConvictionCreateProposal {
+                actor,
+                target,
+                fn_name,
+                calldata,
+                requested_amount,
+            } => {
+                let proposer = self.get_actor(actor).clone();
+                let target_addr = self.resolve_target(target);
+                let fn_symbol = Symbol::new(&self.env, fn_name);
+                let calldata_bytes = if let Some(cd) = calldata {
+                    Bytes::from_slice(&self.env, cd.as_bytes())
+                } else {
+                    Bytes::new(&self.env)
+                };
+                self.conviction_voting.create_proposal(
+                    &proposer,
+                    &target_addr,
+                    &fn_symbol,
+                    &calldata_bytes,
+                    requested_amount,
+                );
+            }
+            SimStep::ConvictionStake {
+                actor,
+                proposal_id,
+                amount,
+            } => {
+                let staker = self.get_actor(actor).clone();
+                self.conviction_voting.stake(&staker, proposal_id, amount);
+            }
+            SimStep::ConvictionWithdrawStake { actor } => {
+                let staker = self.get_actor(actor).clone();
+                self.conviction_voting.withdraw_stake(&staker);
+            }
+            SimStep::ConvictionCheckpoint { proposal_id } => {
+                self.conviction_voting.checkpoint_conviction(proposal_id);
             }
         }
     }

--- a/tools/sim/src/scenario.rs
+++ b/tools/sim/src/scenario.rs
@@ -174,6 +174,24 @@ pub enum SimStep {
     ValidateDag {
         schedule_step_indices: Vec<usize>,
     },
+    ConvictionCreateProposal {
+        actor: String,
+        target: String,
+        fn_name: String,
+        calldata: Option<String>,
+        requested_amount: i128,
+    },
+    ConvictionStake {
+        actor: String,
+        proposal_id: u64,
+        amount: i128,
+    },
+    ConvictionWithdrawStake {
+        actor: String,
+    },
+    ConvictionCheckpoint {
+        proposal_id: u64,
+    },
 }
 
 impl SimStep {
@@ -205,6 +223,10 @@ impl SimStep {
             SimStep::ScheduleBatch { .. } => "ScheduleBatch",
             SimStep::ExecuteBatch { .. } => "ExecuteBatch",
             SimStep::ValidateDag { .. } => "ValidateDag",
+            SimStep::ConvictionCreateProposal { .. } => "ConvictionCreateProposal",
+            SimStep::ConvictionStake { .. } => "ConvictionStake",
+            SimStep::ConvictionWithdrawStake { .. } => "ConvictionWithdrawStake",
+            SimStep::ConvictionCheckpoint { .. } => "ConvictionCheckpoint",
         }
     }
 }

--- a/tools/sim/src/scenarios/conviction_voting.json
+++ b/tools/sim/src/scenarios/conviction_voting.json
@@ -1,0 +1,89 @@
+{
+  "name": "conviction_voting",
+  "description": "Conviction voting proposal lifecycle with sustained staking, conviction decay, and checkpoint-driven execution",
+  "seed": 42,
+  "governor_settings": {
+    "voting_delay": 1,
+    "voting_period": 10,
+    "quorum_numerator": 10,
+    "proposal_threshold": 100,
+    "vote_type": "Extended",
+    "proposal_grace_period": 1000,
+    "max_calldata_size": 10000,
+    "proposal_cooldown": 0,
+    "max_proposals_per_period": 5,
+    "proposal_period_duration": 10000
+  },
+  "actors": [
+    { "name": "alice", "initial_balance": 5000, "delegate_to": null, "role": "Proposer" },
+    { "name": "bob", "initial_balance": 3000, "delegate_to": null, "role": "TokenHolder" },
+    { "name": "carol", "initial_balance": 2000, "delegate_to": null, "role": "TokenHolder" },
+    { "name": "dave", "initial_balance": 2000, "delegate_to": null, "role": "TokenHolder" }
+  ],
+  "steps": [
+    { "type": "TakeAnalyticsSnapshot" },
+    {
+      "type": "ConvictionCreateProposal",
+      "actor": "alice",
+      "target": "target",
+      "fn_name": "noop",
+      "calldata": null,
+      "requested_amount": 500
+    },
+    {
+      "type": "ConvictionStake",
+      "actor": "alice",
+      "proposal_id": 1,
+      "amount": 2000
+    },
+    {
+      "type": "AdvanceLedger",
+      "ledgers": 5
+    },
+    {
+      "type": "ConvictionStake",
+      "actor": "bob",
+      "proposal_id": 1,
+      "amount": 1500
+    },
+    {
+      "type": "AdvanceLedger",
+      "ledgers": 5
+    },
+    {
+      "type": "ConvictionStake",
+      "actor": "carol",
+      "proposal_id": 1,
+      "amount": 1000
+    },
+    {
+      "type": "AdvanceLedger",
+      "ledgers": 10
+    },
+    {
+      "type": "ConvictionCheckpoint",
+      "proposal_id": 1
+    },
+    {
+      "type": "AdvanceLedger",
+      "ledgers": 10
+    },
+    {
+      "type": "ConvictionCheckpoint",
+      "proposal_id": 1
+    },
+    {
+      "type": "ConvictionWithdrawStake",
+      "actor": "alice"
+    },
+    {
+      "type": "AdvanceLedger",
+      "ledgers": 5
+    },
+    {
+      "type": "ConvictionCheckpoint",
+      "proposal_id": 1
+    },
+    { "type": "TakeAnalyticsSnapshot" }
+  ]
+}


### PR DESCRIPTION
## Summary
This PR addresses all 4 assigned issues by adding comprehensive test coverage for SDK modules and implementing conviction voting scenario support in the simulation harness.

- **#1095**: Add `sdk/src/__tests__/streamEvents.test.ts` with comprehensive WebSocket event streaming tests
- **#1094**: Add `sdk/src/__tests__/wrapper.test.ts` with full WrapperClient test coverage  
- **#1085**: Add conviction voting scenario (`tools/sim/src/scenarios/conviction_voting.json`) and runner support
- **#1080**: Fix CONTRIBUTING.md branch naming examples to match actual convention (no numbers)

## Changes
1. **SDK Test Files** (`wrapper.test.ts`, `streamEvents.test.ts`):
   - Constructor and initialization tests
   - Transaction building and execution tests
   - Event filtering and WebSocket/polling fallback tests
   - Edge case handling (simulation failures, malformed messages, etc.)

2. **Conviction Voting Simulation**:
   - Added 4 new SimStep variants: ConvictionCreateProposal, ConvictionStake, ConvictionWithdrawStake, ConvictionCheckpoint
   - Integrated conviction-voting contract client into simulation runner
   - Contract initialized with sensible defaults (5000 decay_bps, 5000 max_ratio_bps, 100 weight_bps)
   - Scenario exercises full lifecycle: create proposal → multiple actors stake → conviction accumulates over ledgers → checkpoint executes

3. **Documentation Fix**:
   - Updated CONTRIBUTING.md to show actual branch naming convention without numbers
   - Added concrete examples (feat/governor-parameter-tuning, fix/quorum-calculation-edge-case, etc.)

## Test Plan
- [ ] SDK tests run: \`pnpm test:sdk\`
- [ ] Conviction voting scenario validates: \`cargo run --manifest-path tools/sim/Cargo.toml -- validate tools/sim/src/scenarios/conviction_voting.json\`
- [ ] Simulation runs successfully: \`cargo run --manifest-path tools/sim/Cargo.toml -- run --scenario tools/sim/src/scenarios/conviction_voting.json\`
- [ ] No regressions in existing scenarios: \`cargo run --manifest-path tools/sim/Cargo.toml -- run-all\`

closes #1080
closes #1085 
closes #1094
closes #1095