### PR TITLE
docs: restore docs/contributing/branch-protection.md

### DIFF
--- a/docs/contributing/branch-protection.md
+++ b/docs/contributing/branch-protection.md
@@ -1,0 +1,26 @@
+# Branch Protection Rules
+
+For an open-source governance protocol where smart contract changes are high-stakes, strict branch protection rules are required. This document outlines the recommended settings for the NebGov repository and any forks or deployments.
+
+## Recommended Settings for `main`
+
+We recommend applying the following branch protection rules in GitHub:
+
+1. **Require Pull Request reviews before merging**
+   - **Minimum number of approvals**: Set to `1` generally, but `2` for smart contracts. (The `CODEOWNERS` file enforces that the appropriate team reviews specific areas).
+   - **Require review from Code Owners**: Enable this to ensure that the correct teams (e.g., `@nebgov/contracts-team`, `@nebgov/security-team`) approve PRs touching their files.
+
+2. **Require status checks to pass before merging**
+   - Require branches to be up to date before merging.
+   - Require the following checks to pass:
+     - Tests (`cargo test --workspace`, `pnpm test:sdk`, `pnpm test:app`)
+     - Linting and Formatting (e.g., `clippy`)
+     - Security Audits (e.g., `cargo-scout-audit`)
+
+3. **Restrict who can push to matching branches**
+   - Only allow specific individuals or teams to push directly to `main` (typically just the automation bots or core maintainers).
+
+4. **Require signed commits**
+   - Ensure all commits are verified to prevent impersonation.
+
+By adhering to these rules, we ensure that no untested, unreviewed, or insecure code is introduced into the governance framework.


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md`'s PR-process section links to `docs/contributing/branch-protection.md`, but no `docs/contributing/` directory existed — so the link 404'd for anyone following the review guidelines.

## Root cause

The file **is not missing by design.** It was swept up in [`d148fd5`](https://github.com/nebgov/nebgov/commit/d148fd5) — *"chore: remove all stale docs, irrelevant files, and tool config"* — which deleted the **entire `docs/` directory (46 files) in one blanket pass** rather than judging this document individually. The link in `CONTRIBUTING.md` was never updated to match.

Since then `docs/` has been **partially rebuilt** — `architecture.md`, `deployment.md`, and `troubleshooting.md` are all back. So the project's direction is clearly "rebuild `docs/`", not "keep it empty".

## Solution

The issue offers both options ("either create the referenced file or remove/fix the broken link"). I chose **restore**, because:

1. The deletion was collateral from a blanket sweep, not a considered removal of this file.
2. `docs/` is actively being rebuilt, so restoring is consistent with where the tree is heading.
3. It preserves the intent of the sentence that points at it — delinking would silently drop the branch-protection guidance entirely.

Restored **byte-for-byte from `d148fd5^`** rather than rewritten, so the diff reads as a pure revert of an accidental deletion with no unreviewable editorial churn.

**`CONTRIBUTING.md` needs no edit** — the existing link resolves as soon as the file is back. This PR adds one file and changes nothing else.

## Testing

Documentation-only change; no code paths touched.

- **Link now resolves** — re-ran a link check over `CONTRIBUTING.md`; `L244 docs/contributing/branch-protection.md` flipped from `BROKEN` to `OK`.
- **Verbatim restore confirmed** — `diff` against `d148fd5^` reports byte-identical.
- **Every factual claim in the restored doc re-verified against the repo as it stands today**, so this isn't a blind revert of stale content:

  | Claim in doc | Verified against | Status |
  | ------------ | ---------------- | ------ |
  | `@nebgov/contracts-team` | `.github/CODEOWNERS` | ✓ present |
  | `@nebgov/security-team` | `.github/CODEOWNERS` | ✓ present |
  | `pnpm test:sdk` | root `package.json` scripts | ✓ real script |
  | `pnpm test:app` | root `package.json` scripts | ✓ real script |
  | `clippy` | `.github/workflows/rust.yml` | ✓ real job |
  | `cargo-scout-audit` | CI + `CONTRIBUTING.md` | ✓ referenced |
  | `cargo test --workspace` | `CONTRIBUTING.md` | ✓ documented command |

- The document describes **recommended** settings rather than asserting the repo's current GitHub configuration, so it makes no claim that can silently drift out of date.
- No Prettier config or markdown linter exists in the repo and no workflow lints `.md`, so there is no formatting gate to satisfy.

## CI expectations

Only two workflows run on a docs-only change; the rest are path-filtered to `app/**`, `sdk/**`, `contracts/**`, `tools/**`, or are tag-only (`v*.*.*`):

| Workflow | Runs? | Expected |
| -------- | ----- | -------- |
| `backend.yml` | yes (no path filter) | pass — green on `main` |
| `rust.yml` | yes (no path filter) | **`Test` job red — pre-existing on `main`** |
| `frontend.yml` / `sdk.yml` / `simulation.yml` | no | path-filtered |
| `deploy-testnet.yml` / `release.yml` | no | tag-only |

⚠️ **`Rust Contracts / Test` is already failing on `main`** and will therefore be red here too. Adding a markdown file cannot affect Rust tests. Run [32843261478](https://github.com/nebgov/nebgov/actions/runs/32843261478) on `main` fails with:

```
test split_delegation_tests::test_single_100_weight_delegate_split_collapses_to_legacy_delegate_key ... FAILED
panicked at contracts/token-votes/src/split_delegation_tests.rs:279:5
test result: FAILED. 86 passed; 1 failed
```

Every other job in that workflow (`Clippy`, `Build WASM`, `Security audit`, `Security Scan`) passes. Out of scope here; worth its own fix.

## Related broken links found (not fixed here)

The issue notes this is a recurring defect category (cf. #898). While verifying, I audited every relative link in `CONTRIBUTING.md` and `README.md` — **7 others are still broken**, all pointing at files that the same `d148fd5` sweep removed:

| File | Line | Broken target |
| ---- | ---- | ------------- |
| `CONTRIBUTING.md` | 200 | `./docs/security.md` |
| `CONTRIBUTING.md` | 248 | `./SECURITY.md` |
| `README.md` | 72 | `./docs/tutorial.md` |
| `README.md` | 92 | `./docs/local-development.md` |
| `README.md` | 103 | `./docs/parameter-guide.md` |
| `README.md` | 104 | `./docs/security.md` |
| `README.md` | 105 | `./docs/deployments.md` |
| `README.md` | 142 | `./SECURITY.md` |

`SECURITY.md` is notable — it's referenced from both files *and* from the README's "Security Policy" badge, and the security-reporting process depends on it.

These are deliberately left out to keep this PR scoped to #1081 as written; each needs its own restore-vs-delink judgement. Happy to open a follow-up issue covering them, or fold them into this PR if you'd prefer one sweep.

Closes #1081
