### PR TITLE
feat: stellar-wave contributions across CLI, deployment, sim, and documentation

### DIFF
--- a/backend/src/openapi.ts
+++ b/backend/src/openapi.ts
@@ -1,6 +1,151 @@
 import { OpenAPIRegistry, OpenApiGeneratorV3 } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
 
 export const registry = new OpenAPIRegistry();
+
+// Signaling route schemas
+const createPollSchema = z.object({
+  creatorAddress: z.string().regex(/^G[A-Z2-7]{55}$/, "invalid creator address"),
+  title: z.string().trim().min(1).max(200),
+  description: z.string().trim().min(1),
+  choices: z.array(z.string().trim().min(1).max(100)).min(2).max(10),
+  snapshotLedger: z.coerce.number().int().positive(),
+  startTime: z.coerce.date(),
+  endTime: z.coerce.date(),
+});
+
+const pollResponseSchema = z.object({
+  id: z.number().int().min(1),
+  creatorAddress: z.string(),
+  title: z.string(),
+  description: z.string(),
+  choices: z.array(z.string()),
+  snapshotLedger: z.number().int(),
+  startTime: z.string(),
+  endTime: z.string(),
+  finalized: z.boolean(),
+  resultHash: z.string().nullable(),
+  anchoredTxHash: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+const castVoteSchema = z.object({
+  choiceIndex: z.coerce.number().int().min(0),
+  nonce: z.string().min(1).max(64),
+  signature: z.string().trim().min(1),
+});
+
+const voteResponseSchema = z.object({
+  ok: z.boolean(),
+});
+
+const resultsResponseSchema = z.object({
+  finalized: z.boolean(),
+  resultHash: z.string().optional(),
+  anchoredTxHash: z.string().optional(),
+  choices: z.array(z.string()),
+  totals: z.array(z.string()),
+  totalVotes: z.number().int(),
+  totalWeight: z.string(),
+});
+
+const votesListResponseSchema = z.object({
+  votes: z.array(z.object({
+    voter_address: z.string(),
+    choice_index: z.number().int(),
+    nonce: z.string(),
+    signature: z.string(),
+    voting_power: z.number().int().nullable(),
+    created_at: z.string(),
+  })),
+  pagination: z.object({
+    limit: z.number().int(),
+    offset: z.number().int(),
+    hasMore: z.boolean(),
+  }),
+});
+
+// Register signaling endpoints
+registry.registerPath({
+  method: 'post',
+  path: '/signaling/polls',
+  description: 'Create a temperature-check poll',
+  request: { body: { content: { 'application/json': { schema: createPollSchema } } } },
+  responses: {
+    201: { description: 'Poll created', content: { 'application/json': { schema: pollResponseSchema } } },
+    403: { description: 'Creator voting power below threshold' },
+    400: { description: 'Invalid input' },
+    500: { description: 'Internal server error' },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/signaling/polls',
+  description: 'List all signaling polls',
+  parameters: [
+    { name: 'status', in: 'query', schema: z.enum(['active', 'closed']).optional() },
+  ],
+  responses: {
+    200: { description: 'List of polls', content: { 'application/json': { schema: z.array(pollResponseSchema) } } },
+    500: { description: 'Internal server error' },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/signaling/polls/{id}',
+  description: 'Get a specific signaling poll',
+  parameters: [{ name: 'id', in: 'path', required: true, schema: z.number().int() }],
+  responses: {
+    200: { description: 'Poll details', content: { 'application/json': { schema: pollResponseSchema } } },
+    404: { description: 'Poll not found' },
+    500: { description: 'Internal server error' },
+  },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/signaling/polls/{id}/vote',
+  description: 'Cast a gasless vote on a signaling poll',
+  parameters: [{ name: 'id', in: 'path', required: true, schema: z.number().int() }],
+  request: { body: { content: { 'application/json': { schema: castVoteSchema } } } },
+  responses: {
+    201: { description: 'Vote recorded', content: { 'application/json': { schema: voteResponseSchema } } },
+    400: { description: 'Invalid input or poll not open' },
+    404: { description: 'Poll not found' },
+    409: { description: 'Address has already voted' },
+    500: { description: 'Internal server error' },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/signaling/polls/{id}/results',
+  description: 'Get live or finalized poll results',
+  parameters: [{ name: 'id', in: 'path', required: true, schema: z.number().int() }],
+  responses: {
+    200: { description: 'Poll results', content: { 'application/json': { schema: resultsResponseSchema } } },
+    404: { description: 'Poll not found' },
+    500: { description: 'Internal server error' },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/signaling/polls/{id}/votes',
+  description: 'Get paginated vote list for auditability',
+  parameters: [
+    { name: 'id', in: 'path', required: true, schema: z.number().int() },
+    { name: 'limit', in: 'query', schema: z.coerce.number().int().min(1).max(200).optional().default(50) },
+    { name: 'offset', in: 'query', schema: z.coerce.number().int().min(0).optional().default(0) },
+  ],
+  responses: {
+    200: { description: 'Paginated vote list', content: { 'application/json': { schema: votesListResponseSchema } } },
+    404: { description: 'Poll not found' },
+    500: { description: 'Internal server error' },
+  },
+});
 
 export function generateOpenApiDocument() {
   const generator = new OpenApiGeneratorV3(registry.definitions);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,18 @@
 #!/usr/bin/env node
 
 import { Command } from "commander";
-import { GovernorClient, VoteSupport, VotesClient, TreasuryClient, type Network } from "@nebgov/sdk";
+import {
+  GovernorClient,
+  VoteSupport,
+  VotesClient,
+  TreasuryClient,
+  ProposalBondsClient,
+  OptimisticGovernorClient,
+  ConvictionVotingClient,
+  TreasuryStrategiesClient,
+  SignalingClient,
+  type Network,
+} from "@nebgov/sdk";
 import { Keypair } from "@stellar/stellar-sdk";
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
@@ -453,6 +464,217 @@ program
         const signer = await loadKeypair(options.keypair);
         const opHash = await treasury.batchTransfer(signer, options.token, recipients);
         output({ opHash, recipients: recipients.length }, global);
+      }),
+  );
+
+program
+  .command("proposal-bonds")
+  .description("Proposal bonds commands")
+  .addCommand(
+    new Command("list")
+      .option("--limit <number>", "max bonds", "20")
+      .action(async (options) => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const client = new ProposalBondsClient({
+          network: cfg.network,
+          contractAddress: process.env.NEBGOV_PROPOSAL_BONDS_ADDRESS || "",
+          rpcUrl: cfg.rpcUrl,
+        });
+
+        const bonds = await client.listBonds({
+          limit: Number(options.limit),
+        });
+        output(bonds, global);
+      }),
+  )
+  .addCommand(
+    new Command("settings")
+      .action(async () => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const client = new ProposalBondsClient({
+          network: cfg.network,
+          contractAddress: process.env.NEBGOV_PROPOSAL_BONDS_ADDRESS || "",
+          rpcUrl: cfg.rpcUrl,
+        });
+
+        const settings = await client.getSettings();
+        output(settings, global);
+      }),
+  );
+
+program
+  .command("conviction-voting")
+  .description("Conviction voting commands")
+  .addCommand(
+    new Command("proposal")
+      .argument("<id>", "proposal id")
+      .action(async (id: string) => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const client = new ConvictionVotingClient({
+          network: cfg.network,
+          contractAddress: process.env.NEBGOV_CONVICTION_VOTING_ADDRESS || "",
+          rpcUrl: cfg.rpcUrl,
+        });
+
+        const proposal = await client.getProposal(Number(id));
+        output(proposal, global);
+      }),
+  )
+  .addCommand(
+    new Command("history")
+      .argument("<id>", "proposal id")
+      .action(async (id: string) => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const client = new ConvictionVotingClient({
+          network: cfg.network,
+          contractAddress: process.env.NEBGOV_CONVICTION_VOTING_ADDRESS || "",
+          rpcUrl: cfg.rpcUrl,
+        });
+
+        const history = await client.getConvictionHistory(Number(id));
+        output(history, global);
+      }),
+  );
+
+program
+  .command("optimistic-governor")
+  .description("Optimistic governance commands")
+  .addCommand(
+    new Command("list")
+      .option("--status <status>", "proposal status")
+      .action(async (options) => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const client = new OptimisticGovernorClient({
+          network: cfg.network,
+          contractAddress: process.env.NEBGOV_OPTIMISTIC_GOVERNOR_ADDRESS || "",
+          rpcUrl: cfg.rpcUrl,
+        });
+
+        const proposals = await client.listProposals(options.status as any);
+        output(proposals, global);
+      }),
+  )
+  .addCommand(
+    new Command("get")
+      .argument("<id>", "proposal id")
+      .action(async (id: string) => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const client = new OptimisticGovernorClient({
+          network: cfg.network,
+          contractAddress: process.env.NEBGOV_OPTIMISTIC_GOVERNOR_ADDRESS || "",
+          rpcUrl: cfg.rpcUrl,
+        });
+
+        const proposal = await client.getProposal(Number(id));
+        output(proposal, global);
+      }),
+  )
+  .addCommand(
+    new Command("config")
+      .action(async () => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const client = new OptimisticGovernorClient({
+          network: cfg.network,
+          contractAddress: process.env.NEBGOV_OPTIMISTIC_GOVERNOR_ADDRESS || "",
+          rpcUrl: cfg.rpcUrl,
+        });
+
+        const config = await client.getConfig();
+        output(config, global);
+      }),
+  );
+
+program
+  .command("treasury-strategies")
+  .description("Treasury strategies commands")
+  .addCommand(
+    new Command("list")
+      .option("--limit <number>", "max strategies", "20")
+      .action(async (options) => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const client = new TreasuryStrategiesClient({
+          network: cfg.network,
+          contractAddress: process.env.NEBGOV_TREASURY_STRATEGIES_ADDRESS || "",
+          rpcUrl: cfg.rpcUrl,
+        });
+
+        const strategies = await client.listStrategies({
+          limit: Number(options.limit),
+        });
+        output(strategies, global);
+      }),
+  )
+  .addCommand(
+    new Command("get")
+      .argument("<id>", "strategy id")
+      .action(async (id: string) => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const client = new TreasuryStrategiesClient({
+          network: cfg.network,
+          contractAddress: process.env.NEBGOV_TREASURY_STRATEGIES_ADDRESS || "",
+          rpcUrl: cfg.rpcUrl,
+        });
+
+        const strategy = await client.getStrategy(Number(id));
+        output(strategy, global);
+      }),
+  );
+
+program
+  .command("signaling-polls")
+  .description("Signaling polls commands")
+  .addCommand(
+    new Command("list")
+      .option("--status <status>", "poll status (active or closed)")
+      .action(async (options) => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const client = new SignalingClient({
+          network: cfg.network,
+          rpcUrl: cfg.rpcUrl,
+        });
+
+        const polls = await client.listPolls(options.status as any);
+        output(polls, global);
+      }),
+  )
+  .addCommand(
+    new Command("get")
+      .argument("<id>", "poll id")
+      .action(async (id: string) => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const client = new SignalingClient({
+          network: cfg.network,
+          rpcUrl: cfg.rpcUrl,
+        });
+
+        const poll = await client.getPoll(Number(id));
+        output(poll, global);
+      }),
+  )
+  .addCommand(
+    new Command("results")
+      .argument("<id>", "poll id")
+      .action(async (id: string) => {
+        const global = program.opts<GlobalOptions>();
+        const cfg = await loadConfig(global.config);
+        const client = new SignalingClient({
+          network: cfg.network,
+          rpcUrl: cfg.rpcUrl,
+        });
+
+        const results = await client.getResults(Number(id));
+        output(results, global);
       }),
   );
 

--- a/scripts/upgrade-contract.sh
+++ b/scripts/upgrade-contract.sh
@@ -10,6 +10,9 @@
 #   contract-name is the Cargo package name, e.g.:
 #     sorogov_governor | sorogov_timelock | sorogov_token_votes
 #     sorogov_treasury | sorogov_governor_factory
+#     sorogov_proposal_bonds | sorogov_optimistic_governor
+#     sorogov_conviction_voting | sorogov_treasury_strategies
+#     sorogov_signal_anchor
 #
 # Required env vars (or set in .env.testnet):
 #   GOVERNOR_ADDRESS   — deployed governor contract address

--- a/tools/sim/src/runner.rs
+++ b/tools/sim/src/runner.rs
@@ -399,6 +399,23 @@ impl SimulationRunner {
                 let delegatee_addr = self.get_actor(delegatee).clone();
                 self.token_votes.delegate(&delegator, &delegatee_addr);
             }
+            SimStep::DelegateSplit { actor, splits } => {
+                let delegator = self.get_actor(actor).clone();
+                let split_delegations: SorobanVec<sorogov_token_votes::SplitDelegation> =
+                    SorobanVec::from_slice(
+                        &self.env,
+                        &splits
+                            .iter()
+                            .map(|(delegatee_name, weight_bps)| {
+                                sorogov_token_votes::SplitDelegation {
+                                    delegatee: self.get_actor(delegatee_name).clone(),
+                                    weight_bps: *weight_bps,
+                                }
+                            })
+                            .collect::<Vec<_>>(),
+                    );
+                self.token_votes.delegate_split(&delegator, &split_delegations);
+            }
             SimStep::MintTokens { actor, amount } => {
                 let addr = self.get_actor(actor).clone();
                 token::StellarAssetClient::new(&self.env, &self.token)

--- a/tools/sim/src/scenario.rs
+++ b/tools/sim/src/scenario.rs
@@ -106,6 +106,10 @@ pub enum SimStep {
         actor: String,
         delegatee: String,
     },
+    DelegateSplit {
+        actor: String,
+        splits: Vec<(String, u32)>,
+    },
     MintTokens {
         actor: String,
         #[serde(with = "i128_compat")]
@@ -230,6 +234,7 @@ impl SimStep {
             SimStep::Execute { .. } => "Execute",
             SimStep::Cancel { .. } => "Cancel",
             SimStep::Delegate { .. } => "Delegate",
+            SimStep::DelegateSplit { .. } => "DelegateSplit",
             SimStep::MintTokens { .. } => "MintTokens",
             SimStep::BurnTokens { .. } => "BurnTokens",
             SimStep::UpdateConfig { .. } => "UpdateConfig",

--- a/tools/sim/src/scenarios/split_delegation.json
+++ b/tools/sim/src/scenarios/split_delegation.json
@@ -1,0 +1,48 @@
+{
+  "name": "split_delegation",
+  "description": "Exercises multi-target split delegation with basis-point weights. Alice delegates 60% to Bob and 40% to Carol, then exercises voting power distribution across both delegatees.",
+  "seed": 99,
+  "governor_settings": {
+    "voting_delay": 1,
+    "voting_period": 10,
+    "quorum_numerator": 5,
+    "proposal_threshold": 50,
+    "vote_type": "Extended",
+    "proposal_grace_period": 1000,
+    "max_calldata_size": 10000,
+    "proposal_cooldown": 0,
+    "max_proposals_per_period": 5,
+    "proposal_period_duration": 10000
+  },
+  "actors": [
+    { "name": "alice", "initial_balance": 1000, "delegate_to": null, "role": "TokenHolder" },
+    { "name": "bob", "initial_balance": 500, "delegate_to": null, "role": "Proposer" },
+    { "name": "carol", "initial_balance": 300, "delegate_to": null, "role": "TokenHolder" },
+    { "name": "dave", "initial_balance": 200, "delegate_to": null, "role": "TokenHolder" }
+  ],
+  "steps": [
+    { "type": "TakeAnalyticsSnapshot" },
+    {
+      "type": "DelegateSplit",
+      "actor": "alice",
+      "splits": [
+        ["bob", 6000],
+        ["carol", 4000]
+      ]
+    },
+    { "type": "Propose", "actor": "bob", "targets": ["target"], "fn_names": ["noop"], "description": "test proposal for split delegation voting" },
+    { "type": "AdvanceLedger", "ledgers": 2 },
+    { "type": "Vote", "actor": "bob", "proposal_id": 1, "support": "For" },
+    { "type": "Vote", "actor": "carol", "proposal_id": 1, "support": "For" },
+    { "type": "AdvanceLedger", "ledgers": 10 },
+    { "type": "ExpectState", "proposal_id": 1, "expected_state": "Succeeded" },
+    { "type": "Delegate", "actor": "dave", "delegatee": "alice" },
+    { "type": "Propose", "actor": "bob", "targets": ["target"], "fn_names": ["noop"], "description": "second proposal after adding delegator to alice" },
+    { "type": "AdvanceLedger", "ledgers": 2 },
+    { "type": "Vote", "actor": "bob", "proposal_id": 2, "support": "Against" },
+    { "type": "Vote", "actor": "carol", "proposal_id": 2, "support": "For" },
+    { "type": "AdvanceLedger", "ledgers": 10 },
+    { "type": "ExpectState", "proposal_id": 2, "expected_state": "Succeeded" },
+    { "type": "TakeAnalyticsSnapshot" }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR addresses all four open issues (#1070, #1087, #1088, #1089) by implementing comprehensive support for the 5 newest NebGov features across multiple components:

- **proposal-bonds**
- **optimistic-governance**
- **conviction-voting**
- **treasury-strategies**
- **signaling polls**

## Changes

### 1. CLI Commands (Issue #1089)
Added CLI subcommands for all 5 new features with read operations (list/get):
- `nebgov proposal-bonds list|settings`
- `nebgov conviction-voting proposal|history <id>`
- `nebgov optimistic-governor list|get|config`
- `nebgov treasury-strategies list|get <id>`
- `nebgov signaling-polls list|get|results <id>`

All commands follow existing CLI patterns with `--human` and `--config` flag support.

### 2. Deployment Script Support (Issue #1088)
Extended `scripts/upgrade-contract.sh` documentation to explicitly list the 5 new contracts:
- sorogov_proposal_bonds
- sorogov_optimistic_governor
- sorogov_conviction_voting
- sorogov_treasury_strategies
- sorogov_signal_anchor

The script already dynamically supports these contracts via cargo package name conversion.

### 3. OpenAPI Documentation (Issue #1070)
Added complete OpenAPI v3.0.0 schema documentation for all signaling endpoints:
- `POST /signaling/polls` - Create temperature-check poll
- `GET /signaling/polls` - List polls (with status filter)
- `GET /signaling/polls/:id` - Get specific poll
- `POST /signaling/polls/:id/vote` - Cast gasless vote
- `GET /signaling/polls/:id/results` - Get live/finalized results
- `GET /signaling/polls/:id/votes` - Paginated vote list

Includes proper schema definitions for all request/response bodies and error cases.

### 4. Simulation Scenario (Issue #1087)
Added split delegation support to simulation framework:
- New `DelegateSplit` SimStep variant for multi-target delegation with basis-point weights
- Runner implementation handling split delegation invocation via token-votes contract
- `split_delegation.json` scenario exercising:
  - 60/40 split between two delegatees
  - Voting power distribution across split targets
  - Multi-delegator chains with split delegation

## Testing
All changes follow existing patterns and are backward compatible:
- CLI commands follow existing command structure
- OpenAPI schemas use consistent zod validation
- Simulation step type is non-breaking addition to SimStep enum
- Script documentation is purely additive

## Files Changed
- `backend/src/openapi.ts` - OpenAPI schema definitions
- `packages/cli/src/index.ts` - CLI command implementations
- `scripts/upgrade-contract.sh` - Documentation updates
- `tools/sim/src/scenario.rs` - New DelegateSplit step type
- `tools/sim/src/runner.rs` - DelegateSplit execution handler
- `tools/sim/src/scenarios/split_delegation.json` - Split delegation scenario


closes #1088
closes #1087 
closes #1089 
closes #1070