### PR TITLE
test: cover indexer events and treasury strategies client

### DIFF
--- a/packages/indexer/src/__tests__/proposal-signal-optimistic-events.test.ts
+++ b/packages/indexer/src/__tests__/proposal-signal-optimistic-events.test.ts
@@ -1,0 +1,288 @@
+import { nativeToScVal, SorobanRpc, xdr } from "@stellar/stellar-sdk";
+import { pool } from "../db";
+import { processEvents } from "../events";
+import { invalidatePattern } from "../cache";
+import { broadcast } from "../ws";
+
+jest.mock("../db", () => ({
+  pool: { query: jest.fn().mockResolvedValue({ rows: [] }) },
+}));
+
+jest.mock("../cache", () => ({
+  invalidate: jest.fn(),
+  invalidatePattern: jest.fn(),
+}));
+
+jest.mock("../ws", () => ({
+  broadcast: jest.fn(),
+}));
+
+const GOVERNOR_ADDRESS = "CGOVERNOR";
+const PROPOSAL_BONDS_ADDRESS = "CPROPOSALBONDS";
+const SIGNAL_ANCHOR_ADDRESS = "CSIGNALANCHOR";
+const OPTIMISTIC_GOVERNOR_ADDRESS = "COPTIMISTICGOVERNOR";
+
+function toScVal(value: unknown): xdr.ScVal {
+  if (Array.isArray(value)) {
+    return xdr.ScVal.scvVec(value.map(toScVal));
+  }
+  return nativeToScVal(value);
+}
+
+function makeEvent(
+  ledger: number,
+  contractId: string,
+  eventType: string,
+  value: unknown,
+  topics: unknown[] = [],
+): SorobanRpc.Api.EventResponse {
+  return {
+    type: "contract",
+    ledger,
+    contractId,
+    txHash: `tx-${ledger}`,
+    topic: [
+      nativeToScVal(eventType, { type: "symbol" }),
+      ...topics.map(toScVal),
+    ],
+    value: toScVal(value),
+  } as unknown as SorobanRpc.Api.EventResponse;
+}
+
+describe("proposal-bonds event indexing", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (pool.query as jest.Mock).mockResolvedValue({ rows: [] });
+  });
+
+  it("routes bond lifecycle events to the proposal-bonds handlers", async () => {
+    const descriptionHash = Buffer.from("ab".repeat(32), "hex");
+    const proposer = "GPROPOSER";
+    const recipient = "GRECIPIENT";
+    const events = [
+      makeEvent(
+        10,
+        PROPOSAL_BONDS_ADDRESS,
+        "BondLocked",
+        [descriptionHash, 100n],
+        [proposer],
+      ),
+      makeEvent(
+        11,
+        PROPOSAL_BONDS_ADDRESS,
+        "BondRefunded",
+        [descriptionHash, 100n],
+        [proposer],
+      ),
+      makeEvent(
+        12,
+        PROPOSAL_BONDS_ADDRESS,
+        "BondSlashed",
+        [descriptionHash, 100n, recipient],
+        [proposer],
+      ),
+    ];
+    const server = {
+      getEvents: jest.fn().mockResolvedValue({ events }),
+    } as unknown as SorobanRpc.Server;
+
+    const latest = await processEvents(
+      server,
+      {
+        rpcUrl: "http://fake",
+        governorAddress: GOVERNOR_ADDRESS,
+        proposalBondsAddress: PROPOSAL_BONDS_ADDRESS,
+        pollIntervalMs: 1,
+      },
+      10,
+    );
+
+    expect(latest).toBe(12);
+    expect(server.getEvents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: [
+          {
+            type: "contract",
+            contractIds: [GOVERNOR_ADDRESS, PROPOSAL_BONDS_ADDRESS],
+          },
+        ],
+      }),
+    );
+    expect(invalidatePattern).toHaveBeenCalledTimes(3);
+    expect(invalidatePattern).toHaveBeenCalledWith("proposal-bonds:");
+    expect((broadcast as jest.Mock).mock.calls.map(([event]) => event.type)).toEqual([
+      "bond_locked",
+      "bond_refunded",
+      "bond_slashed",
+    ]);
+    expect(broadcast).toHaveBeenCalledWith({
+      type: "bond_slashed",
+      data: {
+        description_hash: "ab".repeat(32),
+        proposer,
+        amount: "100",
+        recipient,
+        ledger: 12,
+      },
+    });
+
+    const queries = (pool.query as jest.Mock).mock.calls.map(([sql]) =>
+      String(sql),
+    );
+    expect(queries.filter((sql) => sql.includes("INSERT INTO event_log"))).toHaveLength(
+      3,
+    );
+    expect(
+      queries.some((sql) => sql.includes("INSERT INTO proposal_bonds")),
+    ).toBe(true);
+    expect(
+      queries.filter((sql) => sql.includes("UPDATE proposal_bonds")),
+    ).toHaveLength(2);
+  });
+});
+
+describe("signal-anchor event indexing", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (pool.query as jest.Mock).mockResolvedValue({ rows: [] });
+  });
+
+  it("persists and broadcasts ResultAnchored events", async () => {
+    const resultHash = Buffer.from("cd".repeat(32), "hex");
+    const anchorer = "GANCHORER";
+    const server = {
+      getEvents: jest.fn().mockResolvedValue({
+        events: [
+          makeEvent(
+            20,
+            SIGNAL_ANCHOR_ADDRESS,
+            "ResultAnchored",
+            [7n, resultHash, 19],
+            [anchorer],
+          ),
+        ],
+      }),
+    } as unknown as SorobanRpc.Server;
+
+    const latest = await processEvents(
+      server,
+      {
+        rpcUrl: "http://fake",
+        governorAddress: GOVERNOR_ADDRESS,
+        signalAnchorAddress: SIGNAL_ANCHOR_ADDRESS,
+        pollIntervalMs: 1,
+      },
+      20,
+    );
+
+    expect(latest).toBe(20);
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO signal_anchors"),
+      ["7", "cd".repeat(32), 19, anchorer, "tx-20"],
+    );
+    expect(invalidatePattern).toHaveBeenCalledWith("signal-anchors:");
+    expect(broadcast).toHaveBeenCalledWith({
+      type: "result_anchored",
+      data: {
+        poll_id: "7",
+        result_hash: "cd".repeat(32),
+        anchored_ledger: 19,
+        anchorer,
+      },
+    });
+  });
+});
+
+describe("optimistic-governor event indexing", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (pool.query as jest.Mock).mockResolvedValue({ rows: [] });
+  });
+
+  it("routes the optimistic governance lifecycle event surface", async () => {
+    const proposalId = 42n;
+    const events = [
+      makeEvent(
+        30,
+        OPTIMISTIC_GOVERNOR_ADDRESS,
+        "ProposalCreated",
+        ["GPROPOSER", 1000n],
+        [proposalId],
+      ),
+      makeEvent(
+        31,
+        OPTIMISTIC_GOVERNOR_ADDRESS,
+        "ObjectionCast",
+        ["GOBJECTOR", 25n, 25n],
+        [proposalId],
+      ),
+      makeEvent(
+        32,
+        OPTIMISTIC_GOVERNOR_ADDRESS,
+        "ProposalObjected",
+        [],
+        [proposalId],
+      ),
+      makeEvent(
+        33,
+        OPTIMISTIC_GOVERNOR_ADDRESS,
+        "ProposalPassed",
+        [],
+        [proposalId],
+      ),
+      makeEvent(
+        34,
+        OPTIMISTIC_GOVERNOR_ADDRESS,
+        "ProposalExecuted",
+        [],
+        [proposalId],
+      ),
+      makeEvent(
+        35,
+        OPTIMISTIC_GOVERNOR_ADDRESS,
+        "ProposalCancelled",
+        [],
+        [proposalId],
+      ),
+    ];
+    const server = {
+      getEvents: jest.fn().mockResolvedValue({ events }),
+    } as unknown as SorobanRpc.Server;
+
+    const latest = await processEvents(
+      server,
+      {
+        rpcUrl: "http://fake",
+        governorAddress: GOVERNOR_ADDRESS,
+        optimisticGovernorAddress: OPTIMISTIC_GOVERNOR_ADDRESS,
+        pollIntervalMs: 1,
+      },
+      30,
+    );
+
+    expect(latest).toBe(35);
+    expect((broadcast as jest.Mock).mock.calls.map(([event]) => event.type)).toEqual([
+      "optimistic_proposal_created",
+      "optimistic_objection_cast",
+      "optimistic_proposal_objected",
+      "optimistic_proposal_passed",
+      "optimistic_proposal_executed",
+      "optimistic_proposal_cancelled",
+    ]);
+    expect(invalidatePattern).toHaveBeenCalledTimes(6);
+    expect(invalidatePattern).toHaveBeenCalledWith("optimistic:");
+
+    const queries = (pool.query as jest.Mock).mock.calls.map(([sql]) =>
+      String(sql),
+    );
+    expect(
+      queries.some((sql) => sql.includes("INSERT INTO optimistic_proposals")),
+    ).toBe(true);
+    expect(
+      queries.some((sql) => sql.includes("INSERT INTO optimistic_objections")),
+    ).toBe(true);
+    expect(
+      queries.filter((sql) => sql.includes("UPDATE optimistic_proposals")),
+    ).toHaveLength(5);
+  });
+});

--- a/packages/indexer/src/events.ts
+++ b/packages/indexer/src/events.ts
@@ -1760,7 +1760,7 @@ function toGovernorSettings(value: unknown): GovernorSettings | null {
 
 // --- Liquidity event stubs (pre-existing references) ---
 
-async function handleLiquidityAdded(
+async function legacyHandleLiquidityAdded(
   event: SorobanRpc.Api.EventResponse,
   topics: unknown[],
 ): Promise<void> {
@@ -1770,7 +1770,7 @@ async function handleLiquidityAdded(
   broadcast({ type: "liquidity_added", data: { account, amount, ledger: event.ledger } });
 }
 
-async function handleLiquidityRemoved(
+async function legacyHandleLiquidityRemoved(
   event: SorobanRpc.Api.EventResponse,
   topics: unknown[],
 ): Promise<void> {
@@ -1780,7 +1780,7 @@ async function handleLiquidityRemoved(
   broadcast({ type: "liquidity_removed", data: { account, amount, ledger: event.ledger } });
 }
 
-async function handleSwap(
+async function legacyHandleSwap(
   event: SorobanRpc.Api.EventResponse,
   topics: unknown[],
 ): Promise<void> {
@@ -1788,14 +1788,14 @@ async function handleSwap(
   broadcast({ type: "swap", data: { trader, ledger: event.ledger } });
 }
 
-async function handlePoolFeeUpdated(
+async function legacyHandlePoolFeeUpdated(
   event: SorobanRpc.Api.EventResponse,
   _topics: unknown[],
 ): Promise<void> {
   broadcast({ type: "pool_fee_updated", data: { ledger: event.ledger } });
 }
 
-export async function maybeTakeGovernanceSnapshot(_ledger: number): Promise<void> {
+async function legacyMaybeTakeGovernanceSnapshot(_ledger: number): Promise<void> {
   // Placeholder — governance snapshot logic not yet implemented.
 }
 
@@ -1817,7 +1817,7 @@ async function logTimelockEvent(
   // are handled by each dedicated handler.
 }
 
-async function handleTimelockOperationScheduled(
+async function legacyHandleTimelockOperationScheduled(
   event: SorobanRpc.Api.EventResponse,
   _topics: unknown[],
 ): Promise<void> {
@@ -1840,7 +1840,7 @@ async function handleTimelockOperationScheduled(
   });
 }
 
-async function handleTimelockOperationExecuted(
+async function legacyHandleTimelockOperationExecuted(
   event: SorobanRpc.Api.EventResponse,
   _topics: unknown[],
 ): Promise<void> {
@@ -1859,7 +1859,7 @@ async function handleTimelockOperationExecuted(
   });
 }
 
-async function handleTimelockOperationCancelled(
+async function legacyHandleTimelockOperationCancelled(
   event: SorobanRpc.Api.EventResponse,
   _topics: unknown[],
 ): Promise<void> {
@@ -1878,7 +1878,7 @@ async function handleTimelockOperationCancelled(
   });
 }
 
-async function handleTimelockBatchOperationScheduled(
+async function legacyHandleTimelockBatchOperationScheduled(
   event: SorobanRpc.Api.EventResponse,
   _topics: unknown[],
 ): Promise<void> {
@@ -1904,7 +1904,7 @@ async function handleTimelockBatchOperationScheduled(
   });
 }
 
-async function handleTimelockBatchOperationExecuted(
+async function legacyHandleTimelockBatchOperationExecuted(
   event: SorobanRpc.Api.EventResponse,
   _topics: unknown[],
 ): Promise<void> {
@@ -1923,7 +1923,7 @@ async function handleTimelockBatchOperationExecuted(
   });
 }
 
-async function handleTimelockBatchOperationCancelled(
+async function legacyHandleTimelockBatchOperationCancelled(
   event: SorobanRpc.Api.EventResponse,
   _topics: unknown[],
 ): Promise<void> {
@@ -1942,7 +1942,7 @@ async function handleTimelockBatchOperationCancelled(
   });
 }
 
-async function handleTimelockMinDelayUpdated(
+async function legacyHandleTimelockMinDelayUpdated(
   event: SorobanRpc.Api.EventResponse,
   _topics: unknown[],
 ): Promise<void> {
@@ -1957,7 +1957,7 @@ async function handleTimelockMinDelayUpdated(
   });
 }
 
-async function handleTimelockDependencyDagValidated(
+async function legacyHandleTimelockDependencyDagValidated(
   event: SorobanRpc.Api.EventResponse,
   _topics: unknown[],
 ): Promise<void> {
@@ -1978,7 +1978,7 @@ async function handleTimelockDependencyDagValidated(
   });
 }
 
-async function handleTimelockCycleDetected(
+async function legacyHandleTimelockCycleDetected(
   event: SorobanRpc.Api.EventResponse,
   _topics: unknown[],
 ): Promise<void> {
@@ -1998,7 +1998,7 @@ async function handleTimelockCycleDetected(
   });
 }
 
-async function handleTimelockPartialBatchStarted(
+async function legacyHandleTimelockPartialBatchStarted(
   event: SorobanRpc.Api.EventResponse,
   _topics: unknown[],
 ): Promise<void> {
@@ -2019,7 +2019,7 @@ async function handleTimelockPartialBatchStarted(
   });
 }
 
-async function handleTimelockPartialOpSucceeded(
+async function legacyHandleTimelockPartialOpSucceeded(
   event: SorobanRpc.Api.EventResponse,
   _topics: unknown[],
 ): Promise<void> {
@@ -2044,7 +2044,7 @@ async function handleTimelockPartialOpSucceeded(
   });
 }
 
-async function handleTimelockPartialOpFailed(
+async function legacyHandleTimelockPartialOpFailed(
   event: SorobanRpc.Api.EventResponse,
   _topics: unknown[],
 ): Promise<void> {
@@ -2065,7 +2065,7 @@ async function handleTimelockPartialOpFailed(
   });
 }
 
-async function handleTimelockBatchRecoveryEntered(
+async function legacyHandleTimelockBatchRecoveryEntered(
   event: SorobanRpc.Api.EventResponse,
   _topics: unknown[],
 ): Promise<void> {
@@ -2088,7 +2088,7 @@ async function handleTimelockBatchRecoveryEntered(
   });
 }
 
-async function handleTimelockFailedOpRetried(
+async function legacyHandleTimelockFailedOpRetried(
   event: SorobanRpc.Api.EventResponse,
   _topics: unknown[],
 ): Promise<void> {
@@ -2107,7 +2107,7 @@ async function handleTimelockFailedOpRetried(
   });
 }
 
-async function handleTimelockFailedOpSkipped(
+async function legacyHandleTimelockFailedOpSkipped(
   event: SorobanRpc.Api.EventResponse,
   _topics: unknown[],
 ): Promise<void> {
@@ -2122,7 +2122,7 @@ async function handleTimelockFailedOpSkipped(
   });
 }
 
-async function handleTimelockBatchFullyComplete(
+async function legacyHandleTimelockBatchFullyComplete(
   event: SorobanRpc.Api.EventResponse,
   _topics: unknown[],
 ): Promise<void> {

--- a/packages/indexer/src/ws.ts
+++ b/packages/indexer/src/ws.ts
@@ -31,6 +31,8 @@ export type WsEventType =
   | "delegated_by_sig"
   | "permits_invalidated"
   | "relayer_whitelist_updated"
+  | "split_delegated"
+  | "split_undelegated"
   | "timelock_operation_scheduled"
   | "timelock_operation_executed"
   | "timelock_operation_cancelled"
@@ -68,7 +70,13 @@ export type WsEventType =
   | "optimistic_proposal_objected"
   | "optimistic_proposal_passed"
   | "optimistic_proposal_executed"
-  | "optimistic_proposal_cancelled";
+  | "optimistic_proposal_cancelled"
+  | "result_anchored"
+  | "strategy_registered"
+  | "strategy_deactivated"
+  | "strategy_deposited"
+  | "strategy_withdrawal_requested"
+  | "strategy_withdrawal_claimed";
 
 export interface WsEvent {
   type: WsEventType;

--- a/sdk/src/__tests__/treasuryStrategies.test.ts
+++ b/sdk/src/__tests__/treasuryStrategies.test.ts
@@ -1,0 +1,135 @@
+import { StrKey } from "@stellar/stellar-sdk";
+import { TreasuryStrategiesClient } from "../treasuryStrategies";
+import {
+  TreasuryStrategiesError,
+  TreasuryStrategiesErrorCode,
+} from "../errors";
+
+describe("TreasuryStrategiesClient", () => {
+  const contractAddress = StrKey.encodeContract(Buffer.alloc(32, 1));
+  const baseConfig = {
+    governorAddress: contractAddress,
+    timelockAddress: contractAddress,
+    votesAddress: contractAddress,
+    treasuryStrategiesAddress: contractAddress,
+    network: "testnet" as const,
+    maxAttempts: 1,
+  };
+
+  const originalFetch = global.fetch;
+  let mockFetch: jest.Mock;
+
+  beforeEach(() => {
+    mockFetch = jest.fn();
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("requires a treasuryStrategiesAddress", () => {
+    expect(
+      () =>
+        new TreasuryStrategiesClient({
+          ...baseConfig,
+          treasuryStrategiesAddress: undefined,
+        }),
+    ).toThrow(
+      expect.objectContaining({
+        name: "TreasuryStrategiesError",
+        code: TreasuryStrategiesErrorCode.SimulationFailed,
+      }),
+    );
+  });
+
+  it("listStrategies maps indexed rows and clamps pagination options", async () => {
+    const client = new TreasuryStrategiesClient({
+      ...baseConfig,
+      indexerUrl: "https://indexer.example.com",
+    });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        strategies: [
+          {
+            strategy_id: "7",
+            adapter: "CADAPTER",
+            token: "CTOKEN",
+            active: true,
+            current_allocation: "2500",
+            registered_ledger: 123,
+          },
+        ],
+      }),
+    });
+
+    const strategies = await client.listStrategies({
+      token: "CTOKEN",
+      active: true,
+      limit: 500,
+      offset: -10,
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://indexer.example.com/treasury-strategies?limit=100&offset=0&token=CTOKEN&active=true",
+    );
+    expect(strategies).toEqual([
+      {
+        strategyId: 7,
+        adapter: "CADAPTER",
+        token: "CTOKEN",
+        active: true,
+        currentAllocation: 2500n,
+        registeredLedger: 123,
+      },
+    ]);
+  });
+
+  it("getPerformanceHistoryPage maps rows and preserves pagination metadata", async () => {
+    const client = new TreasuryStrategiesClient({
+      ...baseConfig,
+      indexerUrl: "https://indexer.example.com",
+    });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        principal_history: [
+          {
+            amount: "1000",
+            ledger: 200,
+            created_at: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+        pagination: { limit: 25, offset: 50, hasMore: true },
+      }),
+    });
+
+    const page = await client.getPerformanceHistoryPage(7, 25, 50);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://indexer.example.com/treasury-strategies/7/performance?limit=25&offset=50",
+    );
+    expect(page).toEqual({
+      history: [
+        {
+          amount: 1000n,
+          ledger: 200,
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      pagination: { limit: 25, offset: 50, hasMore: true },
+    });
+  });
+
+  it("throws a typed error when indexer-backed methods lack indexerUrl", async () => {
+    const client = new TreasuryStrategiesClient(baseConfig);
+
+    await expect(client.listStrategies()).rejects.toBeInstanceOf(
+      TreasuryStrategiesError,
+    );
+    await expect(client.listStrategies()).rejects.toMatchObject({
+      code: TreasuryStrategiesErrorCode.SimulationFailed,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add indexer coverage for proposal-bonds, signal-anchor, and optimistic-governor event routing/side effects
- add TreasuryStrategiesClient SDK tests for required config, indexer mapping, pagination, and missing indexerUrl errors
- repair existing indexer TypeScript compile blockers by moving legacy duplicate stubs out of the active handler namespace and adding missing websocket event literals

## Testing
- pnpm --filter @nebgov/indexer run test -- timelock-events.test.ts proposal-signal-optimistic-events.test.ts --runInBand
- pnpm --filter @nebgov/sdk run test -- treasuryStrategies.test.ts --runInBand
- git diff --check

Closes #1050
Closes #1052
Closes #1053
Closes #1054