### PR TITLE
Fix multiple issues: conviction UI, tally RPC, and treasury strategies

### DIFF
--- a/app/src/app/conviction/[id]/page.tsx
+++ b/app/src/app/conviction/[id]/page.tsx
@@ -2,6 +2,9 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
+import { useWallet } from "../../../lib/wallet-context";
+import { ConvictionVotingClient } from "@nebgov/sdk";
+import { readGovernorConfig } from "../../../lib/nebgov-env";
 
 interface Snapshot { ledger: number; conviction: bigint }
 
@@ -11,8 +14,17 @@ export default function ConvictionProposalPage() {
   const indexerUrl = process.env.NEXT_PUBLIC_INDEXER_URL;
   const [proposal, setProposal] = useState<Record<string, unknown> | null>(null);
   const [history, setHistory] = useState<Snapshot[]>([]);
+  const { isConnected, publicKey, signTransaction } = useWallet();
+  const [stakeAmount, setStakeAmount] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  useEffect(() => {
+  const client = useMemo(() => {
+    const config = readGovernorConfig();
+    if (!config?.convictionVotingAddress) return null;
+    return new ConvictionVotingClient(config);
+  }, []);
+
+  const fetchData = () => {
     if (!indexerUrl) return;
     void Promise.all([
       fetch(`${indexerUrl}/conviction/proposals/${id}`).then((r) => r.json()),
@@ -21,6 +33,10 @@ export default function ConvictionProposalPage() {
       setProposal(nextProposal as Record<string, unknown>);
       setHistory(((nextHistory as { data?: Record<string, unknown>[] }).data ?? []).map((row) => ({ ledger: Number(row.ledger), conviction: BigInt(String(row.conviction)) })));
     });
+  };
+
+  useEffect(() => {
+    fetchData();
   }, [id, indexerUrl]);
 
   const points = useMemo(() => {
@@ -29,11 +45,85 @@ export default function ConvictionProposalPage() {
     return history.map((point, index) => `${(index / Math.max(1, history.length - 1)) * 100},${100 - Number(point.conviction * 100n / max)}`).join(" ");
   }, [history]);
 
+  const handleStake = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!client || !publicKey) return;
+    setIsSubmitting(true);
+    try {
+      await client.stakeWithSign(publicKey, Number(id), BigInt(stakeAmount), signTransaction);
+      setStakeAmount("");
+      fetchData();
+    } catch (err) {
+      console.error(err);
+      alert(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleWithdrawStake = async () => {
+    if (!client || !publicKey) return;
+    setIsSubmitting(true);
+    try {
+      await client.withdrawStakeWithSign(publicKey, signTransaction);
+      fetchData();
+    } catch (err) {
+      console.error(err);
+      alert(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleCheckpoint = async () => {
+    if (!client || !publicKey) return;
+    setIsSubmitting(true);
+    try {
+      await client.checkpointConvictionWithSign(publicKey, Number(id), signTransaction);
+      fetchData();
+    } catch (err) {
+      console.error(err);
+      alert(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   if (!proposal) return <main className="mx-auto max-w-5xl px-4 py-10">Loading proposal…</main>;
   return (
     <main className="mx-auto max-w-5xl px-4 py-10">
-      <h1 className="text-3xl font-bold">Conviction proposal #{id}</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold">Conviction proposal #{id}</h1>
+        {isConnected && (
+          <button onClick={handleCheckpoint} disabled={isSubmitting} className="rounded bg-indigo-600 px-4 py-2 text-white disabled:opacity-50">
+            Checkpoint
+          </button>
+        )}
+      </div>
       <dl className="mt-6 grid gap-3 rounded-xl border p-5"><div><dt className="text-sm text-slate-500">Target</dt><dd className="break-all">{String(proposal.target)}</dd></div><div><dt className="text-sm text-slate-500">Requested</dt><dd>{String(proposal.requested_amount)}</dd></div><div><dt className="text-sm text-slate-500">Conviction</dt><dd>{String(proposal.conviction)}</dd></div></dl>
+      
+      {isConnected && (
+        <section className="mt-8 rounded-xl border p-5">
+          <h2 className="text-xl font-semibold">Stake</h2>
+          <form onSubmit={handleStake} className="mt-4 flex gap-4">
+            <input
+              type="number"
+              value={stakeAmount}
+              onChange={(e) => setStakeAmount(e.target.value)}
+              placeholder="Amount to stake"
+              className="flex-1 rounded border px-3 py-2"
+              disabled={isSubmitting}
+            />
+            <button type="submit" disabled={isSubmitting || !stakeAmount} className="rounded bg-indigo-600 px-4 py-2 text-white disabled:opacity-50">
+              Stake
+            </button>
+            <button type="button" onClick={handleWithdrawStake} disabled={isSubmitting} className="rounded border px-4 py-2 text-indigo-600 disabled:opacity-50">
+              Withdraw Stake
+            </button>
+          </form>
+        </section>
+      )}
+
       <section className="mt-8"><h2 className="text-xl font-semibold">Conviction growth</h2><svg viewBox="0 0 100 100" className="mt-4 h-64 w-full rounded-xl border p-4" role="img" aria-label="Conviction growth over time"><line x1="0" y1="20" x2="100" y2="20" stroke="currentColor" strokeDasharray="3 2" opacity="0.45" /><polyline points={points} fill="none" stroke="rgb(79 70 229)" strokeWidth="2" vectorEffect="non-scaling-stroke" /></svg><p className="mt-2 text-sm text-slate-500">Dashed line represents the required threshold; the trend extends as new checkpoints arrive.</p></section>
     </main>
   );

--- a/backend/src/signaling/tally.ts
+++ b/backend/src/signaling/tally.ts
@@ -157,7 +157,6 @@ export async function computeWeightedTally(
         { err, pollId, voter: vote.voter_address },
         "Failed to resolve voting power for signaling vote",
       );
-      powerByVoter.set(vote.voter_address, 0n);
     }
   }
 
@@ -165,7 +164,8 @@ export async function computeWeightedTally(
   const ids: number[] = [];
   const powers: string[] = [];
   for (const vote of votes) {
-    const power = powerByVoter.get(vote.voter_address) ?? 0n;
+    if (!powerByVoter.has(vote.voter_address)) continue;
+    const power = powerByVoter.get(vote.voter_address)!;
     if (vote.choice_index >= 0 && vote.choice_index < totals.length) {
       totals[vote.choice_index] += power;
     }

--- a/contracts/treasury-strategies/src/lib.rs
+++ b/contracts/treasury-strategies/src/lib.rs
@@ -403,10 +403,8 @@ impl TreasuryStrategiesContract {
                 .persistent()
                 .get::<DataKey, Strategy>(&DataKey::Strategy(strategy_id))
             {
-                if strategy.active {
-                    total +=
-                        StrategyAdapterClient::new(&env, &strategy.adapter).adapter_balance(&token);
-                }
+                total +=
+                    StrategyAdapterClient::new(&env, &strategy.adapter).adapter_balance(&token);
             }
         }
         total

--- a/sdk/src/convictionVoting.ts
+++ b/sdk/src/convictionVoting.ts
@@ -94,6 +94,50 @@ export class ConvictionVotingClient {
     return { conviction, executed: proposal.executed };
   }
 
+  async stakeWithSign(
+    signerPublicKey: string,
+    proposalId: number,
+    amount: bigint,
+    signUnsignedXdr: (xdr: string) => Promise<string>,
+  ): Promise<string> {
+    return (await this.submitWithSign(
+      signerPublicKey,
+      signUnsignedXdr,
+      "stake",
+      nativeToScVal(signerPublicKey, { type: "address" }),
+      nativeToScVal(proposalId, { type: "u64" }),
+      nativeToScVal(amount, { type: "i128" }),
+    )).hash;
+  }
+
+  async withdrawStakeWithSign(
+    signerPublicKey: string,
+    signUnsignedXdr: (xdr: string) => Promise<string>,
+  ): Promise<string> {
+    return (await this.submitWithSign(
+      signerPublicKey,
+      signUnsignedXdr,
+      "withdraw_stake",
+      nativeToScVal(signerPublicKey, { type: "address" }),
+    )).hash;
+  }
+
+  async checkpointConvictionWithSign(
+    signerPublicKey: string,
+    proposalId: number,
+    signUnsignedXdr: (xdr: string) => Promise<string>,
+  ): Promise<{ conviction: bigint; executed: boolean }> {
+    const result = await this.submitWithSign(
+      signerPublicKey,
+      signUnsignedXdr,
+      "checkpoint_conviction",
+      nativeToScVal(proposalId, { type: "u64" }),
+    );
+    const conviction = BigInt(scValToNative(result.returnValue!));
+    const proposal = await this.getProposal(proposalId);
+    return { conviction, executed: proposal.executed };
+  }
+
   async getProposal(proposalId: number): Promise<ConvictionProposal> {
     const native = await this.simulate(
       "get_proposal",
@@ -144,6 +188,35 @@ export class ConvictionVotingClient {
     const prepared = await this.server.prepareTransaction(tx);
     prepared.sign(signer);
     const sent = await this.server.sendTransaction(prepared);
+    if (sent.status === "ERROR") throw parseConvictionVotingError(sent);
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 1_000));
+      const status = await this.server.getTransaction(sent.hash);
+      if (status.status === SorobanRpc.Api.GetTransactionStatus.SUCCESS) {
+        return { hash: sent.hash, ...status };
+      }
+      if (status.status === SorobanRpc.Api.GetTransactionStatus.FAILED) {
+        throw parseConvictionVotingError(status);
+      }
+    }
+    throw parseConvictionVotingError("Transaction confirmation timed out");
+  }
+
+  private async submitWithSign(
+    signerPublicKey: string,
+    signUnsignedXdr: (xdr: string) => Promise<string>,
+    fn: string,
+    ...args: xdr.ScVal[]
+  ) {
+    const account = await this.server.getAccount(signerPublicKey);
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.passphrase,
+    }).addOperation(this.contract.call(fn, ...args)).setTimeout(30).build();
+    const prepared = await this.server.prepareTransaction(tx);
+    const signedXdr = await signUnsignedXdr(prepared.toXDR());
+    const signed = TransactionBuilder.fromXDR(signedXdr, this.passphrase);
+    const sent = await this.server.sendTransaction(signed);
     if (sent.status === "ERROR") throw parseConvictionVotingError(sent);
     for (let attempt = 0; attempt < 20; attempt += 1) {
       await new Promise((resolve) => setTimeout(resolve, 1_000));


### PR DESCRIPTION
Closes #1038
Closes #1039
Closes #1025
Closes #1022

## Overview
This PR addresses four assigned issues:

1. **#1038 (Frontend)**: Added a Stake and Withdraw Stake form to the conviction proposal page. Introduced `stakeWithSign` and `withdrawStakeWithSign` in `@nebgov/sdk`.
2. **#1039 (Frontend)**: Added a Checkpoint button to the conviction proposal page, integrating `checkpointConvictionWithSign` from the SDK.
3. **#1025 (Backend)**: Fixed `computeWeightedTally` to gracefully skip unresolved voting power on transient RPC failures, instead of persisting `0n`.
4. **#1022 (Contracts)**: Updated `get_total_value` in the `treasury-strategies` contract to sum balances across all strategies regardless of their active status, correctly reflecting custody.