### PR TITLE
docs: document split delegation and treasury yield strategies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,9 +96,10 @@ reason = "Suppressed: [reason] — [date] — [author]"
 | ---------------------------- | --------------------------------------- |
 | `contracts/governor`         | Core governance contract (Rust/Soroban) |
 | `contracts/timelock`         | Delayed execution controller            |
-| `contracts/token-votes`      | Voting power with checkpointing         |
+| `contracts/token-votes`      | Voting power with checkpointing, including split delegation ([docs](./docs/split-delegation.md)) |
 | `contracts/governor-factory` | Permissionless governor deployer        |
 | `contracts/treasury`         | Multi-sig treasury                      |
+| `contracts/treasury-strategies` | Governance-controlled yield strategy allocation ([docs](./docs/treasury-strategies.md)) |
 | `sdk/`                       | TypeScript SDK (`@nebgov/sdk`)          |
 | `app/`                       | Next.js governance dashboard            |
 | `docs/`                      | Architecture docs and ADRs              |

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ NebGov is the canonical governance framework for the Stellar ecosystem — a mod
 | Proposal lifecycle     | Create, vote, queue, and execute on-chain proposals |
 | Timelock execution     | Mandatory delay between passing and execution       |
 | Token-weighted voting  | Snapshot voting power from any SEP-41 token         |
-| Delegation             | Delegate voting power to any address                |
+| Delegation             | Delegate voting power to any address, in full or split by percentage ([docs](./docs/split-delegation.md)) |
 | Multi-sig treasury     | DAO-controlled treasury with configurable threshold |
+| Treasury yield strategies | Governance-controlled allocation of idle treasury funds to whitelisted yield adapters ([docs](./docs/treasury-strategies.md)) |
 | Permissionless factory | Deploy your own governance instance in one call     |
 
 ---
@@ -33,6 +34,7 @@ NebGov is the canonical governance framework for the Stellar ecosystem — a mod
 | `contracts/token-votes`      | Voting power with checkpointing (Rust/Soroban)  |
 | `contracts/governor-factory` | Permissionless governor deployer (Rust/Soroban) |
 | `contracts/treasury`         | Multi-sig treasury (Rust/Soroban)               |
+| `contracts/treasury-strategies` | Governance-controlled yield strategy allocation for treasury funds (Rust/Soroban) |
 | `sdk/`                       | TypeScript SDK (`@nebgov/sdk`)                  |
 | `app/`                       | Next.js governance dashboard                    |
 

--- a/docs/split-delegation.md
+++ b/docs/split-delegation.md
@@ -1,0 +1,47 @@
+# Split Delegation
+
+`contracts/token-votes/src/split_delegation.rs` lets a token holder delegate
+arbitrary basis-point percentages of their voting power across multiple
+delegatees at once, instead of the legacy single-target `delegate()`. It's
+exposed on the frontend delegates page via `SplitDelegationEditor`.
+
+## Entrypoints
+
+| Function                                       | Description                                                            |
+| ----------------------------------------------- | ------------------------------------------------------------------------ |
+| `delegate_split(delegator, splits)`              | Replaces the delegator's entire distribution with `splits`.             |
+| `undelegate_split(delegator)`                    | Clears any split/legacy distribution and reverts to self-delegation.    |
+| `get_split_delegations(delegator) -> Vec<SplitDelegation>` | Reads the current distribution, legacy or split (see below).  |
+
+Each `SplitDelegation { delegatee, weight_bps }` entry's `weight_bps` is out
+of `10_000` (basis points). A `delegate_split` call is rejected
+(`TokenVotesError`) if:
+
+- the split list is empty, or has more entries than the governance-settable
+  `MaxSplitTargets` cap (default `10`)
+- any entry has `weight_bps == 0`
+- any delegatee appears more than once
+- the weights don't sum to exactly `10_000`
+
+The delegator's token balance is split across entries proportionally to
+`weight_bps`, with integer-division rounding remainder credited to the last
+entry so the parts always sum exactly to the balance.
+
+## Interop with legacy `delegate()`
+
+Split delegation is additive, not a replacement — `delegate()` /
+`undelegate()` keep working unchanged for any account that never calls a
+`*_split` entrypoint. The two are unified on both sides:
+
+- **Write side**: a `delegate_split` call with a single 100%-weight entry
+  collapses into the same storage key `delegate()` uses, rather than a
+  separate split record. So an account that only ever submits one-entry
+  splits stays fully compatible with `delegate()`/`undelegate()` and with
+  `delegation_registry`'s chain resolution.
+- **Read side**: `get_split_delegations` falls back to the legacy `Delegate`
+  mapping when no split record exists, returning it as a single 100%-weight
+  entry.
+
+This compatibility is one-directional: once a delegator has a genuine
+multi-entry split on file, falling back to the plain `delegate()` entrypoint
+is out of scope — call `undelegate_split` first.

--- a/docs/treasury-strategies.md
+++ b/docs/treasury-strategies.md
@@ -1,0 +1,63 @@
+# Treasury Yield Strategies
+
+`contracts/treasury-strategies` is a governance-controlled allocation layer
+that lets idle funds held by `contracts/treasury` earn yield through
+whitelisted external protocols, instead of sitting unused.
+
+The contract never custodies funds on its own authority: the treasury
+multisig moves tokens in via `deposit`, and every withdrawal ultimately
+settles back to that same treasury address.
+
+## Adapter model
+
+Yield sources are integrated behind a minimal trait so any external protocol
+can be whitelisted without changing this contract:
+
+```rust
+trait StrategyAdapterTrait {
+    fn adapter_deposit(env: Env, caller: Address, token: Address, amount: i128);
+    fn adapter_withdraw(env: Env, caller: Address, token: Address, amount: i128) -> i128;
+    fn adapter_balance(env: Env, token: Address) -> i128;
+}
+```
+
+`contracts/treasury-strategies/src/adapters/mock_adapter.rs` ships a simple
+fixed-APY simulated adapter used by tests and the simulation harness; a real
+integration implements the same trait against a live protocol.
+
+Each registered `Strategy` records:
+
+- `adapter` — the whitelisted adapter contract address
+- `token` — the asset it accepts
+- `max_allocation_bps` — allocation cap (see below)
+- `withdrawal_cooldown_ledgers` — delay before a requested withdrawal is claimable
+- `active` — whether new deposits can route to it
+
+## Governance controls
+
+Access is split by role:
+
+| Action                              | Caller                          |
+| ------------------------------------ | -------------------------------- |
+| `register_strategy` / `deactivate_strategy` | admin only                 |
+| `deposit` / `request_withdrawal`     | treasury only                    |
+| `claim_withdrawal`                   | permissionless, after cooldown   |
+
+**Allocation caps.** Each strategy has a `max_allocation_bps` (out of
+`10_000`) capping how much of a token's total deposited value it may hold.
+`deposit` routes new funds to the active strategy with the lowest current
+allocation for that token, and rejects the deposit
+(`AllocationCapExceeded`) if it would push that strategy's allocation above
+`max_allocation_bps * total_deposited / 10_000`.
+
+**Withdrawal cooldowns.** `request_withdrawal` (treasury-only) reserves an
+amount from a strategy's allocation and records a `claimable_ledger` equal to
+the current ledger plus that strategy's `withdrawal_cooldown_ledgers`.
+`claim_withdrawal` is permissionless but reverts with
+`WithdrawalNotYetClaimable` until that ledger is reached, and
+`WithdrawalAlreadyClaimed` if already claimed — funds actually leave the
+adapter and land back at the treasury only at claim time.
+
+Deactivating a strategy (`deactivate_strategy`) stops it from receiving new
+deposits but does not withdraw existing funds; outstanding allocations still
+go through the normal request/claim flow.


### PR DESCRIPTION
Adds docs/split-delegation.md covering the split_delegation basis-point model and its interop with the legacy delegate() entrypoint, and docs/treasury-strategies.md covering the strategy adapter trait, allocation caps, and withdrawal cooldowns. Links both from the README feature/package tables and CONTRIBUTING's project structure table.
- Documents the governance-tuning recommender's formula, config bounds, and
  auto-propose cooldown safety mechanism in README/CONTRIBUTING/docs/
- Adds sdk/src/__tests__/optimisticGovernor.test.ts covering request
  construction and response parsing for OptimisticGovernorClient's
  propose/object/finalize/execute/cancel and indexer-backed queries



Closes #1044
Closes #1045
Closes #1046
Closes #1048