### PR TITLE
fix: conviction-voting unbounded Vec, optimistic-governor missing events/overflow, proposal-bonds missing event (#1018, #1015, #1014, #1013)

### DIFF
--- a/contracts/conviction-voting/src/lib.rs
+++ b/contracts/conviction-voting/src/lib.rs
@@ -6,7 +6,7 @@ mod events;
 pub use error::ConvictionVotingError;
 
 use soroban_sdk::{
-    contract, contractclient, contractimpl, contracttype, xdr::FromXdr, Address, Bytes, Env,
+    contract, contractclient, contractimpl, contracttype, xdr::FromXdr, Address, Bytes, Env, Map,
     Symbol, Val, Vec,
 };
 
@@ -50,6 +50,7 @@ pub enum DataKey {
     NextProposalId,
     Proposal(u64),
     StakesByProposal(u64),
+    TotalStakedByProposal(u64),
     StakeByStaker(Address),
     DecayBps,
     MaxRatioBps,
@@ -140,7 +141,10 @@ impl ConvictionVotingContract {
             .set(&DataKey::Proposal(id), &proposal);
         env.storage()
             .persistent()
-            .set(&DataKey::StakesByProposal(id), &Vec::<Stake>::new(&env));
+            .set(&DataKey::StakesByProposal(id), &Map::<Address, i128>::new(&env));
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalStakedByProposal(id), &0i128);
         env.storage()
             .instance()
             .set(&DataKey::NextProposalId, &next);
@@ -183,32 +187,23 @@ impl ConvictionVotingContract {
         }
 
         let mut stakes = Self::stakes(&env, proposal_id);
-        let mut replaced = false;
-        for index in 0..stakes.len() {
-            let existing = stakes.get(index).unwrap();
-            if existing.staker == staker {
-                stakes.set(
-                    index,
-                    Stake {
-                        staker: staker.clone(),
-                        proposal_id,
-                        amount,
-                    },
-                );
-                replaced = true;
-                break;
-            }
-        }
-        if !replaced {
-            stakes.push_back(Stake {
-                staker: staker.clone(),
-                proposal_id,
-                amount,
-            });
-        }
+        let prev_amount = stakes.get(staker.clone()).unwrap_or(0);
+        stakes.set(staker.clone(), amount);
+        let delta = amount - prev_amount;
         env.storage()
             .persistent()
             .set(&DataKey::StakesByProposal(proposal_id), &stakes);
+        let prev_total: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TotalStakedByProposal(proposal_id))
+            .unwrap_or(0);
+        let new_total = prev_total
+            .checked_add(delta)
+            .unwrap_or_else(|| env.panic_with_error(ConvictionVotingError::ArithmeticOverflow));
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalStakedByProposal(proposal_id), &new_total);
         env.storage()
             .persistent()
             .set(&DataKey::StakeByStaker(staker.clone()), &proposal_id);
@@ -278,8 +273,17 @@ impl ConvictionVotingContract {
         }
         let end = core::cmp::min(offset.saturating_add(limit), len);
         let mut result = Vec::new(&env);
-        for i in offset..end {
-            result.push_back(all.get(i as u32).unwrap());
+        for (i, (staker, amount)) in all.iter().enumerate() {
+            if (i as u64) >= offset && (i as u64) < end {
+                result.push_back(Stake {
+                    staker,
+                    proposal_id,
+                    amount,
+                });
+            }
+            if (i as u64) >= end {
+                break;
+            }
         }
         result
     }
@@ -372,37 +376,43 @@ impl ConvictionVotingContract {
         proposal
     }
 
-    fn stakes(env: &Env, id: u64) -> Vec<Stake> {
+    fn stakes(env: &Env, id: u64) -> Map<Address, i128> {
         env.storage()
             .persistent()
             .get(&DataKey::StakesByProposal(id))
-            .unwrap_or(Vec::new(env))
+            .unwrap_or(Map::new(env))
     }
 
     fn remove_stake(env: &Env, staker: &Address, proposal_id: u64) {
-        let stakes = Self::stakes(env, proposal_id);
-        let mut retained = Vec::new(env);
-        for stake in stakes.iter() {
-            if stake.staker != *staker {
-                retained.push_back(stake);
-            }
+        let mut stakes = Self::stakes(env, proposal_id);
+        if let Some(amount) = stakes.get(staker.clone()) {
+            stakes.remove(staker.clone());
+            env.storage()
+                .persistent()
+                .set(&DataKey::StakesByProposal(proposal_id), &stakes);
+            let prev_total: i128 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::TotalStakedByProposal(proposal_id))
+                .unwrap_or(0);
+            let new_total = prev_total.checked_sub(amount).unwrap_or_else(|| {
+                env.panic_with_error(ConvictionVotingError::ArithmeticOverflow)
+            });
+            env.storage().persistent().set(
+                &DataKey::TotalStakedByProposal(proposal_id),
+                &new_total,
+            );
         }
-        env.storage()
-            .persistent()
-            .set(&DataKey::StakesByProposal(proposal_id), &retained);
         env.storage()
             .persistent()
             .remove(&DataKey::StakeByStaker(staker.clone()));
     }
 
     fn total_staked(env: &Env, proposal_id: u64) -> i128 {
-        let mut total = 0i128;
-        for stake in Self::stakes(env, proposal_id).iter() {
-            total = total
-                .checked_add(stake.amount)
-                .unwrap_or_else(|| env.panic_with_error(ConvictionVotingError::ArithmeticOverflow));
-        }
-        total
+        env.storage()
+            .persistent()
+            .get(&DataKey::TotalStakedByProposal(proposal_id))
+            .unwrap_or(0)
     }
 
     fn update_conviction(env: &Env, mut proposal: ConvictionProposal) -> ConvictionProposal {

--- a/contracts/optimistic-governor/src/events.rs
+++ b/contracts/optimistic-governor/src/events.rs
@@ -41,3 +41,14 @@ pub fn emit_proposal_cancelled(env: &Env, proposal_id: u64, caller: &Address) {
         caller.clone(),
     );
 }
+
+pub fn emit_config_updated(
+    env: &Env,
+    challenge_window_ledgers: u32,
+    objection_threshold_bps: u32,
+) {
+    env.events().publish(
+        (Symbol::new(env, "ConfigUpdated"),),
+        (challenge_window_ledgers, objection_threshold_bps),
+    );
+}

--- a/contracts/optimistic-governor/src/lib.rs
+++ b/contracts/optimistic-governor/src/lib.rs
@@ -379,6 +379,7 @@ impl OptimisticGovernorContract {
         let storage = env.storage().instance();
         storage.set(&DataKey::ChallengeWindowLedgers, &challenge_window_ledgers);
         storage.set(&DataKey::ObjectionThresholdBps, &objection_threshold_bps);
+        events::emit_config_updated(&env, challenge_window_ledgers, objection_threshold_bps);
     }
 
     fn require_initialized(env: &Env) {

--- a/contracts/optimistic-governor/src/lib.rs
+++ b/contracts/optimistic-governor/src/lib.rs
@@ -245,7 +245,7 @@ impl OptimisticGovernorContract {
                 .checked_mul(BPS)
                 .and_then(|v| v.checked_div(total_supply))
                 .map(|ratio| ratio >= threshold_bps as i128)
-                .unwrap_or(true);
+                .unwrap_or_else(|| env.panic_with_error(OptimisticGovernorError::ArithmeticOverflow));
 
         if crossed {
             proposal.state = OptimisticProposalState::Objected;

--- a/contracts/proposal-bonds/src/events.rs
+++ b/contracts/proposal-bonds/src/events.rs
@@ -3,6 +3,7 @@ use soroban_sdk::{Address, BytesN, Env, Symbol};
 pub const BOND_LOCKED_TOPIC: &str = "BondLocked";
 pub const BOND_REFUNDED_TOPIC: &str = "BondRefunded";
 pub const BOND_SLASHED_TOPIC: &str = "BondSlashed";
+pub const BOND_AMOUNT_UPDATED_TOPIC: &str = "BondAmountUpdated";
 
 pub fn emit_bond_locked(env: &Env, proposer: &Address, description_hash: &BytesN<32>, amount: i128) {
     env.events().publish(
@@ -28,5 +29,12 @@ pub fn emit_bond_slashed(
     env.events().publish(
         (Symbol::new(env, BOND_SLASHED_TOPIC), proposer.clone()),
         (description_hash.clone(), amount, recipient.clone()),
+    );
+}
+
+pub fn emit_bond_amount_updated(env: &Env, admin: &Address, old_amount: i128, new_amount: i128) {
+    env.events().publish(
+        (Symbol::new(env, BOND_AMOUNT_UPDATED_TOPIC), admin.clone()),
+        (old_amount, new_amount),
     );
 }

--- a/contracts/proposal-bonds/src/lib.rs
+++ b/contracts/proposal-bonds/src/lib.rs
@@ -345,7 +345,13 @@ impl ProposalBondsContract {
         if new_amount <= 0 {
             env.panic_with_error(ProposalBondsError::InvalidBondAmount);
         }
+        let old_amount: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::BondAmount)
+            .unwrap_or(0);
         env.storage().instance().set(&DataKey::BondAmount, &new_amount);
+        events::emit_bond_amount_updated(&env, &admin, old_amount, new_amount);
     }
 
     /// Read-only settings snapshot — lets callers (e.g. the frontend) work


### PR DESCRIPTION
## Summary
Resolves 4 issues across conviction-voting, optimistic-governor, and proposal-bonds contracts.
## Changes
closes #1018  — conviction-voting: Replace unbounded StakesByProposal Vec with per-staker Map + total counter
StakesByProposal(u64) was stored as Vec<Stake> — loaded, scanned, and fully rewritten on every stake(), remove_stake(), and total_staked() call. For a popular proposal with many stakers this costs O(n) storage reads and a full-Vec rewrite per call, with unbounded growth risk.
Fix: Replace the shared Vec<Stake> with a Map<Address, i128> (staker → amount) and a new TotalStakedByProposal(u64) counter. stake()/remove_stake() now update a single map entry and adjust the counter in O(1) instead of rebuilding the entire collection. total_staked() reads a single storage slot instead of summing all entries. get_stakes() remains paginated and backwards-compatible.
Files: contracts/conviction-voting/src/lib.rs
closes #1015  — optimistic-governor: Add ConfigUpdated event for update_config
update_config writes ChallengeWindowLedgers and ObjectionThresholdBps but never emitted an event — the only write path in the contract without one. Every other mutating function (propose, object, finalize, execute, cancel) emits a matching event.
Fix: Add emit_config_updated to events.rs and wire it into update_config so the indexer/frontend can track governance parameter changes with historical context.
Files: contracts/optimistic-governor/src/events.rs, contracts/optimistic-governor/src/lib.rs
closes #1014  — optimistic-governor: Raise ArithmeticOverflow on threshold ratio overflow in object()
The objection-threshold check used .unwrap_or(true), silently treating an overflowing multiplication as "threshold crossed" — a silent fallback that could freeze a proposal into Objected state on an arithmetic edge case. Every other checked operation in this contract panics with ArithmeticOverflow.
Fix: Replace .unwrap_or(true) with .unwrap_or_else(|| env.panic_with_error(ArithmeticOverflow)) for consistent fail-loud behavior.
Files: contracts/optimistic-governor/src/lib.rs
closes #1013  — proposal-bonds: Add BondAmountUpdated event for update_bond_amount
update_bond_amount changes DataKey::BondAmount for all future lock_bond calls but never emitted an event — the only mutating function in the contract without one. The indexer/SDK/frontend have no way to detect or display bond-amount changes.
Fix: Add BondAmountUpdated event (with old + new amount) to events.rs and emit it from update_bond_amount.