### PR TITLE
fix: resolve signal-anchor retry, add indexer CI, governance-tuning config editor, and optimistic finalize/execute buttons

### DIFF
--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -1,0 +1,59 @@
+name: Indexer
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/indexer/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "packages/indexer/**"
+
+jobs:
+  indexer:
+    name: Indexer Build & Test
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: nebgov_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/nebgov_test
+      NODE_ENV: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type-check indexer
+        run: pnpm --filter @nebgov/indexer run build
+
+      - name: Run indexer database migrations
+        run: pnpm --filter @nebgov/indexer run migrate
+
+      - name: Test indexer
+        run: pnpm --filter @nebgov/indexer run test

--- a/app/src/app/governance-tuning/page.tsx
+++ b/app/src/app/governance-tuning/page.tsx
@@ -1,7 +1,12 @@
 "use client";
 
-import { useGovernanceTuning } from "../../hooks/useGovernanceTuning";
+import { useState } from "react";
+import {
+  useGovernanceTuning,
+  useGovernanceTuningConfig,
+} from "../../hooks/useGovernanceTuning";
 import { TuningRecommendationCard } from "../../components/TuningRecommendationCard";
+import { GovernanceTuningConfigEditor } from "../../components/GovernanceTuningConfigEditor";
 
 function ParticipationTrendChart({ snapshotVotesCast }: { snapshotVotesCast: string[] }) {
   if (!snapshotVotesCast || snapshotVotesCast.length < 2) {
@@ -47,6 +52,14 @@ function ParticipationTrendChart({ snapshotVotesCast }: { snapshotVotesCast: str
 
 export default function GovernanceTuningPage() {
   const { latest, history, loading, error } = useGovernanceTuning();
+  const {
+    config,
+    loading: configLoading,
+    error: configError,
+    updateConfig,
+    refresh: refreshConfig,
+  } = useGovernanceTuningConfig();
+  const [configExpanded, setConfigExpanded] = useState(false);
 
   const snapshotVotesCast = (latest?.rationale.inputs.snapshotVotesCast as string[] | undefined) ?? [];
 
@@ -116,6 +129,32 @@ export default function GovernanceTuningPage() {
               </li>
             ))}
           </ul>
+        )}
+      </section>
+
+      <section className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
+        <button
+          type="button"
+          onClick={() => setConfigExpanded(!configExpanded)}
+          className="flex w-full items-center justify-between p-5 text-left"
+        >
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            Admin config
+          </h2>
+          <span className="text-gray-400 dark:text-gray-500 text-lg">
+            {configExpanded ? "−" : "+"}
+          </span>
+        </button>
+        {configExpanded && (
+          <div className="border-t border-gray-200 dark:border-gray-800 p-5">
+            {configLoading ? (
+              <p className="text-sm text-gray-500 dark:text-gray-400">Loading config...</p>
+            ) : configError ? (
+              <p className="text-sm text-rose-600 dark:text-rose-400">{configError}</p>
+            ) : config ? (
+              <GovernanceTuningConfigEditor config={config} onUpdate={updateConfig} />
+            ) : null}
+          </div>
         )}
       </section>
     </div>

--- a/app/src/app/optimistic/[id]/page.tsx
+++ b/app/src/app/optimistic/[id]/page.tsx
@@ -3,9 +3,9 @@
 /**
  * Optimistic-governance proposal detail (Issue #993).
  *
- * Shows the challenge-window countdown, objector list, and an "Object"
- * button gated to connected-wallet holders who had voting power at the
- * proposal's created_ledger and haven't already objected.
+ * Shows the challenge-window countdown, objector list, and action buttons:
+ * "Object" (gated to voting-power holders), "Finalize" (permissionless once
+ * challenge window elapses), and "Execute" (permissionless once passed).
  */
 
 import { useEffect, useState } from "react";
@@ -38,6 +38,7 @@ export default function OptimisticProposalPage() {
   const { currentLedger } = useLedgerClock();
   const [votingPower, setVotingPower] = useState<bigint | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [actionType, setActionType] = useState<"object" | "finalize" | "execute" | null>(null);
 
   const hasObjected = !!publicKey && objections.some((o) => o.objector === publicKey);
   const challengeElapsed = !!proposal && currentLedger >= proposal.challengeEndLedger;
@@ -68,6 +69,7 @@ export default function OptimisticProposalPage() {
       return;
     }
     setSubmitting(true);
+    setActionType("object");
     try {
       const client = new OptimisticGovernorClient(config);
       await client.objectWithSign(publicKey, Number(proposal.proposalId), signTransaction);
@@ -77,6 +79,51 @@ export default function OptimisticProposalPage() {
       toast.error(e instanceof Error ? e.message : "Objection failed");
     } finally {
       setSubmitting(false);
+      setActionType(null);
+    }
+  }
+
+  async function handleFinalize() {
+    if (!publicKey || !signTransaction || !proposal) return;
+    const config = readGovernorConfig();
+    if (!config || !config.optimisticGovernorAddress) {
+      toast.error("Optimistic governance is not configured.");
+      return;
+    }
+    setSubmitting(true);
+    setActionType("finalize");
+    try {
+      const client = new OptimisticGovernorClient(config);
+      await client.finalizeWithSign(publicKey, Number(proposal.proposalId), signTransaction);
+      toast.success("Proposal finalized.");
+      refresh();
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : "Finalize failed");
+    } finally {
+      setSubmitting(false);
+      setActionType(null);
+    }
+  }
+
+  async function handleExecute() {
+    if (!publicKey || !signTransaction || !proposal) return;
+    const config = readGovernorConfig();
+    if (!config || !config.optimisticGovernorAddress) {
+      toast.error("Optimistic governance is not configured.");
+      return;
+    }
+    setSubmitting(true);
+    setActionType("execute");
+    try {
+      const client = new OptimisticGovernorClient(config);
+      await client.executeWithSign(publicKey, Number(proposal.proposalId), signTransaction);
+      toast.success("Proposal executed.");
+      refresh();
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : "Execute failed");
+    } finally {
+      setSubmitting(false);
+      setActionType(null);
     }
   }
 
@@ -94,6 +141,15 @@ export default function OptimisticProposalPage() {
     !hasObjected &&
     votingPower !== null &&
     votingPower > 0n;
+
+  const canFinalize =
+    !!publicKey &&
+    proposal.state === "challenge_window" &&
+    challengeElapsed;
+
+  const canExecute =
+    !!publicKey &&
+    proposal.state === "passed";
 
   return (
     <main className="mx-auto max-w-5xl px-4 py-10">
@@ -121,28 +177,71 @@ export default function OptimisticProposalPage() {
         </div>
       </dl>
 
-      <section className="mt-8">
-        <div className="flex items-center justify-between">
-          <h2 className="text-xl font-semibold">Objections</h2>
+      {proposal.state === "challenge_window" && (
+        <section className="mt-6">
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl font-semibold">Actions</h2>
+            {!publicKey && (
+              <span className="text-sm text-slate-500">Connect your wallet to interact.</span>
+            )}
+          </div>
+          <div className="mt-4 flex gap-3">
+            <button
+              onClick={handleObject}
+              disabled={!canObject || submitting}
+              className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {submitting && actionType === "object" ? "Submitting…" : "Object"}
+            </button>
+            <button
+              onClick={handleFinalize}
+              disabled={!canFinalize || submitting}
+              className="rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {submitting && actionType === "finalize" ? "Submitting…" : "Finalize"}
+            </button>
+          </div>
           {!publicKey && (
-            <span className="text-sm text-slate-500">Connect your wallet to object.</span>
+            <p className="mt-2 text-sm text-slate-500">Connect your wallet to object or finalize.</p>
           )}
           {publicKey && hasObjected && (
-            <span className="text-sm text-slate-500">You&apos;ve already objected.</span>
+            <p className="mt-2 text-sm text-slate-500">You&apos;ve already objected.</p>
           )}
           {publicKey && !hasObjected && votingPower !== null && votingPower <= 0n && (
-            <span className="text-sm text-slate-500">
+            <p className="mt-2 text-sm text-slate-500">
               No voting power at this proposal&apos;s created ledger.
-            </span>
+            </p>
           )}
-          <button
-            onClick={handleObject}
-            disabled={!canObject || submitting}
-            className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {submitting ? "Submitting…" : "Object"}
-          </button>
-        </div>
+          {publicKey && !challengeElapsed && (
+            <p className="mt-2 text-sm text-slate-500">
+              Challenge window is still open — finalize once it closes.
+            </p>
+          )}
+        </section>
+      )}
+
+      {proposal.state === "passed" && (
+        <section className="mt-6">
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl font-semibold">Actions</h2>
+            {!publicKey && (
+              <span className="text-sm text-slate-500">Connect your wallet to execute.</span>
+            )}
+          </div>
+          <div className="mt-4">
+            <button
+              onClick={handleExecute}
+              disabled={!canExecute || submitting}
+              className="rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {submitting && actionType === "execute" ? "Submitting…" : "Execute"}
+            </button>
+          </div>
+        </section>
+      )}
+
+      <section className="mt-8">
+        <h2 className="text-xl font-semibold">Objections</h2>
         <div className="mt-4 grid gap-2">
           {objections.map((objection) => (
             <div

--- a/app/src/components/GovernanceTuningConfigEditor.tsx
+++ b/app/src/components/GovernanceTuningConfigEditor.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useState } from "react";
+import type { TuningConfig } from "@nebgov/sdk";
+
+interface GovernanceTuningConfigEditorProps {
+  config: TuningConfig;
+  onUpdate: (patch: Partial<Omit<TuningConfig, "updatedAt">>) => Promise<void>;
+}
+
+export function GovernanceTuningConfigEditor({
+  config,
+  onUpdate,
+}: GovernanceTuningConfigEditorProps) {
+  const [minQuorumNumerator, setMinQuorumNumerator] = useState(config.minQuorumNumerator);
+  const [maxQuorumNumerator, setMaxQuorumNumerator] = useState(config.maxQuorumNumerator);
+  const [maxQuorumDeltaBps, setMaxQuorumDeltaBps] = useState(config.maxQuorumDeltaBps);
+  const [minProposalThreshold, setMinProposalThreshold] = useState(
+    config.minProposalThreshold.toString(),
+  );
+  const [maxProposalThreshold, setMaxProposalThreshold] = useState(
+    config.maxProposalThreshold === null ? "" : config.maxProposalThreshold.toString(),
+  );
+  const [maxThresholdDeltaBps, setMaxThresholdDeltaBps] = useState(config.maxThresholdDeltaBps);
+  const [trailingWindow, setTrailingWindow] = useState(config.trailingWindow);
+  const [intervalMs, setIntervalMs] = useState(config.intervalMs);
+  const [autoPropose, setAutoPropose] = useState(config.autoPropose);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      await onUpdate({
+        minQuorumNumerator,
+        maxQuorumNumerator,
+        maxQuorumDeltaBps,
+        minProposalThreshold: BigInt(minProposalThreshold || "0"),
+        maxProposalThreshold: maxProposalThreshold === "" ? null : BigInt(maxProposalThreshold),
+        maxThresholdDeltaBps,
+        trailingWindow,
+        intervalMs,
+        autoPropose,
+      });
+      setSuccess(true);
+      setTimeout(() => setSuccess(false), 3000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update config");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error && (
+        <p className="rounded-lg border border-rose-200 bg-rose-50 dark:border-rose-900 dark:bg-rose-900/20 p-3 text-sm text-rose-700 dark:text-rose-300">
+          {error}
+        </p>
+      )}
+      {success && (
+        <p className="rounded-lg border border-emerald-200 bg-emerald-50 dark:border-emerald-900 dark:bg-emerald-900/20 p-3 text-sm text-emerald-700 dark:text-emerald-300">
+          Config updated successfully.
+        </p>
+      )}
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <label className="block text-sm">
+          <span className="font-medium text-gray-700 dark:text-gray-200">Min quorum numerator</span>
+          <input
+            type="number"
+            value={minQuorumNumerator}
+            onChange={(e) => setMinQuorumNumerator(Number(e.target.value))}
+            className="mt-1 block w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="font-medium text-gray-700 dark:text-gray-200">Max quorum numerator</span>
+          <input
+            type="number"
+            value={maxQuorumNumerator}
+            onChange={(e) => setMaxQuorumNumerator(Number(e.target.value))}
+            className="mt-1 block w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="font-medium text-gray-700 dark:text-gray-200">Max quorum delta (bps)</span>
+          <input
+            type="number"
+            value={maxQuorumDeltaBps}
+            onChange={(e) => setMaxQuorumDeltaBps(Number(e.target.value))}
+            className="mt-1 block w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="font-medium text-gray-700 dark:text-gray-200">Min proposal threshold</span>
+          <input
+            type="text"
+            value={minProposalThreshold}
+            onChange={(e) => setMinProposalThreshold(e.target.value)}
+            className="mt-1 block w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="font-medium text-gray-700 dark:text-gray-200">Max proposal threshold</span>
+          <input
+            type="text"
+            value={maxProposalThreshold}
+            onChange={(e) => setMaxProposalThreshold(e.target.value)}
+            placeholder="No limit"
+            className="mt-1 block w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="font-medium text-gray-700 dark:text-gray-200">Max threshold delta (bps)</span>
+          <input
+            type="number"
+            value={maxThresholdDeltaBps}
+            onChange={(e) => setMaxThresholdDeltaBps(Number(e.target.value))}
+            className="mt-1 block w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="font-medium text-gray-700 dark:text-gray-200">Trailing window (snapshots)</span>
+          <input
+            type="number"
+            value={trailingWindow}
+            onChange={(e) => setTrailingWindow(Number(e.target.value))}
+            className="mt-1 block w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="font-medium text-gray-700 dark:text-gray-200">Interval (ms)</span>
+          <input
+            type="number"
+            value={intervalMs}
+            onChange={(e) => setIntervalMs(Number(e.target.value))}
+            className="mt-1 block w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+          />
+        </label>
+      </div>
+
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={autoPropose}
+          onChange={(e) => setAutoPropose(e.target.checked)}
+          className="h-4 w-4 rounded border-gray-300 dark:border-gray-700"
+        />
+        <span className="font-medium text-gray-700 dark:text-gray-200">Auto-propose recommendations</span>
+      </label>
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {submitting ? "Saving..." : "Save Config"}
+      </button>
+    </form>
+  );
+}

--- a/app/src/hooks/useGovernanceTuning.ts
+++ b/app/src/hooks/useGovernanceTuning.ts
@@ -1,7 +1,11 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { GovernanceTuningClient, type TuningRecommendation } from "@nebgov/sdk";
+import {
+  GovernanceTuningClient,
+  type TuningConfig,
+  type TuningRecommendation,
+} from "@nebgov/sdk";
 import { readGovernorConfig } from "../lib/nebgov-env";
 
 interface UseGovernanceTuningResult {
@@ -64,4 +68,72 @@ export function useGovernanceTuning(): UseGovernanceTuningResult {
   }, [refreshToken]);
 
   return { latest, history, loading, error, refresh };
+}
+
+export interface UseGovernanceTuningConfigResult {
+  config: TuningConfig | null;
+  loading: boolean;
+  error: string | null;
+  updateConfig: (patch: Partial<Omit<TuningConfig, "updatedAt">>) => Promise<void>;
+  refresh: () => void;
+}
+
+/**
+ * Fetches and allows admin updates to the governance tuning config.
+ */
+export function useGovernanceTuningConfig(): UseGovernanceTuningConfigResult {
+  const [config, setConfig] = useState<TuningConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshToken, setRefreshToken] = useState(0);
+
+  const refresh = useCallback(() => setRefreshToken((t) => t + 1), []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const governorConfig = readGovernorConfig();
+        if (!governorConfig) {
+          throw new Error("Missing required environment variables");
+        }
+
+        const client = new GovernanceTuningClient(governorConfig);
+        const cfg = await client.getConfig();
+
+        if (cancelled) return;
+        setConfig(cfg);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load config");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshToken]);
+
+  const updateConfig = useCallback(
+    async (patch: Partial<Omit<TuningConfig, "updatedAt">>) => {
+      const governorConfig = readGovernorConfig();
+      if (!governorConfig) {
+        throw new Error("Missing required environment variables");
+      }
+
+      const client = new GovernanceTuningClient(governorConfig);
+      const updated = await client.updateConfig(patch);
+      setConfig(updated);
+    },
+    [],
+  );
+
+  return { config, loading, error, updateConfig, refresh };
 }

--- a/backend/migrations/013_add_signaling_anchor_retry.sql
+++ b/backend/migrations/013_add_signaling_anchor_retry.sql
@@ -1,0 +1,11 @@
+-- Up Migration
+
+ALTER TABLE signaling_polls
+  ADD COLUMN anchor_attempts INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN next_anchor_at TIMESTAMPTZ;
+
+-- Down Migration
+
+ALTER TABLE signaling_polls
+  DROP COLUMN IF EXISTS anchor_attempts,
+  DROP COLUMN IF EXISTS next_anchor_at;

--- a/backend/src/jobs/signal-anchor.ts
+++ b/backend/src/jobs/signal-anchor.ts
@@ -14,6 +14,8 @@ import { invalidate } from "../cache";
 import { computeWeightedTally, type PollResults } from "../signaling/tally";
 import { resultsCacheKey } from "../routes/signaling";
 
+const MAX_ANCHOR_ATTEMPTS = 5;
+
 const NETWORK_PASSPHRASES: Record<string, string> = {
   mainnet: Networks.PUBLIC,
   public: Networks.PUBLIC,
@@ -125,9 +127,12 @@ export class SignalAnchorService {
 
   private async finalizeEndedPolls(): Promise<void> {
     const { rows: polls } = await pool.query(
-      `SELECT id, choices, snapshot_ledger FROM signaling_polls
-       WHERE finalized = FALSE AND end_time <= NOW()`,
+      `SELECT id, choices, snapshot_ledger, anchor_attempts FROM signaling_polls
+       WHERE finalized = FALSE AND end_time <= NOW()
+         AND (next_anchor_at IS NULL OR next_anchor_at <= NOW())`,
     );
+
+    const anchorEnabled = process.env.SIGNAL_ANCHOR_ON_CHAIN === "true";
 
     for (const poll of polls) {
       try {
@@ -135,22 +140,49 @@ export class SignalAnchorService {
         const resultHash = computeResultHash(poll.id, results);
 
         let anchoredTxHash: string | null = null;
-        if (process.env.SIGNAL_ANCHOR_ON_CHAIN === "true") {
+        let anchorSucceeded = !anchorEnabled;
+
+        if (anchorEnabled) {
           try {
             anchoredTxHash = await anchorOnChain(poll.id, resultHash);
+            anchorSucceeded = true;
           } catch (err) {
-            logger.error({ err, pollId: poll.id }, "Failed to anchor signaling result on-chain");
+            const attempts = (poll.anchor_attempts ?? 0) + 1;
+            const backoffMs = Math.min(attempts * 30_000, 300_000);
+
+            if (attempts >= MAX_ANCHOR_ATTEMPTS) {
+              logger.error(
+                { err, pollId: poll.id, attempts },
+                "Anchor failed after max retries — marking finalized without on-chain proof",
+              );
+              anchorSucceeded = true;
+            } else {
+              logger.error(
+                { err, pollId: poll.id, attempts, nextRetryMs: backoffMs },
+                "Failed to anchor on-chain, scheduling retry",
+              );
+              await pool.query(
+                `UPDATE signaling_polls
+                 SET result_hash = $1, anchor_attempts = $2, next_anchor_at = NOW() + ($3 || ' ms')::INTERVAL
+                 WHERE id = $4`,
+                [resultHash, attempts, String(backoffMs), poll.id],
+              );
+              invalidate(resultsCacheKey(poll.id));
+              continue;
+            }
           }
         }
 
-        await pool.query(
-          `UPDATE signaling_polls
-           SET finalized = TRUE, result_hash = $1, anchored_tx_hash = $2
-           WHERE id = $3`,
-          [resultHash, anchoredTxHash, poll.id],
-        );
-        invalidate(resultsCacheKey(poll.id));
-        logger.info({ pollId: poll.id, resultHash, anchoredTxHash }, "Finalized signaling poll");
+        if (anchorSucceeded) {
+          await pool.query(
+            `UPDATE signaling_polls
+             SET finalized = TRUE, result_hash = $1, anchored_tx_hash = $2
+             WHERE id = $3`,
+            [resultHash, anchoredTxHash, poll.id],
+          );
+          invalidate(resultsCacheKey(poll.id));
+          logger.info({ pollId: poll.id, resultHash, anchoredTxHash }, "Finalized signaling poll");
+        }
       } catch (err) {
         logger.error({ err, pollId: poll.id }, "Failed to finalize signaling poll");
       }

--- a/sdk/src/governanceTuning.ts
+++ b/sdk/src/governanceTuning.ts
@@ -136,4 +136,42 @@ export class GovernanceTuningClient {
     const raw = await this.backendRequest<any>("/governance-tuning/config");
     return mapConfig(raw);
   }
+
+  /**
+   * Admin-only partial update of the tunable config.
+   *
+   * Hits `PUT /governance-tuning/config`. Requires the backend's
+   * `ADMIN_SECRET` header to be set via `config.adminSecret`.
+   */
+  async updateConfig(
+    patch: Partial<Omit<TuningConfig, "updatedAt">>,
+  ): Promise<TuningConfig> {
+    if (!this.config.adminSecret) {
+      throw new GovernorError(
+        GovernorErrorCode.SimulationFailed,
+        `GovernanceTuningClient.updateConfig requires config.adminSecret to be set`,
+      );
+    }
+
+    const body: Record<string, unknown> = {};
+    if (patch.minQuorumNumerator !== undefined) body.min_quorum_numerator = patch.minQuorumNumerator;
+    if (patch.maxQuorumNumerator !== undefined) body.max_quorum_numerator = patch.maxQuorumNumerator;
+    if (patch.maxQuorumDeltaBps !== undefined) body.max_quorum_delta_bps = patch.maxQuorumDeltaBps;
+    if (patch.minProposalThreshold !== undefined) body.min_proposal_threshold = patch.minProposalThreshold.toString();
+    if (patch.maxProposalThreshold !== undefined) body.max_proposal_threshold = patch.maxProposalThreshold === null ? null : patch.maxProposalThreshold.toString();
+    if (patch.maxThresholdDeltaBps !== undefined) body.max_threshold_delta_bps = patch.maxThresholdDeltaBps;
+    if (patch.trailingWindow !== undefined) body.trailing_window = patch.trailingWindow;
+    if (patch.intervalMs !== undefined) body.interval_ms = patch.intervalMs;
+    if (patch.autoPropose !== undefined) body.auto_propose = patch.autoPropose;
+
+    const raw = await this.backendRequest<any>("/governance-tuning/config", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "X-ADMIN-SECRET": this.config.adminSecret,
+      },
+      body: JSON.stringify(body),
+    });
+    return mapConfig(raw);
+  }
 }

--- a/sdk/src/types/index.ts
+++ b/sdk/src/types/index.ts
@@ -304,6 +304,8 @@ export interface GovernorConfig {
   baseDelayMs?: number;
   /** Token decimals for vote display (optional — fetched from contract if not provided) */
   decimals?: number;
+  /** Admin secret for admin-only backend endpoints (e.g. governance tuning config update) */
+  adminSecret?: string;
 }
 
 export interface ConvictionProposal {


### PR DESCRIPTION
## Summary
Resolves 4 issues spanning backend reliability, CI coverage, and frontend interactivity.
## Changes
- closes #1029  — fix(signaling): retry failed on-chain anchor submissions
- finalizeEndedPolls no longer marks finalized = TRUE when anchorOnChain throws
- Added anchor_attempts and next_anchor_at columns (migration 013)
- Failed anchors are retried with linear backoff (30s per attempt, capped at 5min), up to 5 attempts
- After max retries, the poll is finalized without on-chain proof (logged as error)
- Query now filters on (next_anchor_at IS NULL OR next_anchor_at <= NOW()) to respect backoff
closes #1047  — ci: add GitHub Actions workflow for packages/indexer
- New .github/workflows/indexer.yml triggered on PRs and pushes to main touching packages/indexer/**
- Runs tsc --noEmit (via build script), DB migrations, and test suite
- Uses the same Postgres service pattern as backend.yml
closes #1036  — feature(frontend): admin config editor for governance tuning
- Added GovernanceTuningConfigEditor component with form fields for all 9 tunable config parameters
- Added useGovernanceTuningConfig hook for fetching and updating config
- Added updateConfig method to SDK GovernanceTuningClient (requires adminSecret)
- Added adminSecret field to GovernorConfig type
- Config editor appears as a collapsible "Admin config" section on the governance-tuning page
closes #1034  — feature(frontend): optimistic proposal finalize and execute buttons
- Added permissionless "Finalize" button (visible when challenge_window state and challenge window elapsed)
- Added permissionless "Execute" button (visible when passed state)
- Both buttons use wallet signing via finalizeWithSign / executeWithSign
- Restructured the actions section to show Object + Finalize together during challenge window, and Execute when passed