### PR TITLE
test: add missing coverage for conviction-voting, treasury-strategies, and SDK clients

### DIFF
--- a/packages/indexer/src/__tests__/conviction-events.test.ts
+++ b/packages/indexer/src/__tests__/conviction-events.test.ts
@@ -1,0 +1,214 @@
+import { nativeToScVal, SorobanRpc, xdr } from "@stellar/stellar-sdk";
+import { processEvents } from "../events";
+import { pool } from "../db";
+import { broadcast } from "../ws";
+import { invalidatePattern } from "../cache";
+
+jest.mock("../db", () => ({
+  pool: { query: jest.fn() },
+}));
+
+jest.mock("../cache", () => ({
+  invalidate: jest.fn(),
+  invalidatePattern: jest.fn(),
+}));
+
+jest.mock("../ws", () => ({
+  broadcast: jest.fn(),
+}));
+
+const GOVERNOR = "CGOVERNOR";
+const CONVICTION = "CCONVICTION";
+
+function toScVal(value: unknown): any {
+  if (Array.isArray(value)) return xdr.ScVal.scvVec(value.map(toScVal));
+  return nativeToScVal(value);
+}
+
+function makeEvent(
+  id: string,
+  ledger: number,
+  eventType: string,
+  value: unknown,
+  proposalId: unknown,
+  contractId = CONVICTION,
+): SorobanRpc.Api.EventResponse {
+  return {
+    id,
+    type: "contract",
+    ledger,
+    contractId,
+    txHash: `tx-${ledger}`,
+    topic: [
+      nativeToScVal(eventType, { type: "symbol" }),
+      nativeToScVal(proposalId, { type: "u64" }),
+    ],
+    value: toScVal(value),
+  } as unknown as SorobanRpc.Api.EventResponse;
+}
+
+describe("conviction voting event indexing", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (pool.query as jest.Mock).mockResolvedValue({ rows: [] });
+  });
+
+  function run(events: SorobanRpc.Api.EventResponse[]) {
+    const server = {
+      getEvents: jest.fn().mockResolvedValue({ events }),
+    } as unknown as SorobanRpc.Server;
+    return processEvents(
+      server,
+      {
+        rpcUrl: "http://fake",
+        governorAddress: GOVERNOR,
+        convictionVotingAddress: CONVICTION,
+        pollIntervalMs: 1,
+      },
+      100,
+    );
+  }
+
+  it("writes a conviction_proposals row on ProposalCreated", async () => {
+    await run([
+      makeEvent("e1", 100, "ProposalCreated", ["GPROPOSER", "CTARGET", 500n], 1n),
+    ]);
+
+    const insert = (pool.query as jest.Mock).mock.calls.find(([sql]) =>
+      String(sql).includes("INSERT INTO conviction_proposals"),
+    );
+    expect(insert).toBeDefined();
+    expect(insert![1]).toEqual(["1", "GPROPOSER", "CTARGET", "500", 100]);
+    expect(invalidatePattern).toHaveBeenCalledWith("conviction:");
+    expect(broadcast).toHaveBeenCalledWith({
+      type: "conviction_proposal_created",
+      data: { proposal_id: "1", ledger: 100 },
+    });
+  });
+
+  it("upserts a conviction_stakes row on StakeUpdated (non-zero amount)", async () => {
+    await run([
+      makeEvent("e1", 100, "StakeUpdated", ["GSTAKER", 250n], 1n),
+    ]);
+
+    const upsert = (pool.query as jest.Mock).mock.calls.find(([sql]) =>
+      String(sql).includes("INSERT INTO conviction_stakes"),
+    );
+    expect(upsert).toBeDefined();
+    expect(upsert![1]).toEqual(["GSTAKER", "1", "250", 100]);
+    expect(
+      (pool.query as jest.Mock).mock.calls.some(([sql]) =>
+        String(sql).includes("DELETE FROM conviction_stakes"),
+      ),
+    ).toBe(false);
+    expect(broadcast).toHaveBeenCalledWith({
+      type: "conviction_stake_updated",
+      data: { proposal_id: "1", ledger: 100 },
+    });
+  });
+
+  it("deletes the conviction_stakes row when StakeUpdated amount is zero", async () => {
+    await run([
+      makeEvent("e1", 100, "StakeUpdated", ["GSTAKER", 0n], 1n),
+    ]);
+
+    const del = (pool.query as jest.Mock).mock.calls.find(([sql]) =>
+      String(sql).includes("DELETE FROM conviction_stakes"),
+    );
+    expect(del).toBeDefined();
+    expect(del![1]).toEqual(["GSTAKER", "1"]);
+    expect(
+      (pool.query as jest.Mock).mock.calls.some(([sql]) =>
+        String(sql).includes("INSERT INTO conviction_stakes"),
+      ),
+    ).toBe(false);
+  });
+
+  it("updates conviction and appends a conviction_snapshots row on ConvictionUpdated", async () => {
+    await run([
+      makeEvent("e1", 100, "ConvictionUpdated", [777n], 1n),
+    ]);
+
+    const update = (pool.query as jest.Mock).mock.calls.find(([sql]) =>
+      String(sql).includes("UPDATE conviction_proposals SET conviction"),
+    );
+    expect(update).toBeDefined();
+    expect(update![1]).toEqual(["1", "777", 100]);
+
+    const snapshot = (pool.query as jest.Mock).mock.calls.find(([sql]) =>
+      String(sql).includes("INSERT INTO conviction_snapshots"),
+    );
+    expect(snapshot).toBeDefined();
+    expect(snapshot![1]).toEqual(["1", 100, "777"]);
+    expect(broadcast).toHaveBeenCalledWith({
+      type: "conviction_conviction_updated",
+      data: { proposal_id: "1", ledger: 100 },
+    });
+  });
+
+  it("marks the proposal executed on ProposalExecuted", async () => {
+    await run([
+      makeEvent("e1", 100, "ProposalExecuted", [], 1n),
+    ]);
+
+    const update = (pool.query as jest.Mock).mock.calls.find(([sql]) =>
+      String(sql).includes("SET executed = TRUE"),
+    );
+    expect(update).toBeDefined();
+    expect(update![1]).toEqual(["1"]);
+    expect(broadcast).toHaveBeenCalledWith({
+      type: "conviction_proposal_executed",
+      data: { proposal_id: "1", ledger: 100 },
+    });
+  });
+
+  it("marks the proposal cancelled on ProposalCancelled", async () => {
+    await run([
+      makeEvent("e1", 100, "ProposalCancelled", [], 1n),
+    ]);
+
+    const update = (pool.query as jest.Mock).mock.calls.find(([sql]) =>
+      String(sql).includes("SET cancelled = TRUE"),
+    );
+    expect(update).toBeDefined();
+    expect(update![1]).toEqual(["1"]);
+    expect(broadcast).toHaveBeenCalledWith({
+      type: "conviction_proposal_cancelled",
+      data: { proposal_id: "1", ledger: 100 },
+    });
+  });
+
+  it("does not route conviction topics emitted from the governor contract", async () => {
+    const server = {
+      getEvents: jest
+        .fn()
+        .mockResolvedValue({
+          events: [
+            makeEvent("e1", 100, "ProposalCreated", ["GPROPOSER", "CTARGET", 500n], 1n, GOVERNOR),
+          ],
+        }),
+    } as unknown as SorobanRpc.Server;
+
+    await processEvents(
+      server,
+      {
+        rpcUrl: "http://fake",
+        governorAddress: GOVERNOR,
+        convictionVotingAddress: CONVICTION,
+        pollIntervalMs: 1,
+      },
+      100,
+    );
+
+    expect(
+      (pool.query as jest.Mock).mock.calls.some(([sql]) =>
+        String(sql).includes("conviction_proposals"),
+      ),
+    ).toBe(false);
+    expect(invalidatePattern).not.toHaveBeenCalledWith("conviction:");
+    expect(broadcast).not.toHaveBeenCalledWith({
+      type: "conviction_proposal_created",
+      data: { proposal_id: "1", ledger: 100 },
+    });
+  });
+});

--- a/packages/indexer/src/__tests__/treasury-strategies-events.test.ts
+++ b/packages/indexer/src/__tests__/treasury-strategies-events.test.ts
@@ -1,0 +1,203 @@
+import { nativeToScVal, SorobanRpc, xdr } from "@stellar/stellar-sdk";
+import { processEvents } from "../events";
+import { pool } from "../db";
+import { broadcast } from "../ws";
+import { invalidatePattern } from "../cache";
+
+jest.mock("../db", () => ({
+  pool: { query: jest.fn() },
+}));
+
+jest.mock("../cache", () => ({
+  invalidate: jest.fn(),
+  invalidatePattern: jest.fn(),
+}));
+
+jest.mock("../ws", () => ({
+  broadcast: jest.fn(),
+}));
+
+const GOVERNOR = "CGOVERNOR";
+const STRATEGIES = "CSTRATEGIES";
+
+function toScVal(value: unknown): any {
+  if (Array.isArray(value)) return xdr.ScVal.scvVec(value.map(toScVal));
+  return nativeToScVal(value);
+}
+
+function makeEvent(
+  id: string,
+  ledger: number,
+  eventType: string,
+  value: unknown,
+  topic1: unknown,
+  contractId = STRATEGIES,
+): SorobanRpc.Api.EventResponse {
+  return {
+    id,
+    type: "contract",
+    ledger,
+    contractId,
+    txHash: `tx-${ledger}`,
+    topic: [
+      nativeToScVal(eventType, { type: "symbol" }),
+      nativeToScVal(topic1, { type: "u64" }),
+    ],
+    value: toScVal(value),
+  } as unknown as SorobanRpc.Api.EventResponse;
+}
+
+describe("treasury strategies event indexing", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (pool.query as jest.Mock).mockResolvedValue({ rows: [] });
+  });
+
+  function run(events: SorobanRpc.Api.EventResponse[]) {
+    const server = {
+      getEvents: jest.fn().mockResolvedValue({ events }),
+    } as unknown as SorobanRpc.Server;
+    return processEvents(
+      server,
+      {
+        rpcUrl: "http://fake",
+        governorAddress: GOVERNOR,
+        treasuryStrategiesAddress: STRATEGIES,
+        pollIntervalMs: 1,
+      },
+      100,
+    );
+  }
+
+  it("inserts a treasury_strategies row on StratReg", async () => {
+    await run([
+      makeEvent("e1", 100, "StratReg", { adapter: "CADAPTER", token: "CTOKEN" }, 1n),
+    ]);
+
+    const insert = (pool.query as jest.Mock).mock.calls.find(([sql]) =>
+      String(sql).includes("INSERT INTO treasury_strategies"),
+    );
+    expect(insert).toBeDefined();
+    expect(insert![1]).toEqual(["1", "CADAPTER", "CTOKEN", 100]);
+    expect(invalidatePattern).toHaveBeenCalledWith("treasury-strategies:");
+    expect(broadcast).toHaveBeenCalledWith({
+      type: "strategy_registered",
+      data: { strategy_id: "1", adapter: "CADAPTER", token: "CTOKEN", ledger: 100 },
+    });
+  });
+
+  it("deactivates a strategy on StratDeact", async () => {
+    await run([makeEvent("e1", 100, "StratDeact", [], 1n)]);
+
+    const update = (pool.query as jest.Mock).mock.calls.find(([sql]) =>
+      String(sql).includes("UPDATE treasury_strategies SET active = FALSE"),
+    );
+    expect(update).toBeDefined();
+    expect(update![1]).toEqual(["1"]);
+    expect(broadcast).toHaveBeenCalledWith({
+      type: "strategy_deactivated",
+      data: { strategy_id: "1", ledger: 100 },
+    });
+  });
+
+  it("records an allocation and raises current_allocation on Deposited", async () => {
+    await run([
+      makeEvent("e1", 100, "Deposited", { amount: 1000n }, 1n),
+    ]);
+
+    const insert = (pool.query as jest.Mock).mock.calls.find(([sql]) =>
+      String(sql).includes("INSERT INTO strategy_allocations"),
+    );
+    expect(insert).toBeDefined();
+    expect(insert![1]).toEqual(["1", "1000", 100]);
+
+    const update = (pool.query as jest.Mock).mock.calls.find(([sql]) =>
+      String(sql).includes("current_allocation = current_allocation +"),
+    );
+    expect(update).toBeDefined();
+    expect(update![1]).toEqual(["1", "1000"]);
+    expect(broadcast).toHaveBeenCalledWith({
+      type: "strategy_deposited",
+      data: { strategy_id: "1", amount: "1000", ledger: 100 },
+    });
+  });
+
+  it("records a withdrawal and lowers current_allocation on WdrawReq", async () => {
+    await run([
+      makeEvent(
+        "e1",
+        100,
+        "WdrawReq",
+        { strategy_id: 1n, amount: 400n, claimable_ledger: 200 },
+        9n,
+      ),
+    ]);
+
+    const insert = (pool.query as jest.Mock).mock.calls.find(([sql]) =>
+      String(sql).includes("INSERT INTO strategy_withdrawals"),
+    );
+    expect(insert).toBeDefined();
+    expect(insert![1]).toEqual(["9", "1", "400", 100, 200]);
+
+    const update = (pool.query as jest.Mock).mock.calls.find(([sql]) =>
+      String(sql).includes("current_allocation = current_allocation -"),
+    );
+    expect(update).toBeDefined();
+    expect(update![1]).toEqual(["1", "400"]);
+    expect(broadcast).toHaveBeenCalledWith({
+      type: "strategy_withdrawal_requested",
+      data: {
+        withdrawal_id: "9",
+        strategy_id: "1",
+        amount: "400",
+        claimable_ledger: 200,
+      },
+    });
+  });
+
+  it("records the actual amount on WdrawClaim", async () => {
+    await run([
+      makeEvent("e1", 100, "WdrawClaim", { actual_amount: 350n }, 9n),
+    ]);
+
+    const update = (pool.query as jest.Mock).mock.calls.find(([sql]) =>
+      String(sql).includes("UPDATE strategy_withdrawals SET actual_amount"),
+    );
+    expect(update).toBeDefined();
+    expect(update![1]).toEqual(["9", "350", 100]);
+    expect(broadcast).toHaveBeenCalledWith({
+      type: "strategy_withdrawal_claimed",
+      data: { withdrawal_id: "9", actual_amount: "350", ledger: 100 },
+    });
+  });
+
+  it("does not route strategy topics emitted from the governor contract", async () => {
+    const server = {
+      getEvents: jest
+        .fn()
+        .mockResolvedValue({
+          events: [
+            makeEvent("e1", 100, "StratReg", { adapter: "CADAPTER", token: "CTOKEN" }, 1n, GOVERNOR),
+          ],
+        }),
+    } as unknown as SorobanRpc.Server;
+
+    await processEvents(
+      server,
+      {
+        rpcUrl: "http://fake",
+        governorAddress: GOVERNOR,
+        treasuryStrategiesAddress: STRATEGIES,
+        pollIntervalMs: 1,
+      },
+      100,
+    );
+
+    expect(
+      (pool.query as jest.Mock).mock.calls.some(([sql]) =>
+        String(sql).includes("treasury_strategies"),
+      ),
+    ).toBe(false);
+    expect(broadcast).not.toHaveBeenCalled();
+  });
+});

--- a/sdk/src/__tests__/convictionVoting.test.ts
+++ b/sdk/src/__tests__/convictionVoting.test.ts
@@ -1,0 +1,251 @@
+// Define mocks with 'mock' prefix and use 'var' for hoisting support
+var mockNativeToScVal = jest.fn();
+var mockScValToNative = jest.fn();
+var mockGetAccount = jest.fn();
+var mockPrepareTransaction = jest.fn();
+var mockSendTransaction = jest.fn();
+var mockGetTransaction = jest.fn();
+var mockSimulateTransaction = jest.fn();
+
+import { ConvictionVotingClient } from "../convictionVoting";
+import { Account, Keypair } from "@stellar/stellar-sdk";
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const actual = jest.requireActual("@stellar/stellar-sdk");
+  return {
+    ...actual,
+    nativeToScVal: mockNativeToScVal,
+    scValToNative: mockScValToNative,
+    SorobanRpc: {
+      ...actual.SorobanRpc,
+      Server: jest.fn().mockImplementation(() => ({
+        getAccount: mockGetAccount,
+        prepareTransaction: mockPrepareTransaction,
+        sendTransaction: mockSendTransaction,
+        getTransaction: mockGetTransaction,
+        simulateTransaction: mockSimulateTransaction,
+      })),
+      Api: {
+        GetTransactionStatus: {
+          SUCCESS: "SUCCESS",
+          FAILED: "FAILED",
+          NOT_FOUND: "NOT_FOUND",
+        },
+        isSimulationError: jest.fn().mockReturnValue(false),
+      },
+    },
+    Contract: jest.fn().mockImplementation((addr) => ({
+      call: jest.fn().mockReturnValue({}),
+      address: () => addr,
+    })),
+    TransactionBuilder: jest.fn().mockImplementation(() => ({
+      addOperation: jest.fn().mockReturnThis(),
+      setTimeout: jest.fn().mockReturnThis(),
+      build: jest.fn().mockReturnValue({
+        toXDR: jest.fn().mockReturnValue(""),
+      }),
+    })),
+  };
+});
+
+const VALID_CADDR = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+const VALID_GADDR = "GBFUUXATVOGXGD4KS3I423QFZSPE4ZFOQ3TCJVWFUYSIPULXIRVRE2DT";
+const mockKeypair = Keypair.random();
+
+function makeClient(extra: Record<string, unknown> = {}) {
+  return new ConvictionVotingClient({
+    governorAddress: VALID_CADDR,
+    timelockAddress: VALID_CADDR,
+    votesAddress: VALID_CADDR,
+    network: "testnet",
+    convictionVotingAddress: VALID_CADDR,
+    simulationAccount: VALID_GADDR,
+    maxAttempts: 1,
+    ...extra,
+  });
+}
+
+describe("ConvictionVotingClient", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAccount.mockResolvedValue(new Account(VALID_GADDR, "1"));
+    mockNativeToScVal.mockReturnValue({} as any);
+    mockPrepareTransaction.mockResolvedValue({
+      toXDR: jest.fn().mockReturnValue("prepared_xdr"),
+      sign: jest.fn(),
+    });
+    mockSendTransaction.mockResolvedValue({ status: "PENDING", hash: "mock_hash" });
+    mockGetTransaction.mockResolvedValue({
+      status: "SUCCESS",
+      returnValue: {} as any,
+    });
+    mockSimulateTransaction.mockResolvedValue({ result: { retval: {} } });
+  });
+
+  describe("constructor", () => {
+    it("throws when convictionVotingAddress is missing", () => {
+      expect(
+        () =>
+          new ConvictionVotingClient({
+            governorAddress: VALID_CADDR,
+    timelockAddress: VALID_CADDR,
+    votesAddress: VALID_CADDR,
+            network: "testnet",
+          }),
+      ).toThrow("ConvictionVotingClient requires convictionVotingAddress");
+    });
+  });
+
+  describe("submit-based mutations", () => {
+    it("createProposal builds the call and returns the numeric id", async () => {
+      mockScValToNative.mockReturnValue(7n);
+      const client = makeClient();
+
+      const id = await client.createProposal(
+        mockKeypair,
+        VALID_CADDR,
+        "do_thing",
+        Buffer.from([0x01, 0x02]),
+        1000n,
+      );
+
+      expect(id).toBe(7);
+      expect(mockNativeToScVal).toHaveBeenCalledWith(mockKeypair.publicKey(), { type: "address" });
+      expect(mockNativeToScVal).toHaveBeenCalledWith(VALID_CADDR, { type: "address" });
+      expect(mockNativeToScVal).toHaveBeenCalledWith("do_thing", { type: "symbol" });
+      expect(mockNativeToScVal).toHaveBeenCalledWith(Buffer.from([0x01, 0x02]), { type: "bytes" });
+      expect(mockNativeToScVal).toHaveBeenCalledWith(1000n, { type: "i128" });
+    });
+
+    it("stake submits a stake call and returns the tx hash", async () => {
+      const client = makeClient();
+      const hash = await client.stake(mockKeypair, 3, 50n);
+      expect(hash).toBe("mock_hash");
+      expect(mockNativeToScVal).toHaveBeenCalledWith(3, { type: "u64" });
+      expect(mockNativeToScVal).toHaveBeenCalledWith(50n, { type: "i128" });
+    });
+
+    it("withdrawStake submits a withdraw_stake call and returns the tx hash", async () => {
+      const client = makeClient();
+      const hash = await client.withdrawStake(mockKeypair);
+      expect(hash).toBe("mock_hash");
+      expect(mockNativeToScVal).toHaveBeenCalledWith(mockKeypair.publicKey(), { type: "address" });
+    });
+
+    it("checkpointConviction returns conviction and execution status", async () => {
+      mockScValToNative
+        .mockReturnValueOnce(42n) // returnValue of checkpoint_conviction
+        .mockReturnValueOnce({
+          id: "5",
+          proposer: VALID_GADDR,
+          target: VALID_CADDR,
+          fn_name: "fn",
+          calldata: Buffer.from([]),
+          requested_amount: "1000",
+          created_ledger: 1,
+          conviction: "42",
+          last_updated_ledger: 2,
+          executed: true,
+          cancelled: false,
+        }); // getProposal simulate result
+      const client = makeClient();
+
+      const result = await client.checkpointConviction(mockKeypair, 5);
+
+      expect(result).toEqual({ conviction: 42n, executed: true });
+      // getProposal (after the checkpoint submit) is the only simulateTransaction call
+      expect(mockSimulateTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects when the submitted transaction fails", async () => {
+      mockSendTransaction.mockResolvedValue({ status: "ERROR" });
+      const client = makeClient();
+      await expect(client.stake(mockKeypair, 3, 50n)).rejects.toThrow(
+        "Transaction submission failed: stake",
+      );
+    });
+  });
+
+  describe("read methods", () => {
+    it("getProposal decodes the proposal struct", async () => {
+      mockScValToNative.mockReturnValue({
+        id: "9",
+        proposer: VALID_GADDR,
+        target: VALID_CADDR,
+        fn_name: "run",
+        calldata: Buffer.from([0xaa]),
+        requested_amount: "5000",
+        created_ledger: 10,
+        conviction: "123",
+        last_updated_ledger: 11,
+        executed: false,
+        cancelled: true,
+      });
+      const client = makeClient();
+
+      const proposal = await client.getProposal(9);
+
+      expect(proposal).toMatchObject({
+        id: 9n,
+        proposer: VALID_GADDR,
+        target: VALID_CADDR,
+        fnName: "run",
+        requestedAmount: 5000n,
+        createdLedger: 10,
+        conviction: 123n,
+        executed: false,
+        cancelled: true,
+      });
+      expect(mockSimulateTransaction).toHaveBeenCalled();
+    });
+
+    it("getRequiredThreshold returns the simulated threshold", async () => {
+      mockScValToNative.mockReturnValue("750");
+      const client = makeClient();
+
+      const threshold = await client.getRequiredThreshold(1000n);
+
+      expect(threshold).toBe(750n);
+      expect(mockNativeToScVal).toHaveBeenCalledWith(1000n, { type: "i128" });
+    });
+  });
+
+  describe("getConvictionHistory (indexer-backed)", () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it("fetches and maps the conviction history from the indexer", async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          data: [
+            { proposal_id: "1", ledger: 100, conviction: "10" },
+            { proposal_id: "1", ledger: 200, conviction: "25" },
+          ],
+        }),
+      });
+      global.fetch = mockFetch as unknown as typeof fetch;
+      const client = makeClient({ indexerUrl: "https://indexer.example.com" });
+
+      const history = await client.getConvictionHistory(1);
+
+      expect(history).toEqual([
+        { proposalId: 1n, ledger: 100, conviction: 10n },
+        { proposalId: 1n, ledger: 200, conviction: 25n },
+      ]);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://indexer.example.com/conviction/proposals/1/conviction-history",
+      );
+    });
+
+    it("throws when indexerUrl is not configured", async () => {
+      const client = makeClient();
+      await expect(client.getConvictionHistory(1)).rejects.toThrow(
+        "indexerUrl is required",
+      );
+    });
+  });
+});

--- a/sdk/src/__tests__/governanceTuning.test.ts
+++ b/sdk/src/__tests__/governanceTuning.test.ts
@@ -1,0 +1,196 @@
+import { GovernanceTuningClient } from "../governanceTuning";
+import { GovernorError, GovernorErrorCode } from "../errors";
+
+const BACKEND = "https://backend.example.com";
+
+function makeClient(extra: Record<string, unknown> = {}) {
+  return new GovernanceTuningClient({
+    governorAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+    timelockAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+    votesAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+    network: "testnet",
+    backendUrl: BACKEND,
+    maxAttempts: 1,
+    baseDelayMs: 1,
+    ...extra,
+  });
+}
+
+const RAW_RECOMMENDATION = {
+  id: 3,
+  computed_at: "2026-01-01T00:00:00Z",
+  current_quorum_numerator: 10,
+  recommended_quorum_numerator: 12,
+  current_proposal_threshold: 100,
+  recommended_proposal_threshold: 80,
+  rationale: "participation dropped",
+  auto_proposed: true,
+  proposal_id: 42,
+};
+
+const RAW_CONFIG = {
+  min_quorum_numerator: 5,
+  max_quorum_numerator: 20,
+  max_quorum_delta_bps: 200,
+  min_proposal_threshold: 50,
+  max_proposal_threshold: 500,
+  max_threshold_delta_bps: 300,
+  trailing_window: 1000,
+  interval_ms: 60000,
+  auto_propose: true,
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+describe("GovernanceTuningClient", () => {
+  const originalFetch = global.fetch;
+  let mockFetch: jest.Mock;
+
+  beforeEach(() => {
+    mockFetch = jest.fn();
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe("constructor / backendUrl", () => {
+    it("throws a GovernorError when backendUrl is missing", async () => {
+      const client = new GovernanceTuningClient({
+        governorAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+        timelockAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+        votesAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+        network: "testnet",
+        maxAttempts: 1,
+      });
+      await expect(client.getLatestRecommendation()).rejects.toBeInstanceOf(GovernorError);
+      try {
+        await client.getLatestRecommendation();
+      } catch (e) {
+        if (e instanceof GovernorError) {
+          expect(e.code).toBe(GovernorErrorCode.SimulationFailed);
+        }
+      }
+    });
+  });
+
+  describe("getLatestRecommendation", () => {
+    it("maps the latest recommendation from the backend", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(RAW_RECOMMENDATION),
+      });
+      const client = makeClient();
+
+      const rec = await client.getLatestRecommendation();
+
+      expect(rec).toMatchObject({
+        id: 3,
+        currentQuorumNumerator: 10,
+        recommendedQuorumNumerator: 12,
+        currentProposalThreshold: 100n,
+        recommendedProposalThreshold: 80n,
+        rationale: "participation dropped",
+        autoProposed: true,
+        proposalId: 42n,
+      });
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://backend.example.com/governance-tuning/recommendations/latest",
+        undefined,
+      );
+    });
+
+    it("returns null when the backend reports no recommendation yet", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(null),
+      });
+      const client = makeClient();
+
+      expect(await client.getLatestRecommendation()).toBeNull();
+    });
+  });
+
+  describe("getRecommendationHistory / getRecommendationHistoryPage", () => {
+    it("returns a flat array of mapped recommendations", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          data: [RAW_RECOMMENDATION, { ...RAW_RECOMMENDATION, id: 4, proposal_id: null }],
+        }),
+      });
+      const client = makeClient();
+
+      const history = await client.getRecommendationHistory(2, 0);
+
+      expect(history).toHaveLength(2);
+      expect(history[0].id).toBe(3);
+      expect(history[1].id).toBe(4);
+      expect(history[1].proposalId).toBeNull();
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://backend.example.com/governance-tuning/recommendations?limit=2&offset=0",
+        undefined,
+      );
+    });
+
+    it("returns the page wrapper with pagination metadata", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          data: [RAW_RECOMMENDATION],
+          pagination: { page: 1, limit: 20, hasMore: false },
+        }),
+      });
+      const client = makeClient();
+
+      const page = await client.getRecommendationHistoryPage(20, 0);
+
+      expect(page.recommendations).toHaveLength(1);
+      expect(page.pagination).toEqual({ page: 1, limit: 20, hasMore: false });
+    });
+  });
+
+  describe("getConfig", () => {
+    it("maps the tunable config from the backend", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(RAW_CONFIG),
+      });
+      const client = makeClient();
+
+      const config = await client.getConfig();
+
+      expect(config).toMatchObject({
+        minQuorumNumerator: 5,
+        maxQuorumNumerator: 20,
+        maxQuorumDeltaBps: 200,
+        minProposalThreshold: 50n,
+        maxProposalThreshold: 500n,
+        maxThresholdDeltaBps: 300,
+        trailingWindow: 1000,
+        intervalMs: 60000,
+        autoPropose: true,
+      });
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://backend.example.com/governance-tuning/config",
+        undefined,
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    it("wraps a non-ok backend response in a GovernorError", async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 500, json: jest.fn() });
+      const client = makeClient();
+
+      await expect(client.getConfig()).rejects.toBeInstanceOf(GovernorError);
+      try {
+        await client.getConfig();
+      } catch (e) {
+        if (e instanceof GovernorError) {
+          expect(e.code).toBe(GovernorErrorCode.SimulationFailed);
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
Adds the four missing test files from issues #1055, #1049, #1051, and #1056.

Closes #1055
Closes #1049
Closes #1051
Closes #1056