### PR TITLE
fix(deploy): add signal-anchor contract to testnet deployment script

### DIFF
--- a/scripts/deploy-testnet.sh
+++ b/scripts/deploy-testnet.sh
@@ -109,7 +109,7 @@ cargo build --release --target wasm32v1-none --manifest-path "$ROOT_DIR/Cargo.to
 ok "WASM build complete"
 
 # Verify expected artefacts exist
-for wasm in sorogov_token_votes sorogov_timelock sorogov_governor sorogov_treasury sorogov_governor_factory sorogov_liquidity; do
+for wasm in sorogov_token_votes sorogov_timelock sorogov_governor sorogov_treasury sorogov_governor_factory sorogov_liquidity sorogov_signal_anchor; do
   [[ -f "$WASM_DIR/${wasm}.wasm" ]] || fail "Expected WASM not found: $WASM_DIR/${wasm}.wasm"
 done
 
@@ -176,6 +176,9 @@ deploy_contract "$WASM_DIR/sorogov_governor_factory.wasm" "FACTORY_ADDRESS"
 
 # 6. Liquidity
 deploy_contract "$WASM_DIR/sorogov_liquidity.wasm" "LIQUIDITY_ADDRESS"
+
+# 7. Signal-Anchor
+deploy_contract "$WASM_DIR/sorogov_signal_anchor.wasm" "SIGNAL_ANCHOR_CONTRACT_ID"
 
 # ====================================================================
 # Initialize contracts (idempotent — each checks storage internally)
@@ -302,6 +305,17 @@ stellar contract invoke \
   2>/dev/null && ok "factory native token configured" \
   || warn "factory native token already configured (or update failed — check manually)"
 
+# -- Initialize signal-anchor -----------------------------------------
+info "Initializing signal-anchor ..."
+stellar contract invoke \
+  --id "$SIGNAL_ANCHOR_CONTRACT_ID" \
+  --source "$IDENTITY" \
+  --network "$NETWORK" \
+  -- initialize \
+  --admin "$DEPLOYER_ADDR" \
+  2>/dev/null && ok "signal-anchor initialized" \
+  || warn "signal-anchor already initialized (or init failed — check manually)"
+
 # ====================================================================
 # Summary
 # ====================================================================
@@ -319,6 +333,7 @@ info "  Governor ............. $GOVERNOR_ADDRESS"
 info "  Treasury ............. $TREASURY_ADDRESS"
 info "  Factory .............. $FACTORY_ADDRESS"
 info "  Liquidity ............ $LIQUIDITY_ADDRESS"
+info "  Signal-Anchor ........ $SIGNAL_ANCHOR_CONTRACT_ID"
 info "  Env file ............. $ENV_FILE"
 info "============================================================"
 printf '\n'


### PR DESCRIPTION
The signal-anchor contract (merged in #999) was missing from deploy-testnet.sh, leaving on-chain result anchoring unconfigured after a fresh testnet deployment.

Add deploy + initialize steps following the existing pattern:
- Include sorogov_signal_anchor in WASM artifact verification
- Deploy contract and persist address as SIGNAL_ANCHOR_CONTRACT_ID
- Initialize with deployer as admin (matching contract's initialize(admin) signature)
- Add to deployment summary output


**Changes in `scripts/deploy-testnet.sh`:**

1. **WASM verification** (line 112) — added `sorogov_signal_anchor` to the artifact check list
2. **Deploy step** (line 180-181) — deploys the contract and persists the address as `SIGNAL_ANCHOR_CONTRACT_ID` (matching what `backend/src/jobs/signal-anchor.ts:33` reads from env)
3. **Initialize step** (lines 308-317) — calls `initialize --admin $DEPLOYER_ADDR`, matching the contract's `initialize(env, admin: Address)` signature in `contracts/signal-anchor/src/lib.rs:44`
4. **Summary** (line 336) — prints the deployed address alongside the other contracts

Closes #1062
Closes #1061
Closes #1058
Closes #1057