### PR TITLE
feat(stellar-wave): add typed error parsing and replace bare unwrap() calls

### DIFF
--- a/contracts/conviction-voting/src/lib.rs
+++ b/contracts/conviction-voting/src/lib.rs
@@ -117,7 +117,7 @@ impl ConvictionVotingContract {
             .storage()
             .instance()
             .get(&DataKey::NextProposalId)
-            .unwrap();
+            .unwrap_or_else(|| env.panic_with_error(ConvictionVotingError::NotInitialized));
         let next = id
             .checked_add(1)
             .unwrap_or_else(|| env.panic_with_error(ConvictionVotingError::ArithmeticOverflow));
@@ -281,7 +281,7 @@ impl ConvictionVotingContract {
             .storage()
             .instance()
             .get(&DataKey::MinThresholdConviction)
-            .unwrap();
+            .unwrap_or_else(|| env.panic_with_error(ConvictionVotingError::NotInitialized));
         if requested_amount == 0 {
             return minimum;
         }
@@ -289,7 +289,11 @@ impl ConvictionVotingContract {
         if supply <= 0 {
             return i128::MAX;
         }
-        let max_ratio: u32 = env.storage().instance().get(&DataKey::MaxRatioBps).unwrap();
+        let max_ratio: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxRatioBps)
+            .unwrap_or_else(|| env.panic_with_error(ConvictionVotingError::NotInitialized));
         let ratio = requested_amount
             .checked_mul(BPS)
             .and_then(|v| v.checked_div(supply))
@@ -310,7 +314,11 @@ impl ConvictionVotingContract {
     pub fn cancel_proposal(env: Env, caller: Address, proposal_id: u64) {
         caller.require_auth();
         let mut proposal = Self::must_get_open_proposal(&env, proposal_id);
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| env.panic_with_error(ConvictionVotingError::NotInitialized));
         if caller != proposal.proposer && caller != admin {
             env.panic_with_error(ConvictionVotingError::Unauthorized);
         }
@@ -390,8 +398,16 @@ impl ConvictionVotingContract {
         if elapsed == 0 || proposal.executed || proposal.cancelled {
             return proposal;
         }
-        let decay_bps: u32 = env.storage().instance().get(&DataKey::DecayBps).unwrap();
-        let weight_bps: u32 = env.storage().instance().get(&DataKey::WeightBps).unwrap();
+        let decay_bps: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::DecayBps)
+            .unwrap_or_else(|| env.panic_with_error(ConvictionVotingError::NotInitialized));
+        let weight_bps: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::WeightBps)
+            .unwrap_or_else(|| env.panic_with_error(ConvictionVotingError::NotInitialized));
         let decay = Self::pow_bps(decay_bps as i128, elapsed);
         let total = Self::total_staked(env, proposal.id);
         let steady = total

--- a/contracts/optimistic-governor/src/lib.rs
+++ b/contracts/optimistic-governor/src/lib.rs
@@ -138,7 +138,7 @@ impl OptimisticGovernorContract {
             .storage()
             .instance()
             .get(&DataKey::NextProposalId)
-            .unwrap();
+            .unwrap_or_else(|| env.panic_with_error(OptimisticGovernorError::NotInitialized));
         let next = id
             .checked_add(1)
             .unwrap_or_else(|| env.panic_with_error(OptimisticGovernorError::ArithmeticOverflow));
@@ -148,13 +148,13 @@ impl OptimisticGovernorContract {
             .storage()
             .instance()
             .get(&DataKey::ProposerBondAmount)
-            .unwrap();
+            .unwrap_or_else(|| env.panic_with_error(OptimisticGovernorError::NotInitialized));
         if bond_amount > 0 {
             let bond_token: Address = env
                 .storage()
                 .instance()
                 .get(&DataKey::ProposerBondToken)
-                .unwrap();
+                .unwrap_or_else(|| env.panic_with_error(OptimisticGovernorError::NotInitialized));
             token::TokenClient::new(&env, &bond_token).transfer(
                 &proposer,
                 &env.current_contract_address(),
@@ -173,7 +173,7 @@ impl OptimisticGovernorContract {
             .storage()
             .instance()
             .get(&DataKey::ChallengeWindowLedgers)
-            .unwrap();
+            .unwrap_or_else(|| env.panic_with_error(OptimisticGovernorError::NotInitialized));
         let challenge_end_ledger = created_ledger
             .checked_add(challenge_window_ledgers)
             .unwrap_or_else(|| env.panic_with_error(OptimisticGovernorError::ArithmeticOverflow));
@@ -238,7 +238,7 @@ impl OptimisticGovernorContract {
             .storage()
             .instance()
             .get(&DataKey::ObjectionThresholdBps)
-            .unwrap();
+            .unwrap_or_else(|| env.panic_with_error(OptimisticGovernorError::NotInitialized));
         let total_supply = Self::votes_client(&env).get_past_total_supply(&proposal.created_ledger);
         let crossed = total_supply > 0
             && running_total
@@ -334,11 +334,21 @@ impl OptimisticGovernorContract {
         Self::require_initialized(&env);
         let storage = env.storage().instance();
         OptimisticGovernorConfig {
-            votes_token: storage.get(&DataKey::VotesToken).unwrap(),
-            challenge_window_ledgers: storage.get(&DataKey::ChallengeWindowLedgers).unwrap(),
-            objection_threshold_bps: storage.get(&DataKey::ObjectionThresholdBps).unwrap(),
-            proposer_bond_amount: storage.get(&DataKey::ProposerBondAmount).unwrap(),
-            proposer_bond_token: storage.get(&DataKey::ProposerBondToken).unwrap(),
+            votes_token: storage
+                .get(&DataKey::VotesToken)
+                .unwrap_or_else(|| env.panic_with_error(OptimisticGovernorError::NotInitialized)),
+            challenge_window_ledgers: storage
+                .get(&DataKey::ChallengeWindowLedgers)
+                .unwrap_or_else(|| env.panic_with_error(OptimisticGovernorError::NotInitialized)),
+            objection_threshold_bps: storage
+                .get(&DataKey::ObjectionThresholdBps)
+                .unwrap_or_else(|| env.panic_with_error(OptimisticGovernorError::NotInitialized)),
+            proposer_bond_amount: storage
+                .get(&DataKey::ProposerBondAmount)
+                .unwrap_or_else(|| env.panic_with_error(OptimisticGovernorError::NotInitialized)),
+            proposer_bond_token: storage
+                .get(&DataKey::ProposerBondToken)
+                .unwrap_or_else(|| env.panic_with_error(OptimisticGovernorError::NotInitialized)),
         }
     }
 

--- a/sdk/src/convictionVoting.ts
+++ b/sdk/src/convictionVoting.ts
@@ -15,6 +15,7 @@ import type {
   GovernorConfig,
   Network,
 } from "./types";
+import { parseConvictionVotingError } from "./errors";
 
 const RPC_URLS: Record<Network, string> = {
   mainnet: "https://soroban-rpc.mainnet.stellar.gateway.fm",
@@ -143,7 +144,7 @@ export class ConvictionVotingClient {
     const prepared = await this.server.prepareTransaction(tx);
     prepared.sign(signer);
     const sent = await this.server.sendTransaction(prepared);
-    if (sent.status === "ERROR") throw new Error(`Transaction submission failed: ${fn}`);
+    if (sent.status === "ERROR") throw parseConvictionVotingError(sent);
     for (let attempt = 0; attempt < 20; attempt += 1) {
       await new Promise((resolve) => setTimeout(resolve, 1_000));
       const status = await this.server.getTransaction(sent.hash);
@@ -151,10 +152,10 @@ export class ConvictionVotingClient {
         return { hash: sent.hash, ...status };
       }
       if (status.status === SorobanRpc.Api.GetTransactionStatus.FAILED) {
-        throw new Error(`Transaction failed: ${sent.hash}`);
+        throw parseConvictionVotingError(status);
       }
     }
-    throw new Error(`Transaction confirmation timed out: ${sent.hash}`);
+    throw parseConvictionVotingError("Transaction confirmation timed out");
   }
 
   private async simulate(fn: string, ...args: xdr.ScVal[]): Promise<unknown> {
@@ -166,7 +167,7 @@ export class ConvictionVotingClient {
     }).addOperation(this.contract.call(fn, ...args)).setTimeout(30).build();
     const result = await this.server.simulateTransaction(tx);
     if (SorobanRpc.Api.isSimulationError(result) || !result.result?.retval) {
-      throw new Error(`Simulation failed: ${fn}`);
+      throw parseConvictionVotingError(result);
     }
     return scValToNative(result.result.retval);
   }

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -1012,6 +1012,190 @@ export function parseTreasuryStrategiesError(
   );
 }
 
+// ─── Conviction Voting Errors ────────────────────────────────────────────
+
+/**
+ * Error codes for the ConvictionVoting contract + SDK transport layer.
+ *
+ * Codes 1–99 mirror the on-chain ConvictionVotingError enum values
+ * (contracts/conviction-voting/src/error.rs).
+ */
+export enum ConvictionVotingErrorCode {
+  AlreadyInitialized = 1,
+  NotInitialized = 2,
+  InvalidConfiguration = 3,
+  InvalidAmount = 4,
+  ProposalNotFound = 5,
+  ProposalClosed = 6,
+  InsufficientVotingPower = 7,
+  StakeNotFound = 8,
+  Unauthorized = 9,
+  ArithmeticOverflow = 10,
+  InvalidCalldata = 11,
+
+  // SDK-level codes
+  SimulationFailed = 100,
+  TransactionFailed = 101,
+  TransactionTimeout = 102,
+}
+
+const CONVICTION_VOTING_MESSAGES: Record<ConvictionVotingErrorCode, string> = {
+  [ConvictionVotingErrorCode.AlreadyInitialized]: "Contract is already initialized",
+  [ConvictionVotingErrorCode.NotInitialized]: "Contract has not been initialized yet",
+  [ConvictionVotingErrorCode.InvalidConfiguration]: "Invalid configuration parameters",
+  [ConvictionVotingErrorCode.InvalidAmount]: "Amount must be positive",
+  [ConvictionVotingErrorCode.ProposalNotFound]: "Proposal not found",
+  [ConvictionVotingErrorCode.ProposalClosed]: "Proposal is closed or already executed",
+  [ConvictionVotingErrorCode.InsufficientVotingPower]: "Insufficient voting power for this action",
+  [ConvictionVotingErrorCode.StakeNotFound]: "No stake found for this account",
+  [ConvictionVotingErrorCode.Unauthorized]: "Caller is not authorized to perform this action",
+  [ConvictionVotingErrorCode.ArithmeticOverflow]: "Arithmetic overflow in conviction calculation",
+  [ConvictionVotingErrorCode.InvalidCalldata]: "Calldata is invalid or malformed",
+  [ConvictionVotingErrorCode.SimulationFailed]: "Simulation failed",
+  [ConvictionVotingErrorCode.TransactionFailed]: "Transaction failed",
+  [ConvictionVotingErrorCode.TransactionTimeout]: "Transaction timed out",
+};
+
+export class ConvictionVotingError extends Error {
+  readonly name = "ConvictionVotingError";
+
+  constructor(
+    public readonly code: ConvictionVotingErrorCode,
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    Object.setPrototypeOf(this, ConvictionVotingError.prototype);
+  }
+}
+
+/**
+ * Parse a raw Soroban RPC error into a typed {@link ConvictionVotingError}.
+ */
+export function parseConvictionVotingError(
+  raw: SorobanRpcError | string | null | undefined,
+  cause?: unknown,
+): ConvictionVotingError {
+  const contractCode = extractContractErrorCode(raw);
+  if (contractCode !== null) {
+    const code = contractCode as ConvictionVotingErrorCode;
+    const message =
+      CONVICTION_VOTING_MESSAGES[code] ?? `Conviction-voting contract error #${contractCode}`;
+    return new ConvictionVotingError(code, message, cause);
+  }
+
+  if (hasErrorStatus(raw)) {
+    return new ConvictionVotingError(
+      ConvictionVotingErrorCode.TransactionFailed,
+      `${CONVICTION_VOTING_MESSAGES[ConvictionVotingErrorCode.TransactionFailed]}: ${errorText(raw) || "unknown"}`,
+      cause,
+    );
+  }
+
+  return new ConvictionVotingError(
+    ConvictionVotingErrorCode.SimulationFailed,
+    `${CONVICTION_VOTING_MESSAGES[ConvictionVotingErrorCode.SimulationFailed]}: ${errorText(raw) || "unknown"}`,
+    cause,
+  );
+}
+
+// ─── Optimistic Governor Errors ───────────────────────────────────────────
+
+/**
+ * Error codes for the OptimisticGovernor contract + SDK transport layer.
+ *
+ * Codes 1–99 mirror the on-chain OptimisticGovernorError enum values
+ * (contracts/optimistic-governor/src/error.rs).
+ */
+export enum OptimisticGovernorErrorCode {
+  AlreadyInitialized = 1,
+  NotInitialized = 2,
+  InvalidConfiguration = 3,
+  InvalidCalldata = 4,
+  ProposalNotFound = 5,
+  NotInChallengeWindow = 6,
+  ChallengeWindowNotElapsed = 7,
+  ChallengeWindowElapsed = 8,
+  AlreadyObjected = 9,
+  NoVotingPower = 10,
+  ProposalObjected = 11,
+  ProposalNotPassed = 12,
+  ProposalAlreadyFinalized = 13,
+  Unauthorized = 14,
+  ArithmeticOverflow = 15,
+  ProposalNotCancellable = 16,
+
+  // SDK-level codes
+  SimulationFailed = 100,
+  TransactionFailed = 101,
+  TransactionTimeout = 102,
+}
+
+const OPTIMISTIC_GOVERNOR_MESSAGES: Record<OptimisticGovernorErrorCode, string> = {
+  [OptimisticGovernorErrorCode.AlreadyInitialized]: "Contract is already initialized",
+  [OptimisticGovernorErrorCode.NotInitialized]: "Contract has not been initialized yet",
+  [OptimisticGovernorErrorCode.InvalidConfiguration]: "Invalid configuration parameters",
+  [OptimisticGovernorErrorCode.InvalidCalldata]: "Calldata is invalid or malformed",
+  [OptimisticGovernorErrorCode.ProposalNotFound]: "Proposal not found",
+  [OptimisticGovernorErrorCode.NotInChallengeWindow]: "Proposal is not in the challenge window",
+  [OptimisticGovernorErrorCode.ChallengeWindowNotElapsed]: "Challenge window has not elapsed yet",
+  [OptimisticGovernorErrorCode.ChallengeWindowElapsed]: "Challenge window has already elapsed",
+  [OptimisticGovernorErrorCode.AlreadyObjected]: "Address has already objected to this proposal",
+  [OptimisticGovernorErrorCode.NoVotingPower]: "Account has zero voting power",
+  [OptimisticGovernorErrorCode.ProposalObjected]: "Proposal has been objected and is no longer passing",
+  [OptimisticGovernorErrorCode.ProposalNotPassed]: "Proposal has not passed the challenge window",
+  [OptimisticGovernorErrorCode.ProposalAlreadyFinalized]: "Proposal has already been finalized or objected",
+  [OptimisticGovernorErrorCode.Unauthorized]: "Caller is not authorized to perform this action",
+  [OptimisticGovernorErrorCode.ArithmeticOverflow]: "Arithmetic overflow in objection calculation",
+  [OptimisticGovernorErrorCode.ProposalNotCancellable]: "Proposal cannot be cancelled in its current state",
+  [OptimisticGovernorErrorCode.SimulationFailed]: "Simulation failed",
+  [OptimisticGovernorErrorCode.TransactionFailed]: "Transaction failed",
+  [OptimisticGovernorErrorCode.TransactionTimeout]: "Transaction timed out",
+};
+
+export class OptimisticGovernorError extends Error {
+  readonly name = "OptimisticGovernorError";
+
+  constructor(
+    public readonly code: OptimisticGovernorErrorCode,
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    Object.setPrototypeOf(this, OptimisticGovernorError.prototype);
+  }
+}
+
+/**
+ * Parse a raw Soroban RPC error into a typed {@link OptimisticGovernorError}.
+ */
+export function parseOptimisticGovernorError(
+  raw: SorobanRpcError | string | null | undefined,
+  cause?: unknown,
+): OptimisticGovernorError {
+  const contractCode = extractContractErrorCode(raw);
+  if (contractCode !== null) {
+    const code = contractCode as OptimisticGovernorErrorCode;
+    const message =
+      OPTIMISTIC_GOVERNOR_MESSAGES[code] ?? `Optimistic-governor contract error #${contractCode}`;
+    return new OptimisticGovernorError(code, message, cause);
+  }
+
+  if (hasErrorStatus(raw)) {
+    return new OptimisticGovernorError(
+      OptimisticGovernorErrorCode.TransactionFailed,
+      `${OPTIMISTIC_GOVERNOR_MESSAGES[OptimisticGovernorErrorCode.TransactionFailed]}: ${errorText(raw) || "unknown"}`,
+      cause,
+    );
+  }
+
+  return new OptimisticGovernorError(
+    OptimisticGovernorErrorCode.SimulationFailed,
+    `${OPTIMISTIC_GOVERNOR_MESSAGES[OptimisticGovernorErrorCode.SimulationFailed]}: ${errorText(raw) || "unknown"}`,
+    cause,
+  );
+}
+
 // ─── Voting Rewards Errors ───────────────────────────────────────────────────
 
 /**

--- a/sdk/src/optimisticGovernor.ts
+++ b/sdk/src/optimisticGovernor.ts
@@ -18,6 +18,7 @@ import type {
   OptimisticProposalState,
 } from "./types";
 import { hexToBytes32 } from "./utils";
+import { parseOptimisticGovernorError } from "./errors";
 
 const RPC_URLS: Record<Network, string> = {
   mainnet: "https://soroban-rpc.mainnet.stellar.gateway.fm",
@@ -174,7 +175,7 @@ export class OptimisticGovernorClient {
     const prepared = await this.server.prepareTransaction(tx);
     prepared.sign(signer);
     const sent = await this.server.sendTransaction(prepared);
-    if (sent.status === "ERROR") throw new Error(`Transaction submission failed: ${fn}`);
+    if (sent.status === "ERROR") throw parseOptimisticGovernorError(sent);
     for (let attempt = 0; attempt < 20; attempt += 1) {
       await new Promise((resolve) => setTimeout(resolve, 1_000));
       const status = await this.server.getTransaction(sent.hash);
@@ -182,10 +183,10 @@ export class OptimisticGovernorClient {
         return { hash: sent.hash, ...status };
       }
       if (status.status === SorobanRpc.Api.GetTransactionStatus.FAILED) {
-        throw new Error(`Transaction failed: ${sent.hash}`);
+        throw parseOptimisticGovernorError(status);
       }
     }
-    throw new Error(`Transaction confirmation timed out: ${sent.hash}`);
+    throw parseOptimisticGovernorError("Transaction confirmation timed out");
   }
 
   /**
@@ -209,7 +210,7 @@ export class OptimisticGovernorClient {
     const signedXdr = await signUnsignedXdr(prepared.toXDR());
     const signed = TransactionBuilder.fromXDR(signedXdr, this.passphrase);
     const sent = await this.server.sendTransaction(signed);
-    if (sent.status === "ERROR") throw new Error(`Transaction submission failed: ${fn}`);
+    if (sent.status === "ERROR") throw parseOptimisticGovernorError(sent);
     for (let attempt = 0; attempt < 20; attempt += 1) {
       await new Promise((resolve) => setTimeout(resolve, 1_000));
       const status = await this.server.getTransaction(sent.hash);
@@ -217,10 +218,10 @@ export class OptimisticGovernorClient {
         return { hash: sent.hash, ...status };
       }
       if (status.status === SorobanRpc.Api.GetTransactionStatus.FAILED) {
-        throw new Error(`Transaction failed: ${sent.hash}`);
+        throw parseOptimisticGovernorError(status);
       }
     }
-    throw new Error(`Transaction confirmation timed out: ${sent.hash}`);
+    throw parseOptimisticGovernorError("Transaction confirmation timed out");
   }
 
   /** Wallet-signing variant of {@link propose}. */
@@ -317,7 +318,7 @@ export class OptimisticGovernorClient {
     }).addOperation(this.contract.call(fn, ...args)).setTimeout(30).build();
     const result = await this.server.simulateTransaction(tx);
     if (SorobanRpc.Api.isSimulationError(result) || !result.result?.retval) {
-      throw new Error(`Simulation failed: ${fn}`);
+      throw parseOptimisticGovernorError(result);
     }
     return scValToNative(result.result.retval);
   }


### PR DESCRIPTION
This PR addresses 4 issues from the Stellar Wave campaign:

## Issue #1072 - ConvictionVotingClient error parsing
- Added `ConvictionVotingErrorCode` enum with all on-chain error codes
- Added `parseConvictionVotingError()` function following the established pattern
- Updated `ConvictionVotingClient.submit()` and `simulate()` to throw typed errors
- Now callers can catch specific `ConvictionVotingError` instances instead of generic `Error`

## Issue #1071 - OptimisticGovernorClient error parsing
- Added `OptimisticGovernorErrorCode` enum with all on-chain error codes
- Added `parseOptimisticGovernorError()` function following the established pattern
- Updated `OptimisticGovernorClient.submit()`, `submitWithSign()`, and `simulate()` to throw typed errors
- Now callers can catch specific `OptimisticGovernorError` instances instead of generic `Error`

## Issue #1017 - conviction-voting contract unwrap() pattern
Replaced bare `.unwrap()` calls with `.unwrap_or_else(|| env.panic_with_error(...))` in:
- `create_proposal()` - NextProposalId storage read
- `get_required_threshold()` - MinThresholdConviction and MaxRatioBps storage reads
- `cancel_proposal()` - Admin storage read
- `update_conviction()` - DecayBps and WeightBps storage reads

This matches the typed error pattern already used in `require_initialized()`, `votes_client()`, and `must_get_proposal()`.

## Issue #1016 - optimistic-governor contract unwrap() pattern
Replaced bare `.unwrap()` calls with `.unwrap_or_else(|| env.panic_with_error(...))` in:
- `propose()` - NextProposalId, ProposerBondAmount, ProposerBondToken, ChallengeWindowLedgers storage reads
- `object()` - ObjectionThresholdBps storage read
- `get_config()` - All five config fields storage reads

This matches the typed error pattern already used in `require_initialized()` and `votes_client()`.

All changes follow the existing patterns in the codebase for error handling and storage access.


closes #1016
closes #1017 
closes #1071 
closes #1072