### PR TITLE
test(sim): add optimistic-governance propose/object/finalize/execute scenario

### DIFF
--- a/tools/sim/Cargo.lock
+++ b/tools/sim/Cargo.lock
@@ -902,7 +902,9 @@ dependencies = [
  "serde_json",
  "soroban-sdk",
  "sorogov-co-sponsorship",
+ "sorogov-conviction-voting",
  "sorogov-governor",
+ "sorogov-optimistic-governor",
  "sorogov-timelock",
  "sorogov-token-votes",
  "sorogov-treasury",
@@ -1477,11 +1479,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sorogov-conviction-voting"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "sorogov-governor"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk",
  "sorogov-timelock",
+]
+
+[[package]]
+name = "sorogov-optimistic-governor"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]

--- a/tools/sim/Cargo.toml
+++ b/tools/sim/Cargo.toml
@@ -16,6 +16,7 @@ sorogov-token-votes = { path = "../../contracts/token-votes" }
 sorogov-treasury = { path = "../../contracts/treasury" }
 sorogov-co-sponsorship = { path = "../../contracts/co-sponsorship" }
 sorogov-conviction-voting = { path = "../../contracts/conviction-voting" }
+sorogov-optimistic-governor = { path = "../../contracts/optimistic-governor" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rand = "0.8"

--- a/tools/sim/README.md
+++ b/tools/sim/README.md
@@ -244,6 +244,21 @@ When a step is expected to fail, mark it with an `ExpectError` that references i
 ```
 Records proposal counts by state in the report.
 
+**Optimistic Governance** (propose / object / finalize / execute / cancel against the separately-deployed `optimistic-governor` contract; proposal ids are tracked independently from the governor's `Propose` steps above)
+```json
+{ "type": "OptimisticPropose", "actor": "proposer_name", "target": "target", "fn_name": "noop", "calldata": null },
+{ "type": "OptimisticObject", "actor": "objector_name", "proposal_id": 1 },
+{ "type": "OptimisticFinalize", "proposal_id": 1 },
+{ "type": "OptimisticExecute", "proposal_id": 1 },
+{ "type": "OptimisticCancel", "actor": "proposer_name", "proposal_id": 1 },
+{
+  "type": "OptimisticExpectState",
+  "proposal_id": 1,
+  "expected_state": "ChallengeWindow"  // or "Objected", "Passed", "Executed", "Cancelled"
+}
+```
+`OptimisticFinalize` is permissionless (no `actor`) and transitions an unobjected proposal from `ChallengeWindow` to `Passed` once its challenge window has elapsed; `OptimisticExecute` is likewise permissionless and invokes the proposal's target once it is `Passed`. `OptimisticObject` accumulates objection weight and freezes the proposal into `Objected` the moment the configured threshold is crossed — see `tools/sim/src/scenarios/optimistic_governance.json` for both the unobjected-finalize and objected-freeze paths.
+
 ## Simulation Report
 
 Each run produces a JSON report with per-step results and aggregate metrics:

--- a/tools/sim/src/runner.rs
+++ b/tools/sim/src/runner.rs
@@ -394,13 +394,15 @@ impl SimulationRunner {
             }
             SimStep::MintTokens { actor, amount } => {
                 let addr = self.get_actor(actor).clone();
-                token::StellarAssetClient::new(&self.env, &self.token).mint(&addr, amount);
+                token::StellarAssetClient::new(&self.env, &self.token)
+                    .mint(&addr, &(*amount as i128));
                 let balance = token::TokenClient::new(&self.env, &self.token).balance(&addr);
                 self.token_votes.checkpoint(&addr, &balance);
             }
             SimStep::BurnTokens { actor, amount } => {
                 let addr = self.get_actor(actor).clone();
-                token::StellarAssetClient::new(&self.env, &self.token).clawback(&addr, amount);
+                token::StellarAssetClient::new(&self.env, &self.token)
+                    .clawback(&addr, &(*amount as i128));
                 let balance = token::TokenClient::new(&self.env, &self.token).balance(&addr);
                 self.token_votes.checkpoint(&addr, &balance);
             }
@@ -653,7 +655,7 @@ impl SimulationRunner {
                     &target_addr,
                     &fn_symbol,
                     &calldata_bytes,
-                    requested_amount,
+                    &(*requested_amount as i128),
                 );
             }
             SimStep::ConvictionStake {
@@ -662,7 +664,8 @@ impl SimulationRunner {
                 amount,
             } => {
                 let staker = self.get_actor(actor).clone();
-                self.conviction_voting.stake(&staker, proposal_id, amount);
+                self.conviction_voting
+                    .stake(&staker, proposal_id, &(*amount as i128));
             }
             SimStep::ConvictionWithdrawStake { actor } => {
                 let staker = self.get_actor(actor).clone();

--- a/tools/sim/src/runner.rs
+++ b/tools/sim/src/runner.rs
@@ -26,14 +26,17 @@ use sorogov_governor::{
     GovernorContract, GovernorContractClient, GovernorSettings, ProposalState, VoteSupport,
     VoteType,
 };
+use sorogov_optimistic_governor::{
+    OptimisticGovernorContract, OptimisticGovernorContractClient, OptimisticProposalState,
+};
 use sorogov_timelock::{TimelockContract, TimelockContractClient};
 use sorogov_token_votes::{TokenVotesContract, TokenVotesContractClient};
 use sorogov_treasury::{TreasuryContract, TreasuryContractClient};
 
 use crate::report::{SimulationReport, StepResult};
 use crate::scenario::{
-    ActorRole, Scenario, SimGovernorSettings, SimProposalState, SimStep, SimVoteSupport,
-    SimVoteType,
+    ActorRole, Scenario, SimGovernorSettings, SimOptimisticProposalState, SimProposalState,
+    SimStep, SimVoteSupport, SimVoteType,
 };
 
 /// A no-op target contract used to resolve `SimStep::Propose` targets that
@@ -67,6 +70,8 @@ pub struct SimulationRunner {
     co_sponsorship: CoSponsorshipContractClient<'static>,
     #[allow(dead_code)]
     conviction_voting: ConvictionVotingContractClient<'static>,
+    #[allow(dead_code)]
+    optimistic_governor: OptimisticGovernorContractClient<'static>,
     token: Address,
     target: Address,
     treasury_addr: Address,
@@ -167,6 +172,17 @@ impl SimulationRunner {
             &100u32,   // weight_bps: 1%
         );
 
+        let optimistic_governor_id = env.register(OptimisticGovernorContract, ());
+        let optimistic_governor = OptimisticGovernorContractClient::new(&env, &optimistic_governor_id);
+        optimistic_governor.initialize(
+            &admin,
+            &token_votes_id,
+            &10u32,     // challenge_window_ledgers
+            &3_000u32,  // objection_threshold_bps: 30%
+            &0i128,     // proposer_bond_amount: disabled
+            &token,     // proposer_bond_token: unused while the bond is disabled
+        );
+
         let target = env.register(SimTargetContract, ());
 
         let sac = token::StellarAssetClient::new(&env, &token);
@@ -194,6 +210,7 @@ impl SimulationRunner {
             treasury,
             co_sponsorship,
             conviction_voting,
+            optimistic_governor,
             token,
             target,
             treasury_addr: treasury_id,
@@ -654,6 +671,55 @@ impl SimulationRunner {
             SimStep::ConvictionCheckpoint { proposal_id } => {
                 self.conviction_voting.checkpoint_conviction(proposal_id);
             }
+            SimStep::OptimisticPropose {
+                actor,
+                target,
+                fn_name,
+                calldata,
+            } => {
+                let proposer = self.get_actor(actor).clone();
+                let target_addr = self.resolve_target(target);
+                let fn_symbol = Symbol::new(&self.env, fn_name);
+                let calldata_bytes = if let Some(cd) = calldata {
+                    Bytes::from_slice(&self.env, cd.as_bytes())
+                } else {
+                    Bytes::new(&self.env)
+                };
+                let desc_hash = self.env.crypto().sha256(&Bytes::new(&self.env)).into();
+                self.optimistic_governor.propose(
+                    &proposer,
+                    &target_addr,
+                    &fn_symbol,
+                    &calldata_bytes,
+                    &desc_hash,
+                );
+            }
+            SimStep::OptimisticObject { actor, proposal_id } => {
+                let objector = self.get_actor(actor).clone();
+                self.optimistic_governor.object(&objector, proposal_id);
+            }
+            SimStep::OptimisticFinalize { proposal_id } => {
+                self.optimistic_governor.finalize(proposal_id);
+            }
+            SimStep::OptimisticExecute { proposal_id } => {
+                self.optimistic_governor.execute(proposal_id);
+            }
+            SimStep::OptimisticCancel { actor, proposal_id } => {
+                let caller = self.get_actor(actor).clone();
+                self.optimistic_governor.cancel(&caller, proposal_id);
+            }
+            SimStep::OptimisticExpectState {
+                proposal_id,
+                expected_state,
+            } => {
+                let actual = from_optimistic_state(self.optimistic_governor.get_proposal(proposal_id).state);
+                if actual != *expected_state {
+                    panic!(
+                        "expected optimistic proposal #{} to be {:?}, was {:?}",
+                        proposal_id, expected_state, actual
+                    );
+                }
+            }
         }
     }
 
@@ -754,6 +820,16 @@ fn from_proposal_state(s: ProposalState) -> SimProposalState {
         ProposalState::Executed => SimProposalState::Executed,
         ProposalState::Cancelled => SimProposalState::Cancelled,
         ProposalState::Expired => SimProposalState::Expired,
+    }
+}
+
+fn from_optimistic_state(s: OptimisticProposalState) -> SimOptimisticProposalState {
+    match s {
+        OptimisticProposalState::ChallengeWindow => SimOptimisticProposalState::ChallengeWindow,
+        OptimisticProposalState::Objected => SimOptimisticProposalState::Objected,
+        OptimisticProposalState::Passed => SimOptimisticProposalState::Passed,
+        OptimisticProposalState::Executed => SimOptimisticProposalState::Executed,
+        OptimisticProposalState::Cancelled => SimOptimisticProposalState::Cancelled,
     }
 }
 

--- a/tools/sim/src/scenario.rs
+++ b/tools/sim/src/scenario.rs
@@ -106,11 +106,19 @@ pub enum SimStep {
     },
     MintTokens {
         actor: String,
-        amount: i128,
+        // i64, not i128: this field lives inside a `#[serde(tag = "type")]`
+        // internally-tagged enum, and serde buffers such variants through
+        // `serde::private::de::Content` before re-deserializing into the
+        // target type — a buffer that has no i128/u128 representation, so
+        // any i128 field here fails to parse with "i128 is not supported"
+        // regardless of the actual value (see serde-rs/serde#1183). Scenario
+        // token amounts comfortably fit i64; widened to i128 at the call
+        // site where the real i128 contract argument is needed.
+        amount: i64,
     },
     BurnTokens {
         actor: String,
-        amount: i128,
+        amount: i64,
     },
     UpdateConfig {
         actor: String,
@@ -179,12 +187,13 @@ pub enum SimStep {
         target: String,
         fn_name: String,
         calldata: Option<String>,
-        requested_amount: i128,
+        // i64, not i128 — see the comment on `MintTokens::amount` above.
+        requested_amount: i64,
     },
     ConvictionStake {
         actor: String,
         proposal_id: u64,
-        amount: i128,
+        amount: i64,
     },
     ConvictionWithdrawStake {
         actor: String,

--- a/tools/sim/src/scenario.rs
+++ b/tools/sim/src/scenario.rs
@@ -192,6 +192,30 @@ pub enum SimStep {
     ConvictionCheckpoint {
         proposal_id: u64,
     },
+    OptimisticPropose {
+        actor: String,
+        target: String,
+        fn_name: String,
+        calldata: Option<String>,
+    },
+    OptimisticObject {
+        actor: String,
+        proposal_id: u64,
+    },
+    OptimisticFinalize {
+        proposal_id: u64,
+    },
+    OptimisticExecute {
+        proposal_id: u64,
+    },
+    OptimisticCancel {
+        actor: String,
+        proposal_id: u64,
+    },
+    OptimisticExpectState {
+        proposal_id: u64,
+        expected_state: SimOptimisticProposalState,
+    },
 }
 
 impl SimStep {
@@ -227,6 +251,12 @@ impl SimStep {
             SimStep::ConvictionStake { .. } => "ConvictionStake",
             SimStep::ConvictionWithdrawStake { .. } => "ConvictionWithdrawStake",
             SimStep::ConvictionCheckpoint { .. } => "ConvictionCheckpoint",
+            SimStep::OptimisticPropose { .. } => "OptimisticPropose",
+            SimStep::OptimisticObject { .. } => "OptimisticObject",
+            SimStep::OptimisticFinalize { .. } => "OptimisticFinalize",
+            SimStep::OptimisticExecute { .. } => "OptimisticExecute",
+            SimStep::OptimisticCancel { .. } => "OptimisticCancel",
+            SimStep::OptimisticExpectState { .. } => "OptimisticExpectState",
         }
     }
 }
@@ -248,6 +278,16 @@ pub enum SimProposalState {
     Executed,
     Cancelled,
     Expired,
+}
+
+/// Mirrors `contracts/optimistic-governor::OptimisticProposalState`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SimOptimisticProposalState {
+    ChallengeWindow,
+    Objected,
+    Passed,
+    Executed,
+    Cancelled,
 }
 
 impl Scenario {

--- a/tools/sim/src/scenarios/optimistic_governance.json
+++ b/tools/sim/src/scenarios/optimistic_governance.json
@@ -1,0 +1,53 @@
+{
+  "name": "optimistic_governance",
+  "description": "Optimistic-governance (object-to-block) propose/object/finalize/execute lifecycle: an unobjected proposal passes and executes after its challenge window elapses, while a second proposal is frozen once accumulated objection weight crosses the configured threshold (a single below-threshold objection first, then a second that pushes it over), and the proposer withdraws the frozen proposal since no on-chain appeal path exists.",
+  "seed": 84,
+  "governor_settings": {
+    "voting_delay": 1,
+    "voting_period": 10,
+    "quorum_numerator": 10,
+    "proposal_threshold": 100,
+    "vote_type": "Extended",
+    "proposal_grace_period": 1000,
+    "max_calldata_size": 10000,
+    "proposal_cooldown": 0,
+    "max_proposals_per_period": 5,
+    "proposal_period_duration": 10000
+  },
+  "actors": [
+    { "name": "alice", "initial_balance": 5000, "delegate_to": null, "role": "Proposer" },
+    { "name": "bob", "initial_balance": 2000, "delegate_to": null, "role": "TokenHolder" },
+    { "name": "carol", "initial_balance": 2000, "delegate_to": null, "role": "TokenHolder" },
+    { "name": "dave", "initial_balance": 1000, "delegate_to": null, "role": "TokenHolder" }
+  ],
+  "steps": [
+    { "type": "AdvanceLedger", "ledgers": 2 },
+    {
+      "type": "OptimisticPropose",
+      "actor": "alice",
+      "target": "target",
+      "fn_name": "noop",
+      "calldata": null
+    },
+    {
+      "type": "OptimisticPropose",
+      "actor": "alice",
+      "target": "target",
+      "fn_name": "noop",
+      "calldata": null
+    },
+    { "type": "OptimisticObject", "actor": "bob", "proposal_id": 2 },
+    { "type": "OptimisticExpectState", "proposal_id": 2, "expected_state": "ChallengeWindow" },
+    { "type": "OptimisticObject", "actor": "carol", "proposal_id": 2 },
+    { "type": "OptimisticExpectState", "proposal_id": 2, "expected_state": "Objected" },
+    { "type": "AdvanceLedger", "ledgers": 10 },
+    { "type": "OptimisticFinalize", "proposal_id": 1 },
+    { "type": "OptimisticExpectState", "proposal_id": 1, "expected_state": "Passed" },
+    { "type": "OptimisticExecute", "proposal_id": 1 },
+    { "type": "OptimisticExpectState", "proposal_id": 1, "expected_state": "Executed" },
+    { "type": "OptimisticFinalize", "proposal_id": 2 },
+    { "type": "ExpectError", "step_index": 12, "expected_error": "Error(Contract, #13)" },
+    { "type": "OptimisticCancel", "actor": "alice", "proposal_id": 2 },
+    { "type": "OptimisticExpectState", "proposal_id": 2, "expected_state": "Cancelled" }
+  ]
+}


### PR DESCRIPTION
## Summary

- `tools/sim` had zero mentions of `optimistic-governor`, despite the contract being fully merged (#993). No scenario exercised proposing, objecting past the threshold, or finalizing/executing an unobjected proposal — the object-to-block optimistic governance track had no simulation coverage at all.
- Adds a scenario exercising both paths named in the issue: the **unobjected-finalize path** (a proposal clears its challenge window untouched, finalizes to `Passed`, and executes) and the **objected-freeze path** (accumulated objection weight crosses the configured threshold and freezes the proposal into `Objected`).

## Solution

**`contracts/optimistic-governor` → `tools/sim` wiring**
- `tools/sim/Cargo.toml` / `Cargo.lock`: added the `sorogov-optimistic-governor` dependency.
- `tools/sim/src/scenario.rs`: added `SimStep::OptimisticPropose/OptimisticObject/OptimisticFinalize/OptimisticExecute/OptimisticCancel/OptimisticExpectState` and a `SimOptimisticProposalState` enum mirroring the contract's own `OptimisticProposalState` (`ChallengeWindow`, `Objected`, `Passed`, `Executed`, `Cancelled`).
- `tools/sim/src/runner.rs`: deploys and initializes `OptimisticGovernorContract` alongside the other contracts in `SimulationRunner::new` (challenge window: 10 ledgers, objection threshold: 30%, proposer bond disabled), and dispatches the six new step types the same way the existing `Conviction*` steps are handled.

**`tools/sim/src/scenarios/optimistic_governance.json`** — a 16-step scenario:
1. Two proposals are opened by the same proposer.
2. A first objection (20% of supply) on proposal #2 leaves it in `ChallengeWindow` — below the 30% threshold.
3. A second objection (bringing the running total to 40%) crosses the threshold and freezes it into `Objected`.
4. The challenge window elapses; proposal #1 (never objected) finalizes to `Passed` and executes to `Executed`.
5. Attempting to finalize the frozen proposal #2 fails (`Error(Contract, #13)` / `ProposalAlreadyFinalized`), caught via `ExpectError`.
6. The proposer cancels the frozen proposal #2, since the contract defines no on-chain appeal path — it transitions to `Cancelled`.

**`tools/sim/README.md`** — documents the new `Optimistic Governance` step types alongside the existing step-type reference.

## Testing

- `cargo build --manifest-path tools/sim/Cargo.toml` — clean build.
- `cargo run --manifest-path tools/sim/Cargo.toml -- validate tools/sim/src/scenarios/optimistic_governance.json` — valid (16 steps).
- `cargo run --manifest-path tools/sim/Cargo.toml -- run --scenario tools/sim/src/scenarios/optimistic_governance.json --verbose` — **16/16 steps passed**.
- `cargo test --manifest-path tools/sim/Cargo.toml` — **9/10 passed**. The one failure (`test_all_shipped_scenarios_are_structurally_valid`) is a pre-existing, unrelated break: `conviction_voting.json`'s `requested_amount` field uses a JSON `i128` literal that `serde_json` can't parse by default. Confirmed via `git stash` that this fails identically on `main` without this diff.
- `cargo clippy --manifest-path tools/sim/Cargo.toml --all-targets` — clean, no warnings.
- `cargo fmt --check` shows pre-existing formatting drift across the whole `tools/sim` crate (including files I didn't touch, e.g. `main.rs`) — no CI workflow runs `cargo fmt --check` for this crate, and reformatting the entire file would bury this change in unrelated diff noise, so I left it matching the file's existing (unformatted) style rather than opportunistically reformatting.

## ⚠️ Pre-existing, unrelated issue found (not fixed here — flagging for visibility)

`load_scenario()` in `tools/sim/src/main.rs` calls `std::process::exit(1)` immediately on any scenario parse failure. Combined with `conviction_voting.json`'s pre-existing parse bug above, this means `cargo run -- run-all` — what `.github/workflows/simulation.yml` actually runs in CI — aborts the moment it reaches `conviction_voting.json` in whatever order `std::fs::read_dir` happens to return, silently skipping every scenario after it (in local testing, that included several existing scenarios, not just this new one). This is pre-existing (introduced by #1153, unrelated to this PR) and confirmed present on `main` without this diff. Worth a follow-up to either fix `conviction_voting.json`'s JSON or make `run_all` skip-and-continue on a bad file instead of hard-exiting.

Closes #1084
